### PR TITLE
Add inventory linkage for licenses and expose selection in forms

### DIFF
--- a/routers/license.py
+++ b/routers/license.py
@@ -37,9 +37,9 @@ def license_create(
     request: Request,
     db: Session = Depends(get_db),
     adi: str = Form(...),
-    vendor: str = Form(None),
-    anahtar: str = Form(None),
-    son_kullanma: str = Form(None),
+    vendor: str | None = Form(None),
+    anahtar: str | None = Form(None),
+    son_kullanma: str | None = Form(None),
     inventory_id: int | None = Form(None),
 ):
     lic = License(
@@ -75,9 +75,9 @@ def license_update(
     request: Request,
     db: Session = Depends(get_db),
     adi: str = Form(...),
-    vendor: str = Form(None),
-    anahtar: str = Form(None),
-    son_kullanma: str = Form(None),
+    vendor: str | None = Form(None),
+    anahtar: str | None = Form(None),
+    son_kullanma: str | None = Form(None),
     inventory_id: int | None = Form(None),
 ):
     lic = db.get(License, id)

--- a/templates/inventory_detail.html
+++ b/templates/inventory_detail.html
@@ -78,7 +78,7 @@
           <th>Vendor</th>
           <th>Son Kullanma</th>
           <th>Anahtar</th>
-          <th>İşlem</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -88,8 +88,8 @@
           <td>{{ lic.vendor or '-' }}</td>
           <td>{{ lic.son_kullanma|date('Y-MM-dd') if lic.son_kullanma else '-' }}</td>
           <td class="text-monospace">{{ lic.anahtar or '-' }}</td>
-          <td>
-            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('license_edit', id=lic.id) }}" onclick="stopRowClick(event)">Düzenle</a>
+          <td class="text-nowrap">
+            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('license_edit', id=lic.id) }}" onclick="event.stopPropagation()">Düzenle</a>
           </td>
         </tr>
         {% endfor %}

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -31,7 +31,7 @@
         </option>
       {% endfor %}
     </select>
-    <div class="form-text">Arama yaparak envanteri seçebilirsiniz.</div>
+    <div class="form-text">Envanterlerden seçin; lisans bu envanter altında listelenecek.</div>
   </div>
 
   <div class="d-flex gap-2">


### PR DESCRIPTION
## Summary
- Allow license creation and update to accept optional linked inventory
- Show inventory selection in license form with helper text
- Display associated licenses on inventory detail with edit links

## Testing
- `python -m py_compile routers/license.py models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87cb26a40832b877f1dad80db373b