### PR TITLE
Serve SPA and redirect root to login

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,37 @@
-from flask import Flask
+"""Flask application for Envanter.
 
-app = Flask(__name__)
+This server serves the compiled front-end so that navigating directly to the
+server's IP address displays the login screen handled by the React app. Any
+unknown route will be routed to ``index.html`` allowing React Router to manage
+client-side navigation.
+"""
 
-@app.route('/')
-def index():
-    return 'Hello from Envanter!'
+from pathlib import Path
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+from flask import Flask, send_from_directory
+
+
+BASE_DIR = Path(__file__).resolve().parent
+
+app = Flask(__name__, static_folder=str(BASE_DIR), static_url_path="")
+
+
+@app.route("/", defaults={"path": ""})
+@app.route("/<path:path>")
+def serve_spa(path: str) -> str:
+    """Serve the React single page application.
+
+    If ``path`` points to an existing file, that file is served directly. For
+    any other route, ``index.html`` is returned so the client-side router can
+    take over. This ensures that visiting the server's root IP displays the
+    login page.
+    """
+
+    file_path = BASE_DIR / path
+    if path and file_path.exists():
+        return send_from_directory(str(BASE_DIR), path)
+    return send_from_directory(str(BASE_DIR), "index.html")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- serve the built React app for all routes
- ensure visiting the server root shows the login page by returning index.html

## Testing
- `python -m py_compile app.py`
- `python app.py` (and `curl -s http://127.0.0.1:5000/ | head -n 20`)


------
https://chatgpt.com/codex/tasks/task_e_68a5afa55e00832b899bd6cfec2fae44