### PR TITLE
Implement catalog lookups and dynamic select helpers

### DIFF
--- a/models.py
+++ b/models.py
@@ -137,6 +137,34 @@ class Model(Base):
     __table_args__ = (UniqueConstraint("brand_id", "name", name="uq_brand_model"),)
 
 
+class UsageArea(Base):
+    __tablename__ = "usage_areas"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(150), unique=True, nullable=False, index=True)
+
+
+class Factory(Base):
+    __tablename__ = "factories"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(150), unique=True, nullable=False, index=True)
+
+
+class LicenseName(Base):
+    __tablename__ = "license_names"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(200), unique=True, nullable=False, index=True)
+
+
+class HardwareType(Base):
+    __tablename__ = "hardware_types"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(150), unique=True, nullable=False, index=True)
+
+
 class Printer(Base):
     __tablename__ = "printers"
 

--- a/routers/catalog.py
+++ b/routers/catalog.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from auth import get_db
-from models import Brand, Model
+from models import Brand, Model, UsageArea, Factory, LicenseName, HardwareType
 
 router = APIRouter(prefix="/catalog", tags=["Katalog"])
 
@@ -20,6 +20,30 @@ def list_models(brand_id: int, db: Session = Depends(get_db)):
         .all()
     )
     return [{"id": m.id, "name": m.name} for m in items]
+
+
+@router.get("/usage-areas")
+def list_usage_areas(db: Session = Depends(get_db)):
+    items = db.query(UsageArea).order_by(UsageArea.name.asc()).all()
+    return [{"id": u.id, "name": u.name} for u in items]
+
+
+@router.get("/factories")
+def list_factories(db: Session = Depends(get_db)):
+    items = db.query(Factory).order_by(Factory.name.asc()).all()
+    return [{"id": f.id, "name": f.name} for f in items]
+
+
+@router.get("/license-names")
+def list_license_names(db: Session = Depends(get_db)):
+    items = db.query(LicenseName).order_by(LicenseName.name.asc()).all()
+    return [{"id": l.id, "name": l.name} for l in items]
+
+
+@router.get("/hardware-types")
+def list_hardware_types(db: Session = Depends(get_db)):
+    items = db.query(HardwareType).order_by(HardwareType.name.asc()).all()
+    return [{"id": h.id, "name": h.name} for h in items]
 
 @router.post("/brands")
 def create_brand(name: str, db: Session = Depends(get_db)):
@@ -53,3 +77,59 @@ def create_model(brand_id: int, name: str, db: Session = Depends(get_db)):
     db.add(m)
     db.commit()
     return {"ok": True, "id": m.id}
+
+
+@router.post("/usage-areas")
+def create_usage_area(name: str, db: Session = Depends(get_db)):
+    name = (name or "").strip()
+    if not name:
+        raise HTTPException(400, "Boş olamaz")
+    exists = db.query(UsageArea).filter(UsageArea.name.ilike(name)).first()
+    if exists:
+        return {"ok": True, "id": exists.id}
+    u = UsageArea(name=name)
+    db.add(u)
+    db.commit()
+    return {"ok": True, "id": u.id}
+
+
+@router.post("/factories")
+def create_factory(name: str, db: Session = Depends(get_db)):
+    name = (name or "").strip()
+    if not name:
+        raise HTTPException(400, "Boş olamaz")
+    exists = db.query(Factory).filter(Factory.name.ilike(name)).first()
+    if exists:
+        return {"ok": True, "id": exists.id}
+    f = Factory(name=name)
+    db.add(f)
+    db.commit()
+    return {"ok": True, "id": f.id}
+
+
+@router.post("/license-names")
+def create_license_name(name: str, db: Session = Depends(get_db)):
+    name = (name or "").strip()
+    if not name:
+        raise HTTPException(400, "Boş olamaz")
+    exists = db.query(LicenseName).filter(LicenseName.name.ilike(name)).first()
+    if exists:
+        return {"ok": True, "id": exists.id}
+    l = LicenseName(name=name)
+    db.add(l)
+    db.commit()
+    return {"ok": True, "id": l.id}
+
+
+@router.post("/hardware-types")
+def create_hardware_type(name: str, db: Session = Depends(get_db)):
+    name = (name or "").strip()
+    if not name:
+        raise HTTPException(400, "Boş olamaz")
+    exists = db.query(HardwareType).filter(HardwareType.name.ilike(name)).first()
+    if exists:
+        return {"ok": True, "id": exists.id}
+    h = HardwareType(name=name)
+    db.add(h)
+    db.commit()
+    return {"ok": True, "id": h.id}

--- a/templates/_catalog_select.js
+++ b/templates/_catalog_select.js
@@ -1,0 +1,78 @@
+<script>
+/**
+ * basitSelectDoldur({
+ *   selectId: "fabrika_select",
+ *   url: "/catalog/factories",
+ *   hiddenName: "fabrika",            // Form POST’unda backend’in beklediği alan
+ *   placeholder: "Seçiniz…"
+ * })
+ */
+async function basitSelectDoldur({selectId, url, hiddenName, placeholder="Seçiniz…"}) {
+  const sel = document.getElementById(selectId);
+  sel.innerHTML = "";
+  const ph = document.createElement("option");
+  ph.value = ""; ph.textContent = placeholder;
+  sel.appendChild(ph);
+
+  const data = await fetch(url).then(r => r.json()).catch(()=>[]);
+  data.forEach(item => {
+    const opt = document.createElement("option");
+    opt.value = item.id;
+    opt.textContent = item.name;
+    sel.appendChild(opt);
+  });
+
+  // Seçilen label'ı gizli input olarak forma bas
+  const form = sel.closest("form");
+  let hid = form.querySelector(`input[name="${hiddenName}"]`);
+  if (!hid) {
+    hid = document.createElement("input");
+    hid.type = "hidden";
+    hid.name = hiddenName;
+    form.appendChild(hid);
+  }
+  sel.addEventListener("change", () => {
+    const txt = sel.options[sel.selectedIndex]?.textContent || "";
+    hid.value = txt;                   // backend yine string alanı alır (örn. fabrika)
+  });
+}
+
+/**
+ * bağımlıSelectDoldur({
+ *   ustSelectId: "marka_select",
+ *   altSelectId: "model_select",
+ *   altUrlBuilder: (brandId)=>`/catalog/models?brand_id=${brandId}`,
+ *   altHiddenName: "model",       // örn. envanter/model veya yazıcı_modeli karşılığı
+ * })
+ */
+function bağımlıSelectDoldur({ustSelectId, altSelectId, altUrlBuilder, altHiddenName, altPlaceholder="Seçiniz…"}) {
+  const upper = document.getElementById(ustSelectId);
+  const lower = document.getElementById(altSelectId);
+
+  upper.addEventListener("change", async () => {
+    lower.innerHTML = "";
+    const ph = document.createElement("option");
+    ph.value = ""; ph.textContent = upper.value ? altPlaceholder : "Önce üst seçimi yapın…";
+    lower.appendChild(ph);
+    lower.disabled = !upper.value;
+    if (!upper.value) return;
+
+    const data = await fetch(altUrlBuilder(upper.value)).then(r=>r.json()).catch(()=>[]);
+    data.forEach(item => {
+      const opt = document.createElement("option");
+      opt.value = item.id;
+      opt.textContent = item.name;
+      lower.appendChild(opt);
+    });
+
+    // alt seçimin metnini gizli inputa bas
+    const form = lower.closest("form");
+    let hid = form.querySelector(`input[name="${altHiddenName}"]`);
+    if (!hid) { hid = document.createElement("input"); hid.type="hidden"; hid.name=altHiddenName; form.appendChild(hid); }
+    lower.addEventListener("change", ()=> {
+      const txt = lower.options[lower.selectedIndex]?.textContent || "";
+      hid.value = txt;
+    });
+  });
+}
+</script>

--- a/templates/_printer_form_fields.html
+++ b/templates/_printer_form_fields.html
@@ -1,28 +1,21 @@
 <div class="row g-3">
-  <!-- ESKİ: yazici_markasi / yazici_modeli alanlarını SİLMİŞ görünecek şekilde kaldırdık -->
-
   <div class="col-md-6">
-    <label class="form-label">Marka</label>
-    <select id="brand" name="brand_id" class="form-select" required>
-      <option value="">Seçiniz…</option>
-    </select>
+    <label class="form-label">Yazıcı Markası</label>
+    <select id="marka_select" name="brand_id" class="form-select"></select>
+  </div>
+  <div class="col-md-6">
+    <label class="form-label">Yazıcı Modeli</label>
+    <select id="model_select" name="model_id" class="form-select" disabled></select>
   </div>
 
   <div class="col-md-6">
-    <label class="form-label">Model</label>
-    <select id="model" name="model_id" class="form-select" required disabled>
-      <option value="">Önce marka seçin…</option>
-    </select>
+    <label class="form-label">Kullanım Alanı</label>
+    <select id="kullanim_select" class="form-select"></select>
   </div>
 
   <div class="col-md-6">
     <label class="form-label">Envanter No</label>
     <input name="envanter_no" class="form-control" required>
-  </div>
-
-  <div class="col-md-6">
-    <label class="form-label">Kullanım Alanı</label>
-    <input name="kullanim_alani" class="form-control">
   </div>
 
   <div class="col-md-4">
@@ -55,50 +48,3 @@
     <input name="islem_yapan" class="form-control">
   </div>
 </div>
-
-<script>
-(async function initBrandModel() {
-  const brandSel = document.getElementById('brand');
-  const modelSel = document.getElementById('model');
-
-  // Markaları yükle
-  const brands = await fetch('/catalog/brands').then(r => r.json()).catch(() => []);
-  brands.forEach(b => {
-    const opt = document.createElement('option');
-    opt.value = b.id; opt.textContent = b.name;
-    if (brandSel.dataset.selected == String(b.id)) { opt.selected = true; }
-    brandSel.appendChild(opt);
-  });
-
-  async function loadModels() {
-    modelSel.innerHTML = '';
-    modelSel.disabled = true;
-    const bid = brandSel.value;
-    if (!bid) {
-      const o = document.createElement('option'); o.textContent = 'Önce marka seçin…';
-      modelSel.appendChild(o); return;
-    }
-    const models = await fetch(`/catalog/models?brand_id=${encodeURIComponent(bid)}`).then(r => r.json()).catch(() => []);
-    if (models.length === 0) {
-      const o = document.createElement('option'); o.textContent = 'Model bulunamadı';
-      modelSel.appendChild(o);
-    } else {
-      const o = document.createElement('option'); o.textContent = 'Seçiniz…'; o.value = '';
-      modelSel.appendChild(o);
-      models.forEach(m => {
-        const opt = document.createElement('option');
-        opt.value = m.id; opt.textContent = m.name;
-        if (modelSel.dataset.selected == String(m.id)) { opt.selected = true; }
-        modelSel.appendChild(opt);
-      });
-      modelSel.disabled = false;
-    }
-  }
-
-  brandSel.addEventListener('change', loadModels);
-
-  if (brandSel.dataset.selected) {
-    await loadModels();
-  }
-})();
-</script>

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -55,6 +55,7 @@
   <div class="modal fade" id="addInvModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
       <form method="post" action="/inventory/add" class="modal-content" style="height: 550px;width: 800px;">
+        {% include "_catalog_select.js" %}
         <div class="modal-header">
           <h5 class="modal-title">Envanter Ekle</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -67,15 +68,15 @@
             </div>
             <div class="col-md-3">
               <label class="form-label">Fabrika</label>
-              <input name="fabrika" class="form-control">
+              <select id="fabrika_select" class="form-select"></select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Departman</label>
-              <input name="departman" class="form-control">
+              <select id="departman_select" class="form-select"></select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Donanım Tipi</label>
-              <input name="donanim_tipi" class="form-control">
+              <select id="donanim_tipi_select" class="form-select"></select>
             </div>
 
             <div class="col-md-3">
@@ -84,11 +85,11 @@
             </div>
             <div class="col-md-3">
               <label class="form-label">Marka</label>
-              <input name="marka" class="form-control">
+              <select id="inv_marka_select" class="form-select"></select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Model</label>
-              <input name="model" class="form-control">
+              <select id="inv_model_select" class="form-select" disabled></select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Seri No</label>
@@ -125,5 +126,18 @@
     </div>
   </div>
 </div>
+
+<script>
+  basitSelectDoldur({selectId:"fabrika_select", url:"/catalog/factories", hiddenName:"fabrika"});
+  basitSelectDoldur({selectId:"departman_select", url:"/catalog/usage-areas", hiddenName:"departman"});
+  basitSelectDoldur({selectId:"donanim_tipi_select", url:"/catalog/hardware-types", hiddenName:"donanim_tipi"});
+  basitSelectDoldur({selectId:"inv_marka_select", url:"/catalog/brands", hiddenName:"marka"});
+  bağımlıSelectDoldur({
+    ustSelectId:"inv_marka_select",
+    altSelectId:"inv_model_select",
+    altUrlBuilder:(bid)=>`/catalog/models?brand_id=${encodeURIComponent(bid)}`,
+    altHiddenName:"model"
+  });
+</script>
 {% endblock %}
 

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -49,6 +49,7 @@
   <div class="modal fade" id="addLicModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
       <form method="post" action="/licenses/add" class="modal-content">
+        {% include "_catalog_select.js" %}
         <div class="modal-header">
           <h5 class="modal-title">Lisans Ekle</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -57,7 +58,7 @@
           <div class="row g-2">
             <div class="col-md-6">
               <label class="form-label">Lisans Adı</label>
-              <input name="lisans_adi" class="form-control" required>
+              <select id="lisans_adi_select" class="form-select"></select>
             </div>
             <div class="col-md-6">
               <label class="form-label">Lisans Anahtarı</label>
@@ -98,4 +99,8 @@
     </div>
   </div>
 </div>
+
+<script>
+  basitSelectDoldur({selectId:"lisans_adi_select", url:"/catalog/license-names", hiddenName:"lisans_adi"});
+</script>
 {% endblock %}

--- a/templates/printer_create.html
+++ b/templates/printer_create.html
@@ -4,6 +4,7 @@
 <div class="container-fluid p-3">
   <h5 class="mb-3">Yazıcı Ekle</h5>
   <form method="post" action="/printers">
+    {% include "_catalog_select.js" %}
     {% include "_printer_form_fields.html" %}
     <div class="mt-3">
       <button class="btn btn-primary btn-sm">Kaydet</button>
@@ -11,4 +12,15 @@
     </div>
   </form>
 </div>
+
+<script>
+  basitSelectDoldur({selectId:"marka_select", url:"/catalog/brands", hiddenName:"yazici_markasi"});
+  bağımlıSelectDoldur({
+    ustSelectId:"marka_select",
+    altSelectId:"model_select",
+    altUrlBuilder:(bid)=>`/catalog/models?brand_id=${encodeURIComponent(bid)}`,
+    altHiddenName:"yazici_modeli"
+  });
+  basitSelectDoldur({selectId:"kullanim_select", url:"/catalog/usage-areas", hiddenName:"kullanim_alani"});
+</script>
 {% endblock %}

--- a/templates/printer_edit.html
+++ b/templates/printer_edit.html
@@ -4,6 +4,7 @@
 <div class="container-fluid p-3">
   <h5 class="mb-3">Yazıcı Güncelle</h5>
   <form method="post" action="/printers/{{ item.id }}/update">
+    {% include "_catalog_select.js" %}
     {% include "_printer_form_fields.html" %}
     <div class="mt-3">
       <button class="btn btn-primary btn-sm">Kaydet</button>
@@ -12,15 +13,38 @@
   </form>
 </div>
 <script>
-  document.querySelector('[name="envanter_no"]').value = "{{ item.envanter_no }}";
-  document.querySelector('[name="kullanim_alani"]').value = "{{ item.kullanim_alani or '' }}";
-  document.querySelector('[name="ip_adresi"]').value = "{{ item.ip_adresi or '' }}";
-  document.querySelector('[name="mac"]').value = "{{ item.mac or '' }}";
-  document.querySelector('[name="hostname"]').value = "{{ item.hostname or '' }}";
-  document.querySelector('[name="ifs_no"]').value = "{{ item.ifs_no or '' }}";
-  document.querySelector('[name="tarih"]').value = "{{ item.tarih or '' }}";
-  document.querySelector('[name="islem_yapan"]').value = "{{ item.islem_yapan or '' }}";
-  document.getElementById('brand').dataset.selected = "{{ item.brand_id or '' }}";
-  document.getElementById('model').dataset.selected = "{{ item.model_id or '' }}";
+  (async () => {
+    document.querySelector('[name="envanter_no"]').value = "{{ item.envanter_no }}";
+    document.querySelector('[name="ip_adresi"]').value = "{{ item.ip_adresi or '' }}";
+    document.querySelector('[name="mac"]').value = "{{ item.mac or '' }}";
+    document.querySelector('[name="hostname"]').value = "{{ item.hostname or '' }}";
+    document.querySelector('[name="ifs_no"]').value = "{{ item.ifs_no or '' }}";
+    document.querySelector('[name="tarih"]').value = "{{ item.tarih or '' }}";
+    document.querySelector('[name="islem_yapan"]').value = "{{ item.islem_yapan or '' }}";
+
+    await basitSelectDoldur({selectId:"marka_select", url:"/catalog/brands", hiddenName:"yazici_markasi"});
+    bağımlıSelectDoldur({
+      ustSelectId:"marka_select",
+      altSelectId:"model_select",
+      altUrlBuilder:(bid)=>`/catalog/models?brand_id=${encodeURIComponent(bid)}`,
+      altHiddenName:"yazici_modeli"
+    });
+    await basitSelectDoldur({selectId:"kullanim_select", url:"/catalog/usage-areas", hiddenName:"kullanim_alani"});
+
+    document.getElementById('marka_select').value = "{{ item.brand_id or '' }}";
+    document.getElementById('marka_select').dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 200));
+    document.getElementById('model_select').value = "{{ item.model_id or '' }}";
+
+    const kull = "{{ item.kullanim_alani or '' }}";
+    if (kull) {
+      const ks = document.getElementById('kullanim_select');
+      for (const opt of ks.options) {
+        if (opt.textContent === kull) { ks.value = opt.value; break; }
+      }
+      const hid = ks.closest('form').querySelector('input[name="kullanim_alani"]');
+      if (hid) hid.value = kull;
+    }
+  })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add catalog tables (brands, models, usage areas, factories, license names, hardware types)
- expose catalog lookup API endpoints with create helpers
- add reusable JS to populate select inputs and update printer, license, and inventory forms

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a72d63ccd0832bbfab711a650d8cf3