### PR TITLE
Fix indentation in app imports to resolve startup error

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,23 +20,23 @@ from auth import (
     verify_password,
     hash_password,
 )
-    from routers import (
-        home,
-        inventory as inventory_router,
-        license as license_router,
-        accessories,
-        printers as printers_router,
-        catalog as catalog_router,
-        requests as reqs,
-        stock,
-        trash,
-        profile,
-        admin as admin_router,
-        integrations,
-        logs,
-        lookup,
-        refdata,
-    )
+from routers import (
+    home,
+    inventory as inventory_router,
+    license as license_router,
+    accessories,
+    printers as printers_router,
+    catalog as catalog_router,
+    requests as reqs,
+    stock,
+    trash,
+    profile,
+    admin as admin_router,
+    integrations,
+    logs,
+    lookup,
+    refdata,
+)
 from security import current_user, require_roles
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- fix indentation of `routers` import in app.py to allow application startup

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a814643420832bb2b8aca14b9c7787