### PR TITLE
Integrate Choices.js helpers for select inputs

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -71,7 +71,7 @@ def inventory_add(
     model_id: str | None = Form(None),
     seri_no: str | None = Form(None),
     sorumlu_personel: str | None = Form(None),
-    bagli_makina_no: str | None = Form(None),
+    bagli_envanter_no: str | None = Form(None),
     tarih: str | None = Form(None),
     notlar: str | None = Form(None),
     db: Session = Depends(get_db),
@@ -99,7 +99,7 @@ def inventory_add(
         model=model,
         seri_no=seri_no,
         sorumlu_personel=sorumlu_personel,
-        bagli_makina_no=bagli_makina_no,
+        bagli_makina_no=bagli_envanter_no,
         tarih=tarih or datetime.now().strftime("%Y-%m-%d"),
         notlar=notlar,
     )

--- a/routers/printers.py
+++ b/routers/printers.py
@@ -4,7 +4,7 @@ from fastapi.templating import Jinja2Templates
 from starlette.responses import HTMLResponse, RedirectResponse
 from datetime import datetime
 
-from models import Printer, PrinterLog, Brand, Model, UsageArea
+from models import Printer, PrinterLog, Brand, Model, UsageArea, User
 from auth import get_db
 
 templates = Jinja2Templates(directory="templates")
@@ -14,8 +14,9 @@ router = APIRouter(prefix="/printers", tags=["Yazıcılar"])
 @router.get("", response_class=HTMLResponse)
 def printer_list(request: Request, db: Session = Depends(get_db)):
     rows = db.query(Printer).order_by(Printer.id.desc()).all()
+    users = db.query(User).order_by(User.full_name).all()
     return templates.TemplateResponse(
-        "printer_list.html", {"request": request, "rows": rows}
+        "printer_list.html", {"request": request, "rows": rows, "users": users}
     )
 
 

--- a/static/js/choices_helpers.js
+++ b/static/js/choices_helpers.js
@@ -1,0 +1,119 @@
+// static/js/choices_helpers.js
+
+// -------- Helpers ----------
+async function getJSON(url) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+
+function ensureChoices(selectEl, placeholder = "Seçiniz…") {
+  if (!window.Choices) {
+    console.warn("Choices.js yüklü değil!");
+    return null;
+  }
+  if (!selectEl) return null;
+  if (selectEl._choicesInstance) return selectEl._choicesInstance;
+
+  const inst = new Choices(selectEl, {
+    searchEnabled: true,
+    itemSelectText: '',
+    placeholder: true,
+    placeholderValue: placeholder,
+    shouldSort: true,
+    allowHTML: false
+  });
+  selectEl._choicesInstance = inst;
+  return inst;
+}
+
+function setChoicesSafe(selectEl, items, replaceAll = true, placeholderOpt) {
+  const inst = ensureChoices(selectEl, placeholderOpt?.placeholderValue || "Seçiniz…");
+  if (!inst) return;
+
+  try { inst.clearStore?.(); } catch (_) {}
+  try { inst.clearChoices?.(); } catch (_) {}
+
+  inst.setChoices(Array.isArray(items) ? items : [], 'value', 'label', replaceAll);
+}
+
+async function fillChoices({ endpoint, selectId, params = {}, placeholder = "Seçiniz…" }) {
+  const sel = document.getElementById(selectId);
+  if (!sel) return;
+  const usp = new URLSearchParams(params);
+  const data = await getJSON(endpoint + (usp.toString() ? "?" + usp : ""));
+
+  const choices = data.map(x => ({
+    value: x.id,
+    label: x.name ?? x.ad
+  }));
+  setChoicesSafe(sel, choices, true, { placeholderValue: placeholder });
+}
+
+function bindBrandToModel(brandSelectId, modelSelectId) {
+  const brandSel = document.getElementById(brandSelectId);
+  const modelSel = document.getElementById(modelSelectId);
+  if (!brandSel || !modelSel) return;
+
+  setChoicesSafe(modelSel,
+    [{ value: "", label: "Önce marka seçiniz…", disabled: true }],
+    true, { placeholderValue: "Önce marka seçiniz…" });
+
+  brandSel.addEventListener("change", async () => {
+    const brandId = brandSel.value;
+    if (!brandId) {
+      setChoicesSafe(modelSel,
+        [{ value: "", label: "Önce marka seçiniz…", disabled: true }],
+        true, { placeholderValue: "Önce marka seçiniz…" });
+      return;
+    }
+    await fillChoices({
+      endpoint: "/api/lookup/model",
+      selectId: modelSelectId,
+      params: { marka_id: brandId },
+      placeholder: "Model seçiniz…"
+    });
+  });
+}
+
+function initPersonelChoices(selectId, placeholder = "Personel seçiniz…") {
+  const sel = document.getElementById(selectId);
+  if (!sel) return;
+  const curr = Array.from(sel.options).map(o => ({ value: o.value, label: o.textContent }));
+  setChoicesSafe(sel, curr, true, { placeholderValue: placeholder });
+}
+
+async function initBagliEnvanterChoices(selectId, tableSelector = 'table tbody a[href^="/inventory/"]', endpoint = '/api/lookup/inventory-no') {
+  const sel = document.getElementById(selectId);
+  if (!sel) return;
+  const placeholder = { placeholderValue: "Envanter no seçiniz…" };
+
+  async function fromEndpoint() {
+    const rows = await getJSON(endpoint);
+    const choices = rows.map(x => ({
+      value: x.no ?? x.name ?? x.id,
+      label: x.no ?? x.name ?? String(x.id)
+    }));
+    setChoicesSafe(sel, choices, true, placeholder);
+  }
+
+  function fromTable() {
+    const links = document.querySelectorAll(tableSelector);
+    const uniq = new Set();
+    links.forEach(a => { const t = (a.textContent || '').trim(); if (t) uniq.add(t); });
+    const choices = Array.from(uniq).sort().map(no => ({ value: no, label: no }));
+    setChoicesSafe(sel, choices.length ? choices : [{ value: "", label: "Kayıt yok", disabled: true }], true, placeholder);
+  }
+
+  try { await fromEndpoint(); } catch { fromTable(); }
+}
+
+window.choicesHelper = {
+  fillChoices,
+  bindBrandToModel,
+  initPersonelChoices,
+  initBagliEnvanterChoices
+};
+
+
+// Not: Bu dosya Choices’in bazı sürümlerinde clearStore olmayan duruma da dayanıklıdır.

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -106,7 +106,7 @@
             </div>
             <div class="col-md-3">
               <label class="form-label">Bağlı Envanter No</label>
-              <select id="selBagliEnvanter" name="bagli_makina_no" class="form-select"></select>
+              <select id="selBagliEnvanter" name="bagli_envanter_no" class="form-select"></select>
             </div>
             <input name="tarih" type="hidden" value="{{ today }}">
             <div class="col-md-3">
@@ -122,173 +122,35 @@
     </div>
   </div>
 </div>
+<link href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
 
+<script src="/static/js/choices_helpers.js"></script>
 <script>
-(function () {
-  // Her select için Choices instance tut
-  const choiceInstances = {};
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('envanterEkleModal');
+  if (!modalEl) return;
 
-  async function getJSON(url) {
-    const r = await fetch(url);
-    if (!r.ok) throw new Error(await r.text());
-    return r.json();
-  }
-
-  // Choices ile select doldur (option.value = id, label = name)
-  async function fillSelect({ endpoint, selectId, params = {}, placeholder = "Seçiniz…" }) {
-    const sel = document.getElementById(selectId);
-    if (!sel) return;
-
-    // Choices instance yoksa oluştur
-    if (!choiceInstances[selectId]) {
-      choiceInstances[selectId] = new Choices(sel, {
-        searchEnabled: true,
-        itemSelectText: '',
-        shouldSort: true,
-        placeholder: true,
-        placeholderValue: placeholder,
-        allowHTML: false
-      });
-    }
-
-    const usp = new URLSearchParams(params);
-    const data = await getJSON(endpoint + (usp.toString() ? "?" + usp : ""));
-    const choices = data.map(item => ({
-      value: item.id,
-      label: item.name ?? item.ad
-    }));
-
-    // Mevcut seçenekleri temizleyip yenilerini yükle
-    const inst = choiceInstances[selectId];
-    inst.clearStore();
-    inst.setChoices(choices, 'value', 'label', true);
-  }
-
-  // Marka -> Model bağımlılığı
-  function bindBrandToModel(brandSelectId, modelSelectId) {
-    const brandSel = document.getElementById(brandSelectId);
-    const modelSel = document.getElementById(modelSelectId);
-    if (!brandSel || !modelSel) return;
-
-    // Model için Choices oluştur ve placeholder bırak
-    if (!choiceInstances[modelSelectId]) {
-      choiceInstances[modelSelectId] = new Choices(modelSel, {
-        searchEnabled: true,
-        itemSelectText: '',
-        placeholder: true,
-        placeholderValue: "Önce marka seçiniz…",
-        allowHTML: false
-      });
-    } else {
-      const inst = choiceInstances[modelSelectId];
-      inst.clearStore();
-      inst.setChoices([{ value: "", label: "Önce marka seçiniz…", disabled: true }], 'value', 'label', true);
-    }
-
-    brandSel.addEventListener("change", async () => {
-      const brandId = brandSel.value;
-      const inst = choiceInstances[modelSelectId];
-      inst.clearStore();
-
-      if (!brandId) {
-        inst.setChoices([{ value: "", label: "Önce marka seçiniz…", disabled: true }], 'value', 'label', true);
-        return;
-      }
-
-      await fillSelect({
-        endpoint: "/api/lookup/model",
-        selectId: modelSelectId,
-        params: { marka_id: brandId },
-        placeholder: "Model seçiniz…"
-      });
-    });
-  }
-
-  function ensureChoices(selectEl, placeholder) {
-    const id = selectEl.id;
-    let inst = choiceInstances[id];
-    if (inst) return inst;
-    inst = new Choices(selectEl, {
-      searchEnabled: true,
-      itemSelectText: '',
-      placeholder: true,
-      placeholderValue: placeholder || 'Seçiniz…',
-      shouldSort: true,
-      allowHTML: false
-    });
-    choiceInstances[id] = inst;
-    return inst;
-  }
-
-  function initPersonelChoices() {
-    const sel = document.getElementById('selPersonel');
-    if (!sel) return;
-    ensureChoices(sel, 'Personel seçiniz…');
-  }
-
-  async function initBagliEnvanterChoices() {
-    const sel = document.getElementById('selBagliEnvanter');
-    if (!sel) return;
-
-    const inst = ensureChoices(sel, 'Envanter no seçiniz…');
-
-    async function fillFromEndpoint() {
-      const data = await getJSON('/api/lookup/inventory-no');
-      const choices = data.map(x => ({
-        value: x.no ?? x.name ?? x.id,
-        label: x.no ?? x.name ?? String(x.id)
-      }));
-      inst.clearStore();
-      inst.setChoices(choices, 'value', 'label', true);
-    }
-
-    function fillFromTableFallback() {
-      const links = document.querySelectorAll('table tbody a[href^="/inventory/"]');
-      const set = new Set();
-      links.forEach(a => {
-        const t = (a.textContent || '').trim();
-        if (t) set.add(t);
-      });
-      const arr = Array.from(set).sort();
-      const choices = arr.map(no => ({ value: no, label: no }));
-      inst.clearStore();
-      if (choices.length) {
-        inst.setChoices(choices, 'value', 'label', true);
-      } else {
-        inst.setChoices([{ value: '', label: 'Kayıt yok', disabled: true }], 'value', 'label', true);
-      }
-    }
-
+  modalEl.addEventListener('shown.bs.modal', async () => {
     try {
-      await fillFromEndpoint();
-    } catch {
-      fillFromTableFallback();
+      // Sözlükler
+      await choicesHelper.fillChoices({ endpoint: "/api/lookup/fabrika",        selectId: "selFabrika",   placeholder: "Fabrika seçiniz…" });
+      await choicesHelper.fillChoices({ endpoint: "/api/lookup/kullanim-alani", selectId: "selDepartman", placeholder: "Departman seçiniz…" });
+      await choicesHelper.fillChoices({ endpoint: "/api/lookup/donanim-tipi",   selectId: "selDonanim",   placeholder: "Donanım tipi seçiniz…" });
+      await choicesHelper.fillChoices({ endpoint: "/api/lookup/marka",          selectId: "selMarka",     placeholder: "Marka seçiniz…" });
+
+      // Marka → Model
+      choicesHelper.bindBrandToModel("selMarka", "selModel");
+
+      // Personel (mevcut <option>’lardan)
+      choicesHelper.initPersonelChoices("selPersonel", "Personel seçiniz…");
+
+      // Bağlı Envanter No (endpoint varsa ondan; yoksa tablo fallback)
+      await choicesHelper.initBagliEnvanterChoices("selBagliEnvanter", 'table tbody a[href^="/inventory/"]');
+    } catch (e) {
+      console.error(e);
     }
-  }
-
-  document.addEventListener('DOMContentLoaded', () => {
-    const modalEl = document.getElementById('envanterEkleModal');
-    if (!modalEl) return;
-
-    modalEl.addEventListener('shown.bs.modal', async () => {
-      try {
-        // Aramalı comboları doldur
-        await fillSelect({ endpoint: "/api/lookup/fabrika",        selectId: "selFabrika",   placeholder: "Fabrika seçiniz…" });
-        await fillSelect({ endpoint: "/api/lookup/kullanim-alani", selectId: "selDepartman", placeholder: "Departman seçiniz…" });
-        await fillSelect({ endpoint: "/api/lookup/donanim-tipi",   selectId: "selDonanim",   placeholder: "Donanım tipi seçiniz…" });
-        await fillSelect({ endpoint: "/api/lookup/marka",          selectId: "selMarka",     placeholder: "Marka seçiniz…" });
-
-        // Marka değişince model listesi markaya göre dolsun
-        bindBrandToModel("selMarka", "selModel");
-
-        // Yeni: Personel ve Bağlı Envanter No
-        initPersonelChoices();
-        await initBagliEnvanterChoices();
-      } catch (e) {
-        console.error(e);
-      }
-    });
   });
-})();
+});
 </script>
 {% endblock %}

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -5,7 +5,7 @@
   <h5 class="mb-3">Lisanslar</h5>
   <div class="d-flex justify-content-between mb-3">
     <div class="d-flex gap-2">
-      <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#addLicModal">Ekle</button>
+      <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#lisansEkleModal">Ekle</button>
       <button class="btn btn-warning btn-sm">Düzenle</button>
       <button class="btn btn-danger btn-sm">Sil</button>
     </div>
@@ -46,7 +46,7 @@
     </table>
   </div>
 
-  <div class="modal fade" id="addLicModal" tabindex="-1" aria-hidden="true">
+  <div class="modal fade" id="lisansEkleModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
         <form method="post" action="/licenses/add" class="modal-content">
           <div class="modal-header">
@@ -65,7 +65,7 @@
             </div>
             <div class="col-md-6">
               <label class="form-label">Sorumlu Personel</label>
-              <select name="sorumlu_personel" class="form-select">
+              <select id="selLisansPersonel" name="sorumlu_personel" class="form-select">
                 <option value="">Seçiniz</option>
                 {% for u in users %}
                 <option value="{{ u.full_name }}">{{ u.full_name }}</option>
@@ -74,12 +74,7 @@
             </div>
             <div class="col-md-6">
               <label class="form-label">Bağlı Envanter No</label>
-              <select name="bagli_envanter_no" class="form-select">
-                <option value="">Seçiniz</option>
-                {% for no in inventory_nos %}
-                <option value="{{ no }}">{{ no }}</option>
-                {% endfor %}
-              </select>
+              <select id="selLisansBagliEnvanter" name="bagli_envanter_no" class="form-select"></select>
             </div>
             <div class="col-md-6">
               <label class="form-label">IFS No</label>
@@ -98,12 +93,24 @@
     </div>
   </div>
 </div>
+<link href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
 
+<script src="/static/js/choices_helpers.js"></script>
 <script>
-document.addEventListener("DOMContentLoaded", async () => {
-  await _selects.fillChoices({ endpoint: "/api/lookup/lisans-adi", selectId: "selLisansAdi", placeholder: "Lisans adı seçiniz…" });
-  _selects.enableRemoteSearch("selLisansAdi", "/api/lookup/lisans-adi");
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('lisansEkleModal');
+  if (!modalEl) return;
+
+  modalEl.addEventListener('shown.bs.modal', async () => {
+    try {
+      await choicesHelper.fillChoices({ endpoint: "/api/lookup/lisans-adi", selectId: "selLisansAdi", placeholder: "Lisans adı seçiniz…" });
+      choicesHelper.initPersonelChoices("selLisansPersonel", "Personel seçiniz…");
+      await choicesHelper.initBagliEnvanterChoices("selLisansBagliEnvanter", 'table tbody a[href^="/inventory/"]');
+    } catch (e) {
+      console.error(e);
+    }
+  });
 });
 </script>
-
-  {% endblock %}
+{% endblock %}

--- a/templates/printer_list.html
+++ b/templates/printer_list.html
@@ -5,7 +5,7 @@
   <h5 class="mb-3">Yazıcılar</h5>
   <div class="d-flex justify-content-between mb-3">
     <div class="d-flex gap-2">
-      <a href="/printers/create" class="btn btn-success btn-sm">Ekle</a>
+      <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#yaziciEkleModal">Ekle</button>
       <button class="btn btn-secondary btn-sm">Düzenle</button>
       <button class="btn btn-danger btn-sm">Sil</button>
     </div>
@@ -55,5 +55,103 @@
       </tbody>
     </table>
   </div>
+
+  <div class="modal fade" id="yaziciEkleModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <form method="post" action="/printers" class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Yazıcı Ekle</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label class="form-label">Marka</label>
+              <select id="selYaziciMarka" name="marka_id" class="form-select"></select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Model</label>
+              <select id="selYaziciModel" name="model_id" class="form-select"></select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Kullanım Alanı</label>
+              <select id="selYaziciKullanim" name="kullanim_alani_id" class="form-select"></select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Envanter No</label>
+              <input name="envanter_no" class="form-control" required>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">IP Adresi</label>
+              <input name="ip_adresi" class="form-control">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">MAC</label>
+              <input name="mac" class="form-control">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Hostname</label>
+              <input name="hostname" class="form-control">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">IFS No</label>
+              <input name="ifs_no" class="form-control">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Tarih</label>
+              <input name="tarih" class="form-control" placeholder="YYYY-MM-DD">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">İşlem Yapan</label>
+              <input name="islem_yapan" class="form-control">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Sorumlu Personel</label>
+              <select id="selYaziciPersonel" name="sorumlu_personel" class="form-select">
+                <option value="">Seçiniz</option>
+                {% for u in users %}
+                <option value="{{ u.full_name }}">{{ u.full_name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Bağlı Envanter No</label>
+              <select id="selYaziciBagliEnvanter" name="bagli_envanter_no" class="form-select"></select>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-success">Kaydet</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
+
+<link href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+
+<script src="/static/js/choices_helpers.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('yaziciEkleModal');
+  if (!modalEl) return;
+
+  modalEl.addEventListener('shown.bs.modal', async () => {
+    try {
+      await choicesHelper.fillChoices({ endpoint: "/api/lookup/marka",          selectId: "selYaziciMarka",   placeholder: "Marka seçiniz…" });
+      await choicesHelper.fillChoices({ endpoint: "/api/lookup/kullanim-alani", selectId: "selYaziciKullanim", placeholder: "Kullanım alanı seçiniz…" });
+
+      // Marka → Model
+      choicesHelper.bindBrandToModel("selYaziciMarka", "selYaziciModel");
+
+      // Personel ve Bağlı Envanter
+      choicesHelper.initPersonelChoices("selYaziciPersonel", "Personel seçiniz…");
+      await choicesHelper.initBagliEnvanterChoices("selYaziciBagliEnvanter", 'table tbody a[href^="/inventory/"]');
+    } catch (e) {
+      console.error(e);
+    }
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add shared `choices_helpers.js` utilities for initializing Choices.js dropdowns
- enhance inventory, license, and printer pages with searchable select elements
- load responsible user lists and inventory numbers dynamically; support brand→model binding

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a87445ee08832ba05cd7a17f66e0a2