### PR TITLE
Auto-fill inventory date and clean add modal

### DIFF
--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -109,10 +109,7 @@
               <label class="form-label">Bağlı Makina No</label>
               <input name="bagli_makina_no" class="form-control">
             </div>
-            <div class="col-md-3">
-              <label class="form-label">Tarih</label>
-              <input name="tarih" type="date" class="form-control" value="{{ today }}">
-            </div>
+            <input name="tarih" type="hidden" value="{{ today }}">
             <div class="col-md-3">
               <label class="form-label">Notlar</label>
               <textarea name="notlar" class="form-control" rows="1"></textarea>


### PR DESCRIPTION
## Summary
- Hide manual date entry in inventory add modal and auto-submit today's date

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8098f4c3c832bb1287d50ec8c6c51