### PR TITLE
Fix inventory add route and HTTPException handling

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -28,6 +28,49 @@ def inventory_list(request: Request, db: Session = Depends(get_db)):
     )
 
 
+@router.post("", response_model=None)
+def create_inventory(payload: InventoryCreate, db: Session = Depends(get_db)):
+    exists = db.query(Inventory).filter(Inventory.no == payload.no).first()
+    if exists:
+        raise HTTPException(400, "Aynı envanter no var")
+    inv = Inventory(**payload.model_dump())
+    db.add(inv)
+    db.commit()
+    return {"ok": True}
+
+
+@router.get("/add", response_class=HTMLResponse)
+def inventory_add_form(request: Request):
+    return templates.TemplateResponse("inventory_add.html", {"request": request})
+
+
+@router.post("/add", response_class=HTMLResponse)
+def inventory_add(
+    no: str = Form(...),
+    fabrika: str | None = Form(None),
+    departman: str | None = Form(None),
+    donanim_tipi: str | None = Form(None),
+    bilgisayar_adi: str | None = Form(None),
+    sorumlu_personel: str | None = Form(None),
+    db: Session = Depends(get_db),
+):
+    payload = InventoryCreate(
+        no=no,
+        fabrika=fabrika,
+        departman=departman,
+        donanim_tipi=donanim_tipi,
+        bilgisayar_adi=bilgisayar_adi,
+        sorumlu_personel=sorumlu_personel,
+    )
+    exists = db.query(Inventory).filter(Inventory.no == payload.no).first()
+    if exists:
+        raise HTTPException(400, "Aynı envanter no var")
+    inv = Inventory(**payload.model_dump())
+    db.add(inv)
+    db.commit()
+    return RedirectResponse("/inventory", status_code=303)
+
+
 @router.get("/{no}", response_class=HTMLResponse)
 def inventory_detail(no: str, request: Request, db: Session = Depends(get_db)):
     inv = db.query(Inventory).filter(Inventory.no == no).first()
@@ -44,17 +87,6 @@ def inventory_detail(no: str, request: Request, db: Session = Depends(get_db)):
     return templates.TemplateResponse(
         "inventory_detail.html", {"request": request, "item": inv, "logs": logs}
     )
-
-
-@router.post("", response_model=None)
-def create_inventory(payload: InventoryCreate, db: Session = Depends(get_db)):
-    exists = db.query(Inventory).filter(Inventory.no == payload.no).first()
-    if exists:
-        raise HTTPException(400, "Aynı envanter no var")
-    inv = Inventory(**payload.model_dump())
-    db.add(inv)
-    db.commit()
-    return {"ok": True}
 
 
 @router.post("/{no}/update", response_model=None)
@@ -99,36 +131,4 @@ def update_inventory(no: str, payload: InventoryUpdate, db: Session = Depends(ge
             )
     db.commit()
     return {"ok": True}
-
-
-@router.get("/add", response_class=HTMLResponse)
-def inventory_add_form(request: Request):
-    return templates.TemplateResponse("inventory_add.html", {"request": request})
-
-
-@router.post("/add", response_class=HTMLResponse)
-def inventory_add(
-    no: str = Form(...),
-    fabrika: str | None = Form(None),
-    departman: str | None = Form(None),
-    donanim_tipi: str | None = Form(None),
-    bilgisayar_adi: str | None = Form(None),
-    sorumlu_personel: str | None = Form(None),
-    db: Session = Depends(get_db),
-):
-    payload = InventoryCreate(
-        no=no,
-        fabrika=fabrika,
-        departman=departman,
-        donanim_tipi=donanim_tipi,
-        bilgisayar_adi=bilgisayar_adi,
-        sorumlu_personel=sorumlu_personel,
-    )
-    exists = db.query(Inventory).filter(Inventory.no == payload.no).first()
-    if exists:
-        raise HTTPException(400, "Aynı envanter no var")
-    inv = Inventory(**payload.model_dump())
-    db.add(inv)
-    db.commit()
-    return RedirectResponse("/inventory", status_code=303)
 


### PR DESCRIPTION
## Summary
- Ensure HTTPException handler delegates non-redirect errors to FastAPI's default handler to avoid 500 responses
- Reorder inventory routes so `/inventory/add` is correctly served instead of being caught by the detail endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6f86562dc832b8ac64d9e695e6d09