### PR TITLE
Add lookup model and admin management interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ from routers import (
     stock,
     trash,
     profile,
-    admin,
+    admin as admin_router,
     integrations,
     logs,
 )
@@ -99,7 +99,7 @@ app.include_router(integrations.router, prefix="/integrations", tags=["Integrati
 
 # Sadece admin
 app.include_router(logs.router, prefix="/logs", tags=["Logs"], dependencies=[Depends(require_roles("admin"))])
-app.include_router(admin.router, prefix="/admin", tags=["Admin"], dependencies=[Depends(require_roles("admin"))])
+app.include_router(admin_router.router, dependencies=[Depends(require_roles("admin"))])
 
 # --- Startup: DB init & default admin ----------------------------------------
 @app.on_event("startup")

--- a/models.py
+++ b/models.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     func,
     ForeignKey,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker, relationship
 
@@ -149,6 +150,19 @@ class PrinterLog(Base):
     )
 
     printer: Mapped["Printer"] = relationship("Printer", back_populates="logs")
+
+
+class Lookup(Base):
+    __tablename__ = "lookups"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    category: Mapped[str] = mapped_column(String(50), index=True, nullable=False)
+    value: Mapped[str] = mapped_column(String(200), nullable=False)
+    created_by: Mapped[str | None] = mapped_column(String(150))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (UniqueConstraint("category", "value", name="uq_lookup_category_value"),)
+
 
 def init_db():
     Base.metadata.create_all(bind=engine)

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1,27 +1,171 @@
-# routers/admin.py
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, Depends, Request, HTTPException, Form
+from sqlalchemy.orm import Session
 from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy import or_, asc
+from typing import Optional
+from types import SimpleNamespace
 
-router = APIRouter()
+from models import Lookup
+from auth import get_db, hash_password
+
+try:
+    from models import User
+except Exception as e:
+    raise RuntimeError("User modeli bulunamadı; models.py içindeki User sınıfını kullanın.") from e
+
 templates = Jinja2Templates(directory="templates")
+router = APIRouter(prefix="/admin", tags=["Admin"])
 
-@router.get("/", response_class=HTMLResponse)
-async def admin_home(request: Request):
-    return templates.TemplateResponse("admin/users.html", {"request": request})
 
-@router.get("/users", response_class=HTMLResponse)
-async def admin_users(request: Request):
-    return templates.TemplateResponse("admin/users.html", {"request": request})
+@router.get("", response_class=HTMLResponse)
+def admin_panel(request: Request, q: Optional[str] = None, db: Session = Depends(get_db)):
+    query = db.query(User)
+    if q:
+        q_like = f"%{q}%"
+        query = query.filter(
+            or_(
+                User.username.ilike(q_like),
+                User.full_name.ilike(q_like),
+            )
+        )
+    db_users = query.order_by(asc(User.id)).all()
 
-@router.get("/taxonomies", response_class=HTMLResponse)
-async def admin_taxonomies(request: Request):
-    return templates.TemplateResponse("admin/taxonomies.html", {"request": request})
+    users = []
+    for u in db_users:
+        first_name = ""
+        last_name = ""
+        if u.full_name:
+            parts = u.full_name.split(" ", 1)
+            first_name = parts[0]
+            if len(parts) > 1:
+                last_name = parts[1]
+        users.append(
+            SimpleNamespace(
+                id=u.id,
+                username=u.username,
+                first_name=first_name,
+                last_name=last_name,
+                email="",
+                is_admin=1 if getattr(u, "role", "") == "admin" else 0,
+            )
+        )
 
-@router.get("/integrations", response_class=HTMLResponse)
-async def admin_integrations(request: Request):
-    return templates.TemplateResponse("admin/integrations.html", {"request": request})
+    CATS = [
+        "yazici_markasi",
+        "yazici_modeli",
+        "kullanim_alani",
+        "lisans_adi",
+        "fabrika",
+        "donanim_tipi",
+        "marka",
+        "model",
+    ]
+    lookups = {
+        c: db.query(Lookup).filter(Lookup.category == c).order_by(asc(Lookup.value)).all()
+        for c in CATS
+    }
 
-@router.get("/settings", response_class=HTMLResponse)
-async def admin_settings(request: Request):
-    return templates.TemplateResponse("admin/settings.html", {"request": request})
+    return templates.TemplateResponse(
+        "admin.html",
+        {
+            "request": request,
+            "users": users,
+            "q": q or "",
+            "lookups": lookups,
+            "CATS": CATS,
+        },
+    )
+
+
+@router.post("/users/create")
+def create_user(
+    username: str = Form(...),
+    password: str = Form(...),
+    first_name: str = Form(""),
+    last_name: str = Form(""),
+    email: str = Form(""),
+    is_admin: Optional[bool] = Form(False),
+    db: Session = Depends(get_db),
+):
+    if db.query(User).filter(User.username == username).first():
+        raise HTTPException(400, "Bu kullanıcı adı zaten mevcut.")
+    full_name = f"{first_name} {last_name}".strip()
+    user = User(
+        username=username,
+        password_hash=hash_password(password),
+        full_name=full_name,
+        role="admin" if is_admin else "user",
+    )
+    db.add(user)
+    db.commit()
+    return RedirectResponse(url="/admin", status_code=303)
+
+
+@router.post("/users/{user_id}/update")
+def update_user(
+    user_id: int,
+    username: str = Form(...),
+    password: str = Form(""),
+    first_name: str = Form(""),
+    last_name: str = Form(""),
+    email: str = Form(""),
+    is_admin: Optional[bool] = Form(False),
+    db: Session = Depends(get_db),
+):
+    user = db.query(User).get(user_id)
+    if not user:
+        raise HTTPException(404, "Kullanıcı bulunamadı.")
+
+    if username != user.username and db.query(User).filter(User.username == username).first():
+        raise HTTPException(400, "Bu kullanıcı adı zaten kullanılıyor.")
+
+    user.username = username
+    user.full_name = f"{first_name} {last_name}".strip()
+    user.role = "admin" if is_admin else "user"
+    if password.strip():
+        user.password_hash = hash_password(password)
+
+    db.commit()
+    return RedirectResponse(url="/admin", status_code=303)
+
+
+@router.post("/users/{user_id}/delete")
+def delete_user(user_id: int, db: Session = Depends(get_db)):
+    user = db.query(User).get(user_id)
+    if not user:
+        raise HTTPException(404, "Kullanıcı bulunamadı.")
+    if user.username.lower() == "admin":
+        raise HTTPException(400, "Admin hesabı silinemez.")
+    db.delete(user)
+    db.commit()
+    return RedirectResponse(url="/admin", status_code=303)
+
+
+@router.post("/lookups/add")
+def add_lookup(
+    category: str = Form(...),
+    value: str = Form(...),
+    who: str = Form(""),
+    db: Session = Depends(get_db),
+):
+    value = value.strip()
+    if not value:
+        raise HTTPException(400, "Değer boş olamaz.")
+    exists = db.query(Lookup).filter(Lookup.category == category, Lookup.value == value).first()
+    if exists:
+        raise HTTPException(400, "Bu değer zaten var.")
+    db.add(Lookup(category=category, value=value, created_by=who))
+    db.commit()
+    return RedirectResponse(url="/admin", status_code=303)
+
+
+@router.post("/lookups/{lookup_id}/delete")
+def delete_lookup(lookup_id: int, db: Session = Depends(get_db)):
+    lk = db.query(Lookup).get(lookup_id)
+    if not lk:
+        raise HTTPException(404, "Kayıt bulunamadı.")
+    db.delete(lk)
+    db.commit()
+    return RedirectResponse(url="/admin", status_code=303)
+

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,252 @@
+{% extends "base.html" %}
+{% block title %}Admin Paneli{% endblock %}
+{% block content %}
+<div class="container-fluid p-3">
+
+  <!-- Üst Kutu Başlıkları -->
+  <div class="d-flex align-items-center gap-2 mb-3">
+    <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#userBox" aria-expanded="true">
+      Kullanıcı
+    </button>
+    <button class="btn btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#productBox" aria-expanded="false">
+      Ürün Ekle
+    </button>
+  </div>
+
+  <!-- KULLANICI KUTUSU -->
+  <div class="collapse show" id="userBox">
+    <div class="card mb-4">
+      <div class="card-header d-flex flex-wrap align-items-center justify-content-between gap-2">
+        <div class="d-flex align-items-center gap-2">
+          <!-- Kullanıcı Ekle: formu aç/kapa -->
+          <button class="btn btn-success btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#userCreateForm">
+            Kullanıcı Ekle
+          </button>
+          <!-- Düzenle: seçili kullanıcıyı formda aç -->
+          <button class="btn btn-warning btn-sm" type="button" id="btnEditUser">Düzenle</button>
+          <!-- Sil: seçili kullanıcıyı sil -->
+          <form id="deleteForm" method="post" class="d-inline">
+            <button class="btn btn-danger btn-sm" type="submit" id="btnDeleteUser">Sil</button>
+          </form>
+        </div>
+
+        <!-- Liste içinde arama (client-side) -->
+        <div class="d-flex align-items-center gap-2">
+          <input type="text" id="tblSearch" class="form-control form-control-sm" placeholder="Listede ara...">
+          <!-- İstersen server-side için: action='/admin' input name='q' -->
+        </div>
+      </div>
+
+      <div class="card-body">
+
+        <!-- Kullanıcı Ekle Formu -->
+        <div class="collapse" id="userCreateForm">
+          <form method="post" action="/admin/users/create" class="border rounded p-3 mb-3">
+            <div class="row g-2">
+              <div class="col-md-3">
+                <label class="form-label">Kullanıcı Adı</label>
+                <input name="username" class="form-control form-control-sm" required>
+              </div>
+              <div class="col-md-3">
+                <label class="form-label">Şifre</label>
+                <input type="password" name="password" class="form-control form-control-sm" required>
+              </div>
+              <div class="col-md-2">
+                <label class="form-label">Adı</label>
+                <input name="first_name" class="form-control form-control-sm">
+              </div>
+              <div class="col-md-2">
+                <label class="form-label">Soyadı</label>
+                <input name="last_name" class="form-control form-control-sm">
+              </div>
+              <div class="col-md-2">
+                <label class="form-label">Mail</label>
+                <input type="email" name="email" class="form-control form-control-sm">
+              </div>
+              <div class="col-12 d-flex align-items-center gap-2 mt-2">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="is_admin" name="is_admin">
+                  <label class="form-check-label" for="is_admin">Admin</label>
+                </div>
+                <button class="btn btn-success btn-sm ms-auto" type="submit">Ekle</button>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <!-- Kullanıcı Düzenle Formu (seçili kullanıcıyla doldurulur) -->
+        <form method="post" id="userEditForm" class="border rounded p-3 mb-3 d-none">
+          <input type="hidden" id="editAction" value="">
+          <div class="row g-2">
+            <div class="col-md-3">
+              <label class="form-label">Kullanıcı Adı</label>
+              <input name="username" id="edit_username" class="form-control form-control-sm" required>
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Yeni Şifre (isteğe bağlı)</label>
+              <input type="password" name="password" id="edit_password" class="form-control form-control-sm" placeholder="Boş bırakılırsa değişmez">
+            </div>
+            <div class="col-md-2">
+              <label class="form-label">Adı</label>
+              <input name="first_name" id="edit_first_name" class="form-control form-control-sm">
+            </div>
+            <div class="col-md-2">
+              <label class="form-label">Soyadı</label>
+              <input name="last_name" id="edit_last_name" class="form-control form-control-sm">
+            </div>
+            <div class="col-md-2">
+              <label class="form-label">Mail</label>
+              <input type="email" name="email" id="edit_email" class="form-control form-control-sm">
+            </div>
+            <div class="col-12 d-flex align-items-center gap-2 mt-2">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="edit_is_admin" name="is_admin">
+                <label class="form-check-label" for="edit_is_admin">Admin</label>
+              </div>
+              <button class="btn btn-warning btn-sm ms-auto" type="submit">Kaydet</button>
+            </div>
+          </div>
+        </form>
+
+        <!-- Kullanıcı Listesi -->
+        <div class="table-responsive">
+          <table class="table table-sm table-hover align-middle" id="userTable">
+            <thead>
+              <tr>
+                <th style="width:36px;"></th>
+                <th>ID</th>
+                <th>Kullanıcı Adı</th>
+                <th>Adı</th>
+                <th>Soyadı</th>
+                <th>Mail</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for u in users %}
+              <tr data-id="{{ u.id }}"
+                  data-username="{{ u.username }}"
+                  data-first_name="{{ u.first_name or '' }}"
+                  data-last_name="{{ u.last_name or '' }}"
+                  data-email="{{ u.email or '' }}"
+                  data-is_admin="{{ 1 if getattr(u,'is_admin',False) else 0 }}">
+                <td><input type="radio" name="selUser" value="{{ u.id }}"></td>
+                <td>{{ u.id }}</td>
+                <td>{{ u.username }}</td>
+                <td>{{ u.first_name or '' }}</td>
+                <td>{{ u.last_name or '' }}</td>
+                <td>{{ u.email or '' }}</td>
+              </tr>
+              {% else %}
+              <tr><td colspan="6" class="text-muted">Kullanıcı yok</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- ÜRÜN EKLE KUTUSU (SÖZLÜKLER) -->
+  <div class="collapse" id="productBox">
+    <div class="row g-3">
+      {% for cat in CATS %}
+      <div class="col-lg-3 col-md-4">
+        <div class="card h-100">
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <span class="text-capitalize">{{ cat.replace('_',' ') }}</span>
+          </div>
+          <div class="card-body d-flex flex-column">
+            <form method="post" action="/admin/lookups/add" class="d-flex gap-2 mb-2">
+              <input type="hidden" name="category" value="{{ cat }}">
+              <input type="text" name="value" class="form-control form-control-sm" placeholder="Yeni değer..." required>
+              <input type="hidden" name="who" value="{{ request.session.get('username','') if request and request.session else '' }}">
+              <button class="btn btn-sm btn-success" type="submit">Ekle</button>
+            </form>
+            <div class="border rounded p-2 flex-grow-1 overflow-auto" style="max-height: 260px;">
+              {% for item in lookups[cat] %}
+              <form method="post" action="/admin/lookups/{{ item.id }}/delete" class="d-flex align-items-center justify-content-between py-1 border-bottom">
+                <span class="small">{{ item.value }}</span>
+                <button class="btn btn-outline-danger btn-sm">Sil</button>
+              </form>
+              {% else %}
+              <div class="text-muted small">Kayıt yok</div>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+
+</div>
+
+<!-- Basit JS: tablo arama + düzenleme formunu doldurma + silme -->
+<script>
+  // Liste içi arama (client-side)
+  const search = document.getElementById('tblSearch');
+  const table = document.getElementById('userTable');
+  if (search && table) {
+    search.addEventListener('input', () => {
+      const q = search.value.toLowerCase();
+      table.querySelectorAll('tbody tr').forEach(tr => {
+        tr.style.display = tr.innerText.toLowerCase().includes(q) ? '' : 'none';
+      });
+    });
+  }
+
+  // Seçili kullanıcıyı bul
+  function getSelectedRow() {
+    const checked = table.querySelector('input[name="selUser"]:checked');
+    if (!checked) return null;
+    return checked.closest('tr');
+  }
+
+  // Düzenle
+  const btnEdit = document.getElementById('btnEditUser');
+  const editForm = document.getElementById('userEditForm');
+  const editAction = document.getElementById('editAction');
+  if (btnEdit && editForm) {
+    btnEdit.addEventListener('click', () => {
+      const row = getSelectedRow();
+      if (!row) { alert('Lütfen bir kullanıcı seçin.'); return; }
+      // Form action
+      const id = row.dataset.id;
+      editAction.value = `/admin/users/${id}/update`;
+      editForm.setAttribute('action', editAction.value);
+      // Doldur
+      document.getElementById('edit_username').value = row.dataset.username || '';
+      document.getElementById('edit_first_name').value = row.dataset.first_name || '';
+      document.getElementById('edit_last_name').value = row.dataset.last_name || '';
+      document.getElementById('edit_email').value = row.dataset.email || '';
+      document.getElementById('edit_is_admin').checked = row.dataset.is_admin === '1';
+      document.getElementById('edit_password').value = '';
+      // Göster
+      editForm.classList.remove('d-none');
+      editForm.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+  }
+
+  // Sil
+  const btnDelete = document.getElementById('btnDeleteUser');
+  const deleteForm = document.getElementById('deleteForm');
+  if (btnDelete && deleteForm) {
+    btnDelete.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      const row = getSelectedRow();
+      if (!row) { alert('Lütfen bir kullanıcı seçin.'); return; }
+      const username = row.dataset.username;
+      if (username && username.toLowerCase() === 'admin') {
+        alert('Admin hesabı silinemez.');
+        return;
+      }
+      if (!confirm(`'${username}' kullanıcısını silmek istediğinize emin misiniz?`)) return;
+      const id = row.dataset.id;
+      deleteForm.setAttribute('action', `/admin/users/${id}/delete`);
+      deleteForm.submit();
+    });
+  }
+</script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add generic Lookup table for product dictionaries
- implement admin router with user CRUD and lookup management
- create admin panel template and wire router in app

## Testing
- `pytest`
- `python -m py_compile models.py routers/admin.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a716dfd664832b84656da637a705ec