### PR TITLE
Expand inventory add form

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -28,7 +28,12 @@ def inventory_list(request: Request, db: Session = Depends(get_db)):
 
     return templates.TemplateResponse(
         "inventory_list.html",
-        {"request": request, "rows": rows, "users": users},
+        {
+            "request": request,
+            "rows": rows,
+            "users": users,
+            "today": datetime.now().strftime("%Y-%m-%d"),
+        },
     )
 
 
@@ -49,17 +54,32 @@ def create_inventory(payload: InventoryCreate, db: Session = Depends(get_db)):
 @router.post("/add", response_class=HTMLResponse)
 def inventory_add(
     no: str = Form(...),
+    fabrika: str | None = Form(None),
+    departman: str | None = Form(None),
+    donanim_tipi: str | None = Form(None),
+    bilgisayar_adi: str | None = Form(None),
+    marka: str | None = Form(None),
+    model: str | None = Form(None),
+    seri_no: str | None = Form(None),
     sorumlu_personel: str | None = Form(None),
     bagli_makina_no: str | None = Form(None),
+    tarih: str | None = Form(None),
     notlar: str | None = Form(None),
     db: Session = Depends(get_db),
 ):
     payload = InventoryCreate(
         no=no,
+        fabrika=fabrika,
+        departman=departman,
+        donanim_tipi=donanim_tipi,
+        bilgisayar_adi=bilgisayar_adi,
+        marka=marka,
+        model=model,
+        seri_no=seri_no,
         sorumlu_personel=sorumlu_personel,
         bagli_makina_no=bagli_makina_no,
+        tarih=tarih or datetime.now().strftime("%Y-%m-%d"),
         notlar=notlar,
-        tarih=datetime.now().strftime("%Y-%m-%d"),
     )
     exists = db.query(Inventory).filter(Inventory.no == payload.no).first()
     if exists:

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -60,26 +60,62 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          <div class="mb-3">
-            <label class="form-label">Envanter No</label>
-            <input name="no" class="form-control" required>
-          </div>
-          <div class="mb-3">
-            <label class="form-label">Sorumlu Personel</label>
-            <select name="sorumlu_personel" class="form-select">
-              <option value="">Seçiniz</option>
-              {% for u in users %}
-              <option value="{{ u.full_name }}">{{ u.full_name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="mb-3">
-            <label class="form-label">Bağlı Makina No</label>
-            <input name="bagli_makina_no" class="form-control">
-          </div>
-          <div class="mb-3">
-            <label class="form-label">Notlar</label>
-            <textarea name="notlar" class="form-control" rows="3"></textarea>
+          <div class="row g-2">
+            <div class="col-md-3">
+              <label class="form-label">Envanter No</label>
+              <input name="no" class="form-control" required>
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Fabrika</label>
+              <input name="fabrika" class="form-control">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Departman</label>
+              <input name="departman" class="form-control">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Donanım Tipi</label>
+              <input name="donanim_tipi" class="form-control">
+            </div>
+
+            <div class="col-md-3">
+              <label class="form-label">Bilgisayar Adı</label>
+              <input name="bilgisayar_adi" class="form-control">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Marka</label>
+              <input name="marka" class="form-control">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Model</label>
+              <input name="model" class="form-control">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Seri No</label>
+              <input name="seri_no" class="form-control">
+            </div>
+
+            <div class="col-md-3">
+              <label class="form-label">Sorumlu Personel</label>
+              <select name="sorumlu_personel" class="form-select">
+                <option value="">Seçiniz</option>
+                {% for u in users %}
+                <option value="{{ u.full_name }}">{{ u.full_name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Bağlı Makina No</label>
+              <input name="bagli_makina_no" class="form-control">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Tarih</label>
+              <input name="tarih" type="date" class="form-control" value="{{ today }}">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Notlar</label>
+              <textarea name="notlar" class="form-control" rows="1"></textarea>
+            </div>
           </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
## Summary
- Display inventory add form in three rows of four inputs each
- Allow recording of factory, department, device specs and auto-filled date

## Testing
- `pytest -q`
- `python -m py_compile routers/inventory.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6fd932294832b90bea88cc301d2fd