### PR TITLE
Fix admin template attribute access and admin-only navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -193,6 +193,7 @@ async def login_submit(
     # Başarılı giriş
     request.session["user_id"] = user.id
     request.session["user_name"] = user.full_name or user.username
+    request.session["user_role"] = getattr(user, "role", "")
     _ensure_csrf(request)  # token yenile
     response = RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER)
     if remember:

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -128,7 +128,7 @@
                   data-first_name="{{ u.first_name or '' }}"
                   data-last_name="{{ u.last_name or '' }}"
                   data-email="{{ u.email or '' }}"
-                  data-is_admin="{{ 1 if getattr(u,'is_admin',False) else 0 }}">
+                  data-is_admin="{{ 1 if u.is_admin else 0 }}">
                 <td><input type="radio" name="selUser" value="{{ u.id }}"></td>
                 <td>{{ u.id }}</td>
                 <td>{{ u.username }}</td>

--- a/templates/base.html
+++ b/templates/base.html
@@ -43,9 +43,11 @@
         <div class="side-group soft-card p-3">
           <div class="side-title">AYARLAR</div>
           <a class="side-link" href="/profile">Profil</a>
+          {% if request.session.get('user_role') == 'admin' %}
           <a class="side-link" href="/admin">Admin Paneli</a>
-          <a class="side-link" href="/integrations">Bağlantılar</a>
           <a class="side-link" href="/logs">Kayıtlar</a>
+          {% endif %}
+          <a class="side-link" href="/integrations">Bağlantılar</a>
         </div>
       </aside>
       <main class="col-12 col-lg-10">


### PR DESCRIPTION
## Summary
- Remove unsupported `getattr` usage in admin template for is_admin flag
- Store user role in session and show admin links only to admins

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a71f963714832bb1287ab3b6ba62b5