### PR TITLE
Add inventory-license association and management UI

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -112,9 +112,9 @@ def inventory_add(
     return RedirectResponse("/inventory", status_code=303)
 
 
-@router.get("/{no}", response_class=HTMLResponse)
-def inventory_detail(no: str, request: Request, db: Session = Depends(get_db)):
-    inv = db.query(Inventory).filter(Inventory.no == no).first()
+@router.get("/{id}", name="inventory_detail", response_class=HTMLResponse)
+def inventory_detail(id: int, request: Request, db: Session = Depends(get_db)):
+    inv = db.get(Inventory, id)
     if not inv:
         raise HTTPException(404, "Kayıt bulunamadı")
 
@@ -126,7 +126,7 @@ def inventory_detail(no: str, request: Request, db: Session = Depends(get_db)):
     )
 
     return templates.TemplateResponse(
-        "inventory_detail.html", {"request": request, "item": inv, "logs": logs}
+        "inventory_detail.html", {"request": request, "inv": inv, "logs": logs}
     )
 
 

--- a/templates/inventory_detail.html
+++ b/templates/inventory_detail.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
-{% block title %}Envanter Detay - {{ item.no }}{% endblock %}
+{% block title %}Envanter Detay - {{ inv.no }}{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
   <div class="d-flex align-items-center justify-content-between mb-2">
-    <h5>Envanter: {{ item.no }}</h5>
+    <h5>Envanter: {{ inv.no }}</h5>
     <a href="/inventory" class="btn btn-sm btn-outline-secondary">← Listeye dön</a>
   </div>
 
@@ -13,19 +13,19 @@
         <div class="card-header">Temel Bilgiler</div>
         <div class="card-body">
           <div class="row">
-            <div class="col-5 text-muted">Fabrika</div><div class="col-7">{{ item.fabrika }}</div>
-            <div class="col-5 text-muted">Departman</div><div class="col-7">{{ item.departman }}</div>
-            <div class="col-5 text-muted">Donanım Tipi</div><div class="col-7">{{ item.donanim_tipi }}</div>
-            <div class="col-5 text-muted">Bilgisayar Adı</div><div class="col-7">{{ item.bilgisayar_adi }}</div>
-            <div class="col-5 text-muted">Marka</div><div class="col-7">{{ item.marka }}</div>
-            <div class="col-5 text-muted">Model</div><div class="col-7">{{ item.model }}</div>
-            <div class="col-5 text-muted">Seri No</div><div class="col-7">{{ item.seri_no }}</div>
-            <div class="col-5 text-muted">Sorumlu Personel</div><div class="col-7">{{ item.sorumlu_personel }}</div>
-            <div class="col-5 text-muted">Bağlı Makina No</div><div class="col-7">{{ item.bagli_makina_no }}</div>
-            <div class="col-5 text-muted">IFS No</div><div class="col-7">{{ item.ifs_no }}</div>
-            <div class="col-5 text-muted">Tarih</div><div class="col-7">{{ item.tarih }}</div>
-            <div class="col-5 text-muted">İşlem Yapan</div><div class="col-7">{{ item.islem_yapan }}</div>
-            <div class="col-5 text-muted">Not</div><div class="col-7"><pre class="mb-0">{{ item.notlar }}</pre></div>
+            <div class="col-5 text-muted">Fabrika</div><div class="col-7">{{ inv.fabrika }}</div>
+            <div class="col-5 text-muted">Departman</div><div class="col-7">{{ inv.departman }}</div>
+            <div class="col-5 text-muted">Donanım Tipi</div><div class="col-7">{{ inv.donanim_tipi }}</div>
+            <div class="col-5 text-muted">Bilgisayar Adı</div><div class="col-7">{{ inv.bilgisayar_adi }}</div>
+            <div class="col-5 text-muted">Marka</div><div class="col-7">{{ inv.marka }}</div>
+            <div class="col-5 text-muted">Model</div><div class="col-7">{{ inv.model }}</div>
+            <div class="col-5 text-muted">Seri No</div><div class="col-7">{{ inv.seri_no }}</div>
+            <div class="col-5 text-muted">Sorumlu Personel</div><div class="col-7">{{ inv.sorumlu_personel }}</div>
+            <div class="col-5 text-muted">Bağlı Makina No</div><div class="col-7">{{ inv.bagli_makina_no }}</div>
+            <div class="col-5 text-muted">IFS No</div><div class="col-7">{{ inv.ifs_no }}</div>
+            <div class="col-5 text-muted">Tarih</div><div class="col-7">{{ inv.tarih }}</div>
+            <div class="col-5 text-muted">İşlem Yapan</div><div class="col-7">{{ inv.islem_yapan }}</div>
+            <div class="col-5 text-muted">Not</div><div class="col-7"><pre class="mb-0">{{ inv.notlar }}</pre></div>
           </div>
         </div>
       </div>
@@ -65,6 +65,40 @@
       </div>
     </div>
   </div>
+
+  <hr class="my-3">
+  <h5 class="mb-2">Lisanslar</h5>
+
+  {% if inv.licenses and inv.licenses|length > 0 %}
+  <div class="table-responsive">
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th>Lisans Adı</th>
+          <th>Vendor</th>
+          <th>Son Kullanma</th>
+          <th>Anahtar</th>
+          <th>İşlem</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for lic in inv.licenses %}
+        <tr data-href="{{ url_for('license_detail', id=lic.id) }}">
+          <td>{{ lic.adi }}</td>
+          <td>{{ lic.vendor or '-' }}</td>
+          <td>{{ lic.son_kullanma|date('Y-MM-dd') if lic.son_kullanma else '-' }}</td>
+          <td class="text-monospace">{{ lic.anahtar or '-' }}</td>
+          <td>
+            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('license_edit', id=lic.id) }}" onclick="stopRowClick(event)">Düzenle</a>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+    <div class="text-muted">Bu envantere bağlı lisans bulunmuyor.</div>
+  {% endif %}
 </div>
 {% endblock %}
 

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -35,7 +35,7 @@
       </thead>
       <tbody>
         {% for r in rows %}
-        <tr data-href="/inventory/{{ r.no }}">
+        <tr data-href="{{ url_for('inventory_detail', id=r.id) }}">
           <td>
             <input type="checkbox" name="select_row" value="{{ r.id }}" onclick="stopRowClick(event)">
           </td>
@@ -46,7 +46,7 @@
           <td>{{ r.bilgisayar_adi or "" }}</td>
           <td>{{ r.sorumlu_personel or "" }}</td>
           <td class="text-nowrap">
-            <a class="btn btn-sm btn-outline-primary" href="/inventory/{{ r.no }}" onclick="stopRowClick(event)">Düzenle</a>
+            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('inventory_detail', id=r.id) }}" onclick="stopRowClick(event)">Düzenle</a>
             <button class="btn btn-sm btn-outline-danger" onclick="stopRowClick(event); deleteInventory('{{ r.id }}')">Sil</button>
           </td>
         </tr>

--- a/templates/license_detail.html
+++ b/templates/license_detail.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %}Lisans Detay - {{ item.lisans_adi }}{% endblock %}
+{% block title %}Lisans Detayı - {{ license.adi }}{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
   <div class="d-flex align-items-center justify-content-between mb-2">
-    <h5>Lisans: {{ item.lisans_adi }}</h5>
-    <a href="/licenses" class="btn btn-sm btn-outline-secondary">← Listeye dön</a>
+    <h5>Lisans: {{ license.adi }}</h5>
+    <a href="{{ url_for('license_list') }}" class="btn btn-sm btn-outline-secondary">← Listeye dön</a>
   </div>
 
   <div class="row g-3">
@@ -13,49 +13,17 @@
         <div class="card-header">Temel Bilgiler</div>
         <div class="card-body">
           <div class="row">
-            <div class="col-5 text-muted">ID</div><div class="col-7">{{ item.id }}</div>
-            <div class="col-5 text-muted">Lisans Adı</div><div class="col-7">{{ item.lisans_adi }}</div>
-            <div class="col-5 text-muted">Lisans Anahtarı</div><div class="col-7"><code>{{ item.lisans_anahtari }}</code></div>
-            <div class="col-5 text-muted">Sorumlu Personel</div><div class="col-7">{{ item.sorumlu_personel }}</div>
-            <div class="col-5 text-muted">Bağlı Envanter No</div><div class="col-7">{{ item.bagli_envanter_no }}</div>
-            <div class="col-5 text-muted">IFS No</div><div class="col-7">{{ item.ifs_no }}</div>
-            <div class="col-5 text-muted">Tarih</div><div class="col-7">{{ item.tarih }}</div>
-            <div class="col-5 text-muted">İşlem Yapan</div><div class="col-7">{{ item.islem_yapan }}</div>
-            <div class="col-5 text-muted">Mail Adresi</div><div class="col-7">{{ item.mail_adresi }}</div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-lg-6">
-      <div class="card">
-        <div class="card-header">Değişiklik Geçmişi</div>
-        <div class="card-body p-0">
-          <div class="table-responsive">
-            <table class="table table-sm table-striped mb-0">
-              <thead>
-                <tr>
-                  <th>Alan</th>
-                  <th>Önce</th>
-                  <th>Sonra</th>
-                  <th>Değiştiren</th>
-                  <th>Tarih</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for log in logs %}
-                <tr>
-                  <td><code>{{ log.field }}</code></td>
-                  <td class="text-muted">{{ log.old_value }}</td>
-                  <td>{{ log.new_value }}</td>
-                  <td>{{ log.changed_by }}</td>
-                  <td>{{ log.changed_at }}</td>
-                </tr>
-                {% else %}
-                <tr><td colspan="5" class="text-muted">Henüz değişiklik yok</td></tr>
-                {% endfor %}
-              </tbody>
-            </table>
+            <div class="col-5 text-muted">Vendor</div><div class="col-7">{{ license.vendor or '-' }}</div>
+            <div class="col-5 text-muted">Son Kullanma</div><div class="col-7">{{ license.son_kullanma|date('Y-MM-dd') if license.son_kullanma else '-' }}</div>
+            <div class="col-5 text-muted">Anahtar</div><div class="col-7"><code>{{ license.anahtar or '-' }}</code></div>
+            <div class="col-5 text-muted">Bağlı Envanter</div>
+            <div class="col-7">
+              {% if license.inventory %}
+                <a href="{{ url_for('inventory_detail', id=license.inventory.id) }}">{{ license.inventory.no }}</a>
+              {% else %}
+                Yok
+              {% endif %}
+            </div>
           </div>
         </div>
       </div>

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -1,0 +1,49 @@
+<form method="post" action="{{ form_action }}">
+  <div class="mb-2">
+    <label class="form-label">Lisans Adı</label>
+    <input name="adi" class="form-control" value="{{ license.adi if license else '' }}" required>
+  </div>
+
+  <div class="mb-2">
+    <label class="form-label">Vendor</label>
+    <input name="vendor" class="form-control" value="{{ license.vendor if license else '' }}">
+  </div>
+
+  <div class="mb-2">
+    <label class="form-label">Lisans Anahtarı</label>
+    <input name="anahtar" class="form-control" value="{{ license.anahtar if license else '' }}">
+  </div>
+
+  <div class="mb-2">
+    <label class="form-label">Son Kullanma</label>
+    <input type="date" name="son_kullanma" class="form-control"
+           value="{{ license.son_kullanma|date('Y-m-d') if license and license.son_kullanma }}">
+  </div>
+
+  <div class="mb-3">
+    <label class="form-label">Bağlı Olduğu Envanter No</label>
+    <select id="selBagliEnvanter" name="inventory_id" class="form-select">
+      <option value="">(Seçimsiz)</option>
+      {% for inv in envanterler %}
+        <option value="{{ inv.id }}"
+          {% if license and license.inventory_id == inv.id %}selected{% endif %}>
+          {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
+        </option>
+      {% endfor %}
+    </select>
+    <div class="form-text">Arama yaparak envanteri seçebilirsiniz.</div>
+  </div>
+
+  <div class="d-flex gap-2">
+    <button class="btn btn-primary" type="submit">Kaydet</button>
+    <a class="btn btn-secondary" href="{{ url_for('license_list') }}">İptal</a>
+  </div>
+</form>
+
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    if (window.Choices) {
+      new Choices("#selBagliEnvanter", { searchEnabled: true, itemSelectText: '' });
+    }
+  });
+</script>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -1,49 +1,39 @@
 {% extends "base.html" %}
-{% block title %}Lisans Takip{% endblock %}
+{% block title %}Lisanslar{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
-  <h5 class="mb-3">Lisanslar</h5>
   <div class="d-flex justify-content-between mb-3">
-    <div class="d-flex gap-2">
-      <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#lisansEkleModal">Ekle</button>
-      <button class="btn btn-warning btn-sm">Düzenle</button>
-      <button class="btn btn-danger btn-sm">Sil</button>
-    </div>
-    <div class="d-flex gap-2 align-items-center">
-      <select class="form-select form-select-sm w-auto">
-        <option value="25">25</option>
-        <option value="50">50</option>
-        <option value="100">100</option>
-      </select>
-      <button class="btn btn-primary btn-sm">🔍</button>
-      <input type="text" class="form-control form-control-sm" placeholder="Ara...">
-    </div>
+    <h5>Lisanslar</h5>
+    <a class="btn btn-primary btn-sm" href="{{ url_for('license_new') }}">Yeni Lisans</a>
   </div>
   <div class="table-responsive">
     <table class="table table-hover">
       <thead>
         <tr>
-          <th><input type="checkbox" onclick="stopRowClick(event)"></th>
           <th>Lisans Adı</th>
-          <th>Bağlı Envanter No</th>
-          <th>Lisans Anahtarı</th>
-          <th>Sorumlu</th>
-          <th>İşlemler</th>
+          <th>Vendor</th>
+          <th>Son Kullanma</th>
+          <th>Anahtar</th>
+          <th>Envanter</th>
+          <th>İşlem</th>
         </tr>
       </thead>
       <tbody>
-        {% for r in rows %}
-        <tr data-href="/licenses/{{ r.id }}">
+        {% for lic in rows %}
+        <tr data-href="{{ url_for('license_detail', id=lic.id) }}">
+          <td>{{ lic.adi }}</td>
+          <td>{{ lic.vendor or '-' }}</td>
+          <td>{{ lic.son_kullanma|date('Y-MM-dd') if lic.son_kullanma else '-' }}</td>
+          <td class="text-monospace">{{ lic.anahtar or '-' }}</td>
           <td>
-            <input type="checkbox" name="select_row" value="{{ r.id }}" onclick="stopRowClick(event)">
+            {% if lic.inventory %}
+              <a href="{{ url_for('inventory_detail', id=lic.inventory.id) }}" onclick="stopRowClick(event)">{{ lic.inventory.no }}</a>
+            {% else %}
+              -
+            {% endif %}
           </td>
-          <td>{{ r.lisans_adi }}</td>
-          <td>{{ r.bagli_envanter_no or "-" }}</td>
-          <td>{{ r.lisans_anahtari }}</td>
-          <td>{{ r.sorumlu_personel or "" }}</td>
-          <td class="text-nowrap">
-            <a class="btn btn-sm btn-outline-primary" href="/licenses/{{ r.id }}" onclick="stopRowClick(event)">Düzenle</a>
-            <button class="btn btn-sm btn-outline-secondary" onclick="stopRowClick(event); renewLicense('{{ r.id }}')">Yenile</button>
+          <td>
+            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('license_edit', id=lic.id) }}" onclick="stopRowClick(event)">Düzenle</a>
           </td>
         </tr>
         {% else %}
@@ -52,78 +42,5 @@
       </tbody>
     </table>
   </div>
-
-  <div class="modal fade" id="lisansEkleModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-        <form method="post" action="/licenses/add" class="modal-content">
-          <div class="modal-header">
-          <h5 class="modal-title">Lisans Ekle</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body">
-            <div class="row g-2">
-              <div class="col-md-6">
-                <label class="form-label">Lisans Adı</label>
-                <select id="selLisansAdi" name="lisans_adi_id" class="form-select"></select>
-              </div>
-              <div class="col-md-6">
-              <label class="form-label">Lisans Anahtarı</label>
-              <input name="lisans_anahtari" class="form-control" required>
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">Sorumlu Personel</label>
-              <select id="selLisansPersonel" name="sorumlu_personel" class="form-select">
-                <option value="">Seçiniz</option>
-                {% for u in users %}
-                <option value="{{ u.full_name }}">{{ u.full_name }}</option>
-                {% endfor %}
-              </select>
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">Bağlı Envanter No</label>
-              <select id="selLisansBagliEnvanter" name="bagli_envanter_no" class="form-select"></select>
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">IFS No</label>
-              <input name="ifs_no" class="form-control">
-            </div>
-            <div class="col-md-6">
-              <label class="form-label">Mail Adresi</label>
-              <input name="mail_adresi" class="form-control">
-            </div>
-          </div>
-        </div>
-        <div class="modal-footer">
-          <button type="submit" class="btn btn-success">Kaydet</button>
-        </div>
-      </form>
-    </div>
-  </div>
 </div>
-<link href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
-
-<script src="/static/js/choices_helpers.js"></script>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const modalEl = document.getElementById('lisansEkleModal');
-  if (!modalEl) return;
-
-  modalEl.addEventListener('shown.bs.modal', async () => {
-    try {
-      await choicesHelper.fillChoices({ endpoint: "/api/lookup/lisans-adi", selectId: "selLisansAdi", placeholder: "Lisans adı seçiniz…" });
-      choicesHelper.initPersonelChoices("selLisansPersonel", "Personel seçiniz…");
-      await choicesHelper.initBagliEnvanterChoices("selLisansBagliEnvanter", 'table tbody a[href^="/inventory/"]');
-    } catch (e) {
-      console.error(e);
-    }
-  });
-});
-</script>
-
-<script>
-function renewLicense(id){
-  // … lisans yenileme işlemi
-}
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Link `License` records to `Inventory` with a nullable foreign key
- Add license CRUD routes and form allowing inventory selection
- Show related licenses on inventory detail page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8782c67e0832ba44ac8cd8551576a