### PR TITLE
Add license management with logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ from auth import (
 from routers import (
     home,
     inventory as inventory_router,
-    licenses,
+    license as license_router,
     accessories,
     printers,
     requests as reqs,
@@ -88,7 +88,7 @@ templates = Jinja2Templates(directory="templates")
 # --- Routers (korumalı) -------------------------------------------------------
 app.include_router(home.router, prefix="", dependencies=[Depends(current_user)])
 app.include_router(inventory_router.router, dependencies=[Depends(current_user)])
-app.include_router(licenses.router, prefix="/licenses", tags=["Licenses"], dependencies=[Depends(current_user)])
+app.include_router(license_router.router, dependencies=[Depends(current_user)])
 app.include_router(accessories.router, prefix="/accessories", tags=["Accessories"], dependencies=[Depends(current_user)])
 app.include_router(printers.router, prefix="/printers", tags=["Printers"], dependencies=[Depends(current_user)])
 app.include_router(reqs.router, prefix="/requests", tags=["Requests"], dependencies=[Depends(current_user)])

--- a/models.py
+++ b/models.py
@@ -77,5 +77,39 @@ class InventoryLog(Base):
 
     inventory: Mapped["Inventory"] = relationship("Inventory", back_populates="logs")
 
+
+class License(Base):
+    __tablename__ = "licenses"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    lisans_adi: Mapped[str] = mapped_column(String(200), index=True, nullable=False)
+    lisans_anahtari: Mapped[str] = mapped_column(String(500), nullable=False)
+    sorumlu_personel: Mapped[str | None] = mapped_column(String(150), index=True)
+    bagli_envanter_no: Mapped[str | None] = mapped_column(String(150), index=True)
+    ifs_no: Mapped[str | None] = mapped_column(String(150))
+    tarih: Mapped[str | None] = mapped_column(String(50))
+    islem_yapan: Mapped[str | None] = mapped_column(String(150))
+    mail_adresi: Mapped[str | None] = mapped_column(String(200))
+
+    logs: Mapped[list["LicenseLog"]] = relationship(
+        "LicenseLog", back_populates="license_", cascade="all, delete-orphan"
+    )
+
+
+class LicenseLog(Base):
+    __tablename__ = "license_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    license_id: Mapped[int] = mapped_column(
+        ForeignKey("licenses.id", ondelete="CASCADE"), index=True, nullable=False
+    )
+    field: Mapped[str] = mapped_column(String(100), nullable=False)
+    old_value: Mapped[str | None] = mapped_column(Text)
+    new_value: Mapped[str | None] = mapped_column(Text)
+    changed_by: Mapped[str] = mapped_column(String(150), nullable=False)
+    changed_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    license_: Mapped["License"] = relationship("License", back_populates="logs")
+
 def init_db():
     Base.metadata.create_all(bind=engine)

--- a/routers/license.py
+++ b/routers/license.py
@@ -1,0 +1,95 @@
+from fastapi import APIRouter, Depends, Request, HTTPException
+from sqlalchemy.orm import Session
+from fastapi.templating import Jinja2Templates
+from models import License, LicenseLog
+from .license_schemas import LicenseCreate, LicenseUpdate
+from auth import get_db
+
+# from auth import require_login  # login varsa Depends(require_login) ile sarabilirsin
+
+templates = Jinja2Templates(directory="templates")
+router = APIRouter(prefix="/licenses", tags=["Lisanslar"])
+
+
+@router.get("")
+def license_list(request: Request, db: Session = Depends(get_db)):
+    rows = (
+        db.query(
+            License.id,
+            License.bagli_envanter_no,
+            License.lisans_adi,
+            License.lisans_anahtari,
+            License.sorumlu_personel,
+        )
+        .order_by(License.id.desc())
+        .all()
+    )
+    return templates.TemplateResponse("license_list.html", {"request": request, "rows": rows})
+
+
+@router.get("/{license_id}")
+def license_detail(license_id: int, request: Request, db: Session = Depends(get_db)):
+    lic = db.query(License).filter(License.id == license_id).first()
+    if not lic:
+        raise HTTPException(404, "Lisans bulunamadı")
+
+    logs = (
+        db.query(LicenseLog)
+        .filter(LicenseLog.license_id == lic.id)
+        .order_by(LicenseLog.changed_at.desc())
+        .all()
+    )
+    return templates.TemplateResponse(
+        "license_detail.html", {"request": request, "item": lic, "logs": logs}
+    )
+
+
+@router.post("")
+def create_license(payload: LicenseCreate, db: Session = Depends(get_db)):
+    lic = License(**payload.model_dump())
+    db.add(lic)
+    db.commit()
+    return {"ok": True, "id": lic.id}
+
+
+@router.post("/{license_id}/update")
+def update_license(license_id: int, payload: LicenseUpdate, db: Session = Depends(get_db)):
+    lic = db.query(License).filter(License.id == license_id).first()
+    if not lic:
+        raise HTTPException(404, "Lisans yok")
+
+    mutable_fields = [
+        "lisans_adi",
+        "lisans_anahtari",
+        "sorumlu_personel",
+        "bagli_envanter_no",
+        "ifs_no",
+        "tarih",
+        "islem_yapan",
+        "mail_adresi",
+    ]
+
+    changer = payload.islem_yapan or "Sistem"
+
+    changed = False
+    for f in mutable_fields:
+        new_val = getattr(payload, f, None)
+        if new_val is None:
+            continue
+        old_val = getattr(lic, f)
+        if new_val != old_val:
+            setattr(lic, f, new_val)
+            db.add(
+                LicenseLog(
+                    license_id=lic.id,
+                    field=f,
+                    old_value=str(old_val) if old_val is not None else None,
+                    new_value=str(new_val) if new_val is not None else None,
+                    changed_by=changer,
+                )
+            )
+            changed = True
+
+    if changed:
+        db.commit()
+    return {"ok": True}

--- a/routers/license_schemas.py
+++ b/routers/license_schemas.py
@@ -1,0 +1,59 @@
+from typing import Optional, List
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class LicenseBase(BaseModel):
+    lisans_adi: str
+    lisans_anahtari: str
+    sorumlu_personel: Optional[str] = None
+    bagli_envanter_no: Optional[str] = None
+    ifs_no: Optional[str] = None
+    tarih: Optional[str] = None
+    islem_yapan: Optional[str] = None
+    mail_adresi: Optional[str] = None
+
+
+class LicenseCreate(LicenseBase):
+    pass
+
+
+class LicenseUpdate(BaseModel):
+    lisans_adi: Optional[str] = None
+    lisans_anahtari: Optional[str] = None
+    sorumlu_personel: Optional[str] = None
+    bagli_envanter_no: Optional[str] = None
+    ifs_no: Optional[str] = None
+    tarih: Optional[str] = None
+    islem_yapan: Optional[str] = None
+    mail_adresi: Optional[str] = None
+
+
+class LicenseLogOut(BaseModel):
+    field: str
+    old_value: str | None
+    new_value: str | None
+    changed_by: str
+    changed_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class LicenseListOut(BaseModel):
+    id: int
+    bagli_envanter_no: str | None
+    lisans_adi: str
+    lisans_anahtari: str
+    sorumlu_personel: str | None
+
+    class Config:
+        from_attributes = True
+
+
+class LicenseDetailOut(LicenseBase):
+    id: int
+    logs: List[LicenseLogOut] = []
+
+    class Config:
+        from_attributes = True

--- a/templates/license_detail.html
+++ b/templates/license_detail.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+{% block title %}Lisans Detay - {{ item.lisans_adi }}{% endblock %}
+{% block content %}
+<div class="container-fluid p-3">
+  <div class="d-flex align-items-center justify-content-between mb-2">
+    <h5>Lisans: {{ item.lisans_adi }}</h5>
+    <a href="/licenses" class="btn btn-sm btn-outline-secondary">← Listeye dön</a>
+  </div>
+
+  <div class="row g-3">
+    <div class="col-lg-6">
+      <div class="card">
+        <div class="card-header">Temel Bilgiler</div>
+        <div class="card-body">
+          <div class="row">
+            <div class="col-5 text-muted">ID</div><div class="col-7">{{ item.id }}</div>
+            <div class="col-5 text-muted">Lisans Adı</div><div class="col-7">{{ item.lisans_adi }}</div>
+            <div class="col-5 text-muted">Lisans Anahtarı</div><div class="col-7"><code>{{ item.lisans_anahtari }}</code></div>
+            <div class="col-5 text-muted">Sorumlu Personel</div><div class="col-7">{{ item.sorumlu_personel }}</div>
+            <div class="col-5 text-muted">Bağlı Envanter No</div><div class="col-7">{{ item.bagli_envanter_no }}</div>
+            <div class="col-5 text-muted">IFS No</div><div class="col-7">{{ item.ifs_no }}</div>
+            <div class="col-5 text-muted">Tarih</div><div class="col-7">{{ item.tarih }}</div>
+            <div class="col-5 text-muted">İşlem Yapan</div><div class="col-7">{{ item.islem_yapan }}</div>
+            <div class="col-5 text-muted">Mail Adresi</div><div class="col-7">{{ item.mail_adresi }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-6">
+      <div class="card">
+        <div class="card-header">Değişiklik Geçmişi</div>
+        <div class="card-body p-0">
+          <div class="table-responsive">
+            <table class="table table-sm table-striped mb-0">
+              <thead>
+                <tr>
+                  <th>Alan</th>
+                  <th>Önce</th>
+                  <th>Sonra</th>
+                  <th>Değiştiren</th>
+                  <th>Tarih</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for log in logs %}
+                <tr>
+                  <td><code>{{ log.field }}</code></td>
+                  <td class="text-muted">{{ log.old_value }}</td>
+                  <td>{{ log.new_value }}</td>
+                  <td>{{ log.changed_by }}</td>
+                  <td>{{ log.changed_at }}</td>
+                </tr>
+                {% else %}
+                <tr><td colspan="5" class="text-muted">Henüz değişiklik yok</td></tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Lisans Takip{% endblock %}
+{% block content %}
+<div class="container-fluid p-3">
+  <h5 class="mb-3">Lisanslar</h5>
+  <div class="table-responsive">
+    <table class="table table-sm table-hover align-middle">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Bağlı Envanter No</th>
+          <th>Lisans Adı</th>
+          <th>Lisans Anahtarı</th>
+          <th>Sorumlu Personel</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in rows %}
+        <tr>
+          <td>{{ r.id }}</td>
+          <td>{{ r.bagli_envanter_no or "" }}</td>
+          <td><a href="/licenses/{{ r.id }}" class="text-decoration-underline">{{ r.lisans_adi }}</a></td>
+          <td>{{ r.lisans_anahtari }}</td>
+          <td>{{ r.sorumlu_personel or "" }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="5" class="text-muted">Kayıt yok</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce `License` and `LicenseLog` models for tracking software licenses and changes
- add Pydantic schemas, API router endpoints and templates for listing and viewing license details
- wire new license router into application

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a705ca43bc832bb1b718d2cb78d7c4