### PR TITLE
Add lookup APIs and searchable select components

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+from sqlalchemy.orm import Session
+from models import SessionLocal
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -4,7 +4,16 @@ from starlette.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from datetime import datetime
 
-from models import Inventory, InventoryLog, User
+from models import (
+    Inventory,
+    InventoryLog,
+    User,
+    Factory,
+    UsageArea,
+    HardwareType,
+    Brand,
+    Model,
+)
 from auth import get_db
 from .inventory_schemas import InventoryCreate, InventoryUpdate
 
@@ -54,12 +63,12 @@ def create_inventory(payload: InventoryCreate, db: Session = Depends(get_db)):
 @router.post("/add", response_class=HTMLResponse)
 def inventory_add(
     no: str = Form(...),
-    fabrika: str | None = Form(None),
-    departman: str | None = Form(None),
-    donanim_tipi: str | None = Form(None),
+    fabrika_id: int | None = Form(None),
+    departman_id: int | None = Form(None),
+    donanim_tipi_id: int | None = Form(None),
     bilgisayar_adi: str | None = Form(None),
-    marka: str | None = Form(None),
-    model: str | None = Form(None),
+    marka_id: int | None = Form(None),
+    model_id: int | None = Form(None),
     seri_no: str | None = Form(None),
     sorumlu_personel: str | None = Form(None),
     bagli_makina_no: str | None = Form(None),
@@ -67,6 +76,13 @@ def inventory_add(
     notlar: str | None = Form(None),
     db: Session = Depends(get_db),
 ):
+    fabrika = db.query(Factory).get(fabrika_id).name if fabrika_id else None
+    departman = db.query(UsageArea).get(departman_id).name if departman_id else None
+    donanim_tipi = (
+        db.query(HardwareType).get(donanim_tipi_id).name if donanim_tipi_id else None
+    )
+    marka = db.query(Brand).get(marka_id).name if marka_id else None
+    model = db.query(Model).get(model_id).name if model_id else None
     payload = InventoryCreate(
         no=no,
         fabrika=fabrika,

--- a/routers/license.py
+++ b/routers/license.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from fastapi.templating import Jinja2Templates
 from starlette.responses import HTMLResponse, RedirectResponse
 from datetime import datetime
-from models import License, LicenseLog, User, Inventory
+from models import License, LicenseLog, User, Inventory, LicenseName
 from .license_schemas import LicenseCreate, LicenseUpdate
 from auth import get_db
 
@@ -37,7 +37,7 @@ def license_list(request: Request, db: Session = Depends(get_db)):
 @router.post("/add", response_class=HTMLResponse)
 def license_add(
     request: Request,
-    lisans_adi: str = Form(...),
+    lisans_adi_id: int = Form(...),
     lisans_anahtari: str = Form(...),
     sorumlu_personel: str | None = Form(None),
     bagli_envanter_no: str | None = Form(None),
@@ -45,6 +45,8 @@ def license_add(
     mail_adresi: str | None = Form(None),
     db: Session = Depends(get_db),
 ):
+    name_obj = db.query(LicenseName).get(lisans_adi_id)
+    lisans_adi = name_obj.name if name_obj else ""
     payload = LicenseCreate(
         lisans_adi=lisans_adi,
         lisans_anahtari=lisans_anahtari,

--- a/routers/lookup.py
+++ b/routers/lookup.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
-from auth import get_db
+from database import get_db
 from models import Factory, UsageArea, HardwareType, Brand, Model, LicenseName
 
 router = APIRouter(prefix="/api/lookup", tags=["lookup"])
@@ -37,4 +37,4 @@ def lookup_list(
         query = query.filter(func.lower(ModelCls.name).contains(q.lower()))
 
     rows = query.order_by(ModelCls.name).limit(limit).all()
-    return [{"id": r.id, "ad": getattr(r, "name", None)} for r in rows]
+    return [{"id": r.id, "ad": r.name} for r in rows]

--- a/routers/refdata.py
+++ b/routers/refdata.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
-from auth import get_db
+from database import get_db
 from models import Factory, UsageArea, HardwareType, Brand, Model, LicenseName
 
 router = APIRouter(prefix="/api/ref", tags=["refdata"])
@@ -38,7 +38,7 @@ def create_ref(entity: str, body: RefCreate, db: Session = Depends(get_db)):
 
     obj = q.first()
     if obj:
-        return {"id": obj.id, "ad": getattr(obj, "name", None), "created": False}
+        return {"id": obj.id, "ad": obj.name, "created": False}
 
     if entity == "model":
         obj = Model(name=body.ad.strip(), brand_id=body.marka_id)
@@ -48,4 +48,4 @@ def create_ref(entity: str, body: RefCreate, db: Session = Depends(get_db)):
     db.add(obj)
     db.commit()
     db.refresh(obj)
-    return {"id": obj.id, "ad": getattr(obj, "name", None), "created": True}
+    return {"id": obj.id, "ad": obj.name, "created": True}

--- a/templates/_printer_form_fields.html
+++ b/templates/_printer_form_fields.html
@@ -1,32 +1,17 @@
   <div class="row g-3">
     <div class="col-md-6">
       <label class="form-label">Yazıcı Markası</label>
-      <div class="input-group">
-        <input id="txtYaziciMarka" class="form-control" placeholder="Marka">
-        <input type="hidden" id="hidYaziciMarkaId" name="brand_id">
-        <button type="button" class="btn btn-outline-secondary"
-          onclick="openPicker({entity:'marka', label:'Marka seç', targetTextId:'txtYaziciMarka', targetHiddenId:'hidYaziciMarkaId'})">Seç</button>
-      </div>
+      <select id="selYaziciMarka" name="marka_id" class="form-select"></select>
     </div>
     <div class="col-md-6">
       <label class="form-label">Yazıcı Modeli</label>
-      <div class="input-group">
-        <input id="txtYaziciModel" class="form-control" placeholder="Model">
-        <input type="hidden" id="hidYaziciModelId" name="model_id">
-        <button type="button" class="btn btn-outline-secondary"
-          onclick="openPicker({entity:'model', label:'Model seç', targetTextId:'txtYaziciModel', targetHiddenId:'hidYaziciModelId', markaGetter:()=>document.getElementById('hidYaziciMarkaId').value})">Seç</button>
-      </div>
+      <select id="selYaziciModel" name="model_id" class="form-select" disabled></select>
       <small class="text-muted">Not: Model listesi seçilen Markaya göre filtrelenir.</small>
     </div>
 
     <div class="col-md-6">
       <label class="form-label">Kullanım Alanı</label>
-      <div class="input-group">
-        <input id="txtYaziciKullanim" name="kullanim_alani" class="form-control" placeholder="Kullanım Alanı">
-        <input type="hidden" id="hidYaziciKullanimId">
-        <button type="button" class="btn btn-outline-secondary"
-          onclick="openPicker({entity:'kullanim-alani', label:'Kullanım Alanı seç', targetTextId:'txtYaziciKullanim', targetHiddenId:'hidYaziciKullanimId'})">Seç</button>
-      </div>
+      <select id="selYaziciKullanim" name="kullanim_alani_id" class="form-select"></select>
     </div>
 
     <div class="col-md-6">

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="{{ url_for('static', path='css/custom.css') }}" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" rel="stylesheet">
 </head>
 <body class="bg-app">
   <nav class="navbar navbar-light bg-transparent p-3 pb-0">
@@ -81,6 +82,8 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
     <script src="{{ url_for('static', path='js/picker.js') }}"></script>
+    <script defer src="/static/js/selects.js"></script>
   </body>
   </html>

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -5,7 +5,7 @@
     <h5 class="mb-3">Envanter Takip</h5>
     <div class="d-flex justify-content-between mb-3">
       <div class="d-flex gap-2">
-        <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#addInvModal">Ekle</button>
+        <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#envanterEkleModal">Ekle</button>
         <button class="btn btn-secondary btn-sm">Düzenle</button>
         <button class="btn btn-danger btn-sm">Sil</button>
       </div>
@@ -52,10 +52,9 @@
     </table>
   </div>
 
-  <div class="modal fade" id="addInvModal" tabindex="-1" aria-hidden="true">
+  <div class="modal fade" id="envanterEkleModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
       <form method="post" action="/inventory/add" class="modal-content" style="height: 550px;width: 800px;">
-        {% include "_catalog_select.js" %}
         <div class="modal-header">
           <h5 class="modal-title">Envanter Ekle</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -68,15 +67,15 @@
             </div>
             <div class="col-md-3">
               <label class="form-label">Fabrika</label>
-              <select id="fabrika_select" class="form-select"></select>
+              <select id="selFabrika" name="fabrika_id" class="form-select"></select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Departman</label>
-              <select id="departman_select" class="form-select"></select>
+              <select id="selDepartman" name="departman_id" class="form-select"></select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Donanım Tipi</label>
-              <select id="donanim_tipi_select" class="form-select"></select>
+              <select id="selDonanim" name="donanim_tipi_id" class="form-select"></select>
             </div>
 
             <div class="col-md-3">
@@ -85,11 +84,11 @@
             </div>
             <div class="col-md-3">
               <label class="form-label">Marka</label>
-              <select id="inv_marka_select" class="form-select"></select>
+              <select id="selMarka" name="marka_id" class="form-select"></select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Model</label>
-              <select id="inv_model_select" class="form-select" disabled></select>
+              <select id="selModel" name="model_id" class="form-select" disabled></select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Seri No</label>
@@ -125,16 +124,19 @@
 </div>
 
 <script>
-  basitSelectDoldur({selectId:"fabrika_select", url:"/catalog/factories", hiddenName:"fabrika"});
-  basitSelectDoldur({selectId:"departman_select", url:"/catalog/usage-areas", hiddenName:"departman"});
-  basitSelectDoldur({selectId:"donanim_tipi_select", url:"/catalog/hardware-types", hiddenName:"donanim_tipi"});
-  basitSelectDoldur({selectId:"inv_marka_select", url:"/catalog/brands", hiddenName:"marka"});
-  bağımlıSelectDoldur({
-    ustSelectId:"inv_marka_select",
-    altSelectId:"inv_model_select",
-    altUrlBuilder:(bid)=>`/catalog/models?brand_id=${encodeURIComponent(bid)}`,
-    altHiddenName:"model"
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('envanterEkleModal');
+  if (!modalEl) return;
+
+  modalEl.addEventListener('shown.bs.modal', async () => {
+    await _selects.fillChoices({ endpoint: "/api/lookup/fabrika",        selectId: "selFabrika",   placeholder: "Fabrika seçin…" });
+    await _selects.fillChoices({ endpoint: "/api/lookup/kullanim-alani", selectId: "selDepartman", placeholder: "Departman (Kullanım alanından) seçin…" });
+    await _selects.fillChoices({ endpoint: "/api/lookup/donanim-tipi",   selectId: "selDonanim",   placeholder: "Donanım tipi seçin…" });
+    await _selects.fillChoices({ endpoint: "/api/lookup/marka",          selectId: "selMarka",     placeholder: "Marka seçin…" });
+
+    await _selects.bindMarkaModel("selMarka", "selModel");
+    _selects.enableRemoteSearch("selModel", "/api/lookup/model", ()=>({ marka_id: document.getElementById("selMarka").value || "" }));
   });
+});
 </script>
 {% endblock %}
-

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -57,12 +57,7 @@
             <div class="row g-2">
               <div class="col-md-6">
                 <label class="form-label">Lisans Adı</label>
-                <div class="input-group">
-                  <input id="txtLisansAdi" name="lisans_adi" class="form-control" placeholder="Lisans Adı">
-                  <input type="hidden" id="hidLisansAdiId">
-                  <button type="button" class="btn btn-outline-secondary"
-                    onclick="openPicker({entity:'lisans-adi', label:'Lisans Adı seç', targetTextId:'txtLisansAdi', targetHiddenId:'hidLisansAdiId'})">Seç</button>
-                </div>
+                <select id="selLisansAdi" name="lisans_adi_id" class="form-select"></select>
               </div>
               <div class="col-md-6">
               <label class="form-label">Lisans Anahtarı</label>
@@ -103,5 +98,12 @@
     </div>
   </div>
 </div>
+
+<script>
+document.addEventListener("DOMContentLoaded", async () => {
+  await _selects.fillChoices({ endpoint: "/api/lookup/lisans-adi", selectId: "selLisansAdi", placeholder: "Lisans adı seçin…" });
+  _selects.enableRemoteSearch("selLisansAdi", "/api/lookup/lisans-adi");
+});
+</script>
 
   {% endblock %}

--- a/templates/printer_create.html
+++ b/templates/printer_create.html
@@ -11,4 +11,12 @@
       </div>
     </form>
   </div>
+  <script>
+document.addEventListener("DOMContentLoaded", async () => {
+  await _selects.fillChoices({ endpoint: "/api/lookup/marka",          selectId: "selYaziciMarka",   placeholder: "Yazıcı markası seçin…" });
+  await _selects.fillChoices({ endpoint: "/api/lookup/kullanim-alani", selectId: "selYaziciKullanim",placeholder: "Kullanım alanı seçin…" });
+  await _selects.bindMarkaModel("selYaziciMarka", "selYaziciModel");
+  _selects.enableRemoteSearch("selYaziciModel", "/api/lookup/model", ()=>({ marka_id: document.getElementById("selYaziciMarka").value || "" }));
+});
+  </script>
   {% endblock %}

--- a/templates/printer_edit.html
+++ b/templates/printer_edit.html
@@ -12,17 +12,21 @@
     </form>
   </div>
   <script>
-    document.querySelector('[name="envanter_no"]').value = "{{ item.envanter_no }}";
-    document.querySelector('[name="ip_adresi"]').value = "{{ item.ip_adresi or '' }}";
-    document.querySelector('[name="mac"]').value = "{{ item.mac or '' }}";
-    document.querySelector('[name="hostname"]').value = "{{ item.hostname or '' }}";
-    document.querySelector('[name="ifs_no"]').value = "{{ item.ifs_no or '' }}";
-    document.querySelector('[name="tarih"]').value = "{{ item.tarih or '' }}";
-    document.querySelector('[name="islem_yapan"]').value = "{{ item.islem_yapan or '' }}";
-    document.getElementById('hidYaziciMarkaId').value = "{{ item.brand_id or '' }}";
-    document.getElementById('txtYaziciMarka').value = "{{ item.brand.name if item.brand else '' }}";
-    document.getElementById('hidYaziciModelId').value = "{{ item.model_id or '' }}";
-    document.getElementById('txtYaziciModel').value = "{{ item.model.name if item.model else '' }}";
-    document.getElementById('txtYaziciKullanim').value = "{{ item.kullanim_alani or '' }}";
+document.addEventListener("DOMContentLoaded", async () => {
+  document.querySelector('[name="envanter_no"]').value = "{{ item.envanter_no }}";
+  document.querySelector('[name="ip_adresi"]').value = "{{ item.ip_adresi or '' }}";
+  document.querySelector('[name="mac"]').value = "{{ item.mac or '' }}";
+  document.querySelector('[name="hostname"]').value = "{{ item.hostname or '' }}";
+  document.querySelector('[name="ifs_no"]').value = "{{ item.ifs_no or '' }}";
+  document.querySelector('[name="tarih"]').value = "{{ item.tarih or '' }}";
+  document.querySelector('[name="islem_yapan"]').value = "{{ item.islem_yapan or '' }}";
+
+  await _selects.fillChoices({ endpoint: "/api/lookup/marka",          selectId: "selYaziciMarka",   placeholder: "Yazıcı markası seçin…" });
+  await _selects.fillChoices({ endpoint: "/api/lookup/kullanim-alani", selectId: "selYaziciKullanim", placeholder: "Kullanım alanı seçin…" });
+  document.getElementById('selYaziciMarka').value = "{{ item.brand_id or '' }}";
+  await _selects.bindMarkaModel("selYaziciMarka", "selYaziciModel");
+  document.getElementById('selYaziciModel').value = "{{ item.model_id or '' }}";
+  _selects.enableRemoteSearch("selYaziciModel", "/api/lookup/model", ()=>({ marka_id: document.getElementById('selYaziciMarka').value || '' }));
+});
   </script>
   {% endblock %}


### PR DESCRIPTION
## Summary
- add `database` module and hook lookup/refdata APIs
- integrate Choices.js with new `selects.js` helper
- convert inventory, printer, and license forms to use searchable selects

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8160eb020832b9f96c8fef3f06896