### PR TITLE
Serve basic login page at site root

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ routes for the main pages of the application so that requesting ``/``,
 ``404`` errors.
 """
 
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, render_template
 from flask_jwt_extended import JWTManager, create_access_token
 
 
@@ -28,17 +28,11 @@ def login() -> tuple:
 
 
 @app.get("/")
-def index() -> str:
-    """Return a simple home page."""
-
-    return "Home page"
-
-
 @app.get("/login")
 def login_page() -> str:
-    """Return a simple login page."""
+    """Render the login page."""
 
-    return "Login page"
+    return render_template("login.html")
 
 
 @app.get("/inventory")

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Giriş Yap</title>
+</head>
+<body>
+  <form id="loginForm">
+    <label for="username">Kullanıcı Adı:</label>
+    <input type="text" id="username" name="username" required />
+    <br />
+    <label for="password">Şifre:</label>
+    <input type="password" id="password" name="password" required />
+    <br />
+    <button type="submit">Giriş</button>
+  </form>
+  <div id="error" style="color: red;"></div>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = e.target.username.value;
+      const password = e.target.password.value;
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      if (res.ok) {
+        alert('Giriş başarılı');
+      } else {
+        const data = await res.json();
+        document.getElementById('error').textContent = data.error || 'Giriş başarısız';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple HTML login form
- serve login page from `/` and `/login` via Flask

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5dc328f78832baebb9357c88e0033