### PR TITLE
Remove printer brand/model categories from admin panel

### DIFF
--- a/routers/admin.py
+++ b/routers/admin.py
@@ -52,8 +52,6 @@ def admin_panel(request: Request, q: Optional[str] = None, db: Session = Depends
         )
 
     CATS = [
-        "yazici_markasi",
-        "yazici_modeli",
         "kullanim_alani",
         "lisans_adi",
         "fabrika",


### PR DESCRIPTION
## Summary
- remove `yazici_markasi` and `yazici_modeli` lookup categories from admin panel product section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a72f819710832bac43595780c6a7ff