### PR TITLE
Add JWT login route to Flask app

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,12 +8,27 @@ client-side navigation.
 
 from pathlib import Path
 
-from flask import Flask, send_from_directory
+from flask import Flask, jsonify, request, send_from_directory
+from flask_jwt_extended import JWTManager, create_access_token
 
 
 BASE_DIR = Path(__file__).resolve().parent / "dist"
 
 app = Flask(__name__, static_folder=str(BASE_DIR), static_url_path="")
+app.config["JWT_SECRET_KEY"] = "change-me"  # TODO: update in production
+jwt = JWTManager(app)
+
+
+@app.post("/api/login")
+def login() -> tuple:
+    """Authenticate the user and return an access token."""
+    data = request.get_json() or {}
+    username = data.get("username")
+    password = data.get("password")
+    if username == "admin" and password == "password":
+        token = create_access_token(identity=username)
+        return jsonify(token=token), 200
+    return jsonify(error="Invalid credentials"), 401
 
 
 @app.route("/", defaults={"path": ""})

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sqlalchemy==2.0.43
 fastapi==0.116.1
 flask==3.0.3
 gunicorn==23.0.0
+flask-jwt-extended==4.6.0


### PR DESCRIPTION
## Summary
- add `/api/login` route validating credentials and issuing JWT tokens
- configure `Flask-JWT-Extended` for token generation
- list Flask-JWT-Extended in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask-jwt-extended==4.6.0)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d7502064832b982d4baa7b429e0a