### PR TITLE
Fix optional inventory relationship annotation

### DIFF
--- a/models.py
+++ b/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from datetime import datetime, date
+from typing import Optional
 from sqlalchemy import (
     create_engine,
     Integer,
@@ -109,7 +110,9 @@ class License(Base):
         nullable=True,
         index=True,
     )
-    inventory: Mapped["Inventory" | None] = relationship("Inventory", back_populates="licenses")
+    inventory: Mapped[Optional["Inventory"]] = relationship(
+        "Inventory", back_populates="licenses"
+    )
 
     logs: Mapped[list["LicenseLog"]] = relationship(
         "LicenseLog", back_populates="license_", cascade="all, delete-orphan"


### PR DESCRIPTION
## Summary
- fix License.inventory typing by using Optional and aligning with SQLAlchemy Mapped generics
- add Optional typing import

## Testing
- `uvicorn app:app --host 0.0.0.0 --port 8000`


------
https://chatgpt.com/codex/tasks/task_e_68a87de8801c832b98b2aea507c0dde4