### PR TITLE
Implement basic auth flow and route protection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,7 +37,7 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<Login />} />
-        <Route element={<ProtectedLayout />}>
+        <Route path="/" element={<ProtectedLayout />}>
           <Route index element={<Dashboard />} />
           <Route path="inventory">
             <Route index element={<InventoryList />} />

--- a/src/components/ProtectedLayout.jsx
+++ b/src/components/ProtectedLayout.jsx
@@ -1,13 +1,18 @@
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import NavBlock from "./NavBlock";
 
 export default function ProtectedLayout() {
-  const isAuthenticated = true; // demo
-  if (!isAuthenticated) return <Navigate to="/login" replace />;
-  return <ClassicShell />;
+  const isAuthenticated = localStorage.getItem("isAuth") === "true";
+  const location = useLocation();
+
+  if (!isAuthenticated && location.pathname !== "/") {
+    return <Navigate to="/" replace />;
+  }
+
+  return <ClassicShell limited={!isAuthenticated} />;
 }
 
-function ClassicShell() {
+function ClassicShell({ limited = false }) {
   return (
     <div className="min-h-screen bg-slate-100 text-slate-900">
       <div className="mx-auto max-w-6xl px-4 py-6">
@@ -15,25 +20,29 @@ function ClassicShell() {
           <aside className="col-span-3 lg:col-span-2">
             <div className="sticky top-20 space-y-2">
               <NavBlock title="" items={[{ label: "Ana Sayfa", to: "/", icon: "Home" }]} />
-              <NavBlock title="ENVANTER" items={[
-                { label: "Envanter Takip", to: "/inventory", icon: "Box" },
-                { label: "Lisans Takip", to: "/licenses", icon: "Key" },
-                { label: "Aksesuar Takip", to: "/accessories", icon: "Package" },
-                { label: "Yazıcı Takip", to: "/printers", icon: "Printer" },
-              ]} />
-              <NavBlock title="İŞLEMLER" items={[
-                { label: "Talep Takip", to: "/requests", icon: "FileText" },
-                { label: "Stok Takip", to: "/stock", icon: "Layers" },
-                { label: "Çöp Kutusu", to: "/trash", icon: "Trash2" },
-              ]} />
-              <NavBlock title="AYARLAR" items={[
-                { label: "Profil", to: "/profile", icon: "User" },
-                { label: "Admin Paneli", to: "/admin", icon: "Settings" },
-                { label: "Bağlantılar", to: "/integrations", icon: "Link" },
-                { label: "Kayıtlar", to: "/logs", icon: "ClipboardList" },
-                { label: "Envanter Ekleme", to: "/inventory/add", icon: "PlusCircle" },
-              ]} />
-              <NavBlock title="" items={[{ label: "Çıkış", to: "/logout", icon: "LogOut" }]} />
+              {!limited && (
+                <>
+                  <NavBlock title="ENVANTER" items={[
+                    { label: "Envanter Takip", to: "/inventory", icon: "Box" },
+                    { label: "Lisans Takip", to: "/licenses", icon: "Key" },
+                    { label: "Aksesuar Takip", to: "/accessories", icon: "Package" },
+                    { label: "Yazıcı Takip", to: "/printers", icon: "Printer" },
+                  ]} />
+                  <NavBlock title="İŞLEMLER" items={[
+                    { label: "Talep Takip", to: "/requests", icon: "FileText" },
+                    { label: "Stok Takip", to: "/stock", icon: "Layers" },
+                    { label: "Çöp Kutusu", to: "/trash", icon: "Trash2" },
+                  ]} />
+                  <NavBlock title="AYARLAR" items={[
+                    { label: "Profil", to: "/profile", icon: "User" },
+                    { label: "Admin Paneli", to: "/admin", icon: "Settings" },
+                    { label: "Bağlantılar", to: "/integrations", icon: "Link" },
+                    { label: "Kayıtlar", to: "/logs", icon: "ClipboardList" },
+                    { label: "Envanter Ekleme", to: "/inventory/add", icon: "PlusCircle" },
+                  ]} />
+                  <NavBlock title="" items={[{ label: "Çıkış", to: "/logout", icon: "LogOut" }]} />
+                </>
+              )}
             </div>
           </aside>
           <main className="col-span-9 lg:col-span-10 space-y-6">

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,11 +1,36 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { useState } from "react";
 import AuthShell from "../components/AuthShell";
+
 export default function Login() {
+  const navigate = useNavigate();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    if (username && password) {
+      localStorage.setItem("isAuth", "true");
+      navigate("/");
+    }
+  }
+
   return (
     <AuthShell title="Giriş Yap">
-      <form className="space-y-3">
-        <input className="w-full rounded-xl border px-3 py-2" placeholder="Kullanıcı adı" />
-        <input className="w-full rounded-xl border px-3 py-2" placeholder="Şifre" type="password" />
+      <form className="space-y-3" onSubmit={handleSubmit}>
+        <input
+          className="w-full rounded-xl border px-3 py-2"
+          placeholder="Kullanıcı adı"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          className="w-full rounded-xl border px-3 py-2"
+          placeholder="Şifre"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
         <button className="w-full rounded-xl border px-3 py-2 bg-slate-900 text-white">Giriş</button>
       </form>
       <div className="mt-3 text-center text-sm text-slate-500">


### PR DESCRIPTION
## Summary
- handle login submission, store auth flag, and navigate home
- restrict protected layout to home for unauthenticated users and redirect others
- clarify routing by setting root path on protected layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5c7d17d04832b826f44539c4bb375