### PR TITLE
Fix duplicated content block in base template causing login error

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -47,16 +47,12 @@
           <a class="side-link" href="/inventory/add">Envanter Ekleme</a>
         </div>
       </aside>
-
-      <!-- İçerik -->
       <main class="col-12 col-lg-10">
-        {% block content %}{% endblock %}
-      </main>
       {% else %}
       <main class="col-12">
+      {% endif %}
         {% block content %}{% endblock %}
       </main>
-      {% endif %}
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Refactor base template to define the `content` block a single time
- Prevent Jinja `TemplateAssertionError` on login and other views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6d6faca94832bac29b7e317638618