### PR TITLE
Improve license templates and add script block

### DIFF
--- a/routers/license.py
+++ b/routers/license.py
@@ -12,9 +12,9 @@ templates = Jinja2Templates(directory="templates")
 
 @router.get("/licenses", name="license_list", response_class=HTMLResponse)
 def license_list(request: Request, db: Session = Depends(get_db)):
-    rows = db.query(License).order_by(License.adi.asc()).all()
+    lisanslar = db.query(License).order_by(License.adi.asc()).all()
     return templates.TemplateResponse(
-        "license_list.html", {"request": request, "rows": rows}
+        "license_list.html", {"request": request, "lisanslar": lisanslar}
     )
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="{{ url_for('static', path='css/custom.css') }}" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" rel="stylesheet">
+  <title>{% block title %}{% endblock %}</title>
 </head>
 <body class="bg-app">
   <nav class="navbar navbar-light bg-transparent p-3 pb-0">
@@ -85,6 +86,7 @@
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
     <script src="{{ url_for('static', path='js/picker.js') }}"></script>
     <script defer src="/static/js/selects.js"></script>
+    {% block scripts %}
     <script>
 document.addEventListener("DOMContentLoaded", () => {
   // Event delegation: works for dynamically added rows
@@ -137,5 +139,6 @@ function stopRowClick(e) { e.stopPropagation(); }
       tr[data-href]:hover > td { transition: background-color .12s ease-in-out; }
     }
     </style>
+    {% endblock %}
   </body>
   </html>

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -1,49 +1,72 @@
-<form method="post" action="{{ form_action }}">
-  <div class="mb-2">
-    <label class="form-label">Lisans Adı</label>
-    <input name="adi" class="form-control" value="{{ license.adi if license else '' }}" required>
+{% extends "base.html" %}
+{% block title %}Lisans {{ 'Düzenle' if license else 'Ekle' }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid p-3 content">
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <h4 class="mb-0">Lisans {{ 'Düzenle' if license else 'Ekle' }}</h4>
+    <a class="btn btn-light" href="{{ url_for('license_list') }}">← Listeye Dön</a>
   </div>
 
-  <div class="mb-2">
-    <label class="form-label">Vendor</label>
-    <input name="vendor" class="form-control" value="{{ license.vendor if license else '' }}">
-  </div>
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <form method="post" action="{{ form_action }}">
+        <div class="row g-3">
+          <div class="col-md-6">
+            <label class="form-label">Lisans Adı</label>
+            <input name="adi" class="form-control" value="{{ license.adi if license else '' }}" required>
+          </div>
 
-  <div class="mb-2">
-    <label class="form-label">Lisans Anahtarı</label>
-    <input name="anahtar" class="form-control" value="{{ license.anahtar if license else '' }}">
-  </div>
+          <div class="col-md-6">
+            <label class="form-label">Vendor</label>
+            <input name="vendor" class="form-control" value="{{ license.vendor if license else '' }}">
+          </div>
 
-  <div class="mb-2">
-    <label class="form-label">Son Kullanma</label>
-    <input type="date" name="son_kullanma" class="form-control"
-           value="{{ license.son_kullanma|date('Y-m-d') if license and license.son_kullanma }}">
-  </div>
+          <div class="col-md-6">
+            <label class="form-label">Lisans Anahtarı</label>
+            <input name="anahtar" class="form-control" value="{{ license.anahtar if license else '' }}">
+          </div>
 
-  <div class="mb-3">
-    <label class="form-label">Bağlı Olduğu Envanter No</label>
-    <select id="selBagliEnvanter" name="inventory_id" class="form-select">
-      <option value="">(Seçimsiz)</option>
-      {% for inv in envanterler %}
-        <option value="{{ inv.id }}"
-          {% if license and license.inventory_id == inv.id %}selected{% endif %}>
-          {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
-        </option>
-      {% endfor %}
-    </select>
-    <div class="form-text">Envanterlerden seçin; lisans bu envanter altında listelenecek.</div>
-  </div>
+          <div class="col-md-6">
+            <label class="form-label">Son Kullanma</label>
+            <input type="date" name="son_kullanma" class="form-control"
+                   value="{{ license.son_kullanma|date('Y-m-d') if license and license.son_kullanma }}">
+          </div>
 
-  <div class="d-flex gap-2">
-    <button class="btn btn-primary" type="submit">Kaydet</button>
-    <a class="btn btn-secondary" href="{{ url_for('license_list') }}">İptal</a>
-  </div>
-</form>
+          <div class="col-md-6">
+            <label class="form-label">Bağlı Olduğu Envanter No</label>
+            <select id="selBagliEnvanter" name="inventory_id" class="form-select">
+              <option value="">(Seçimsiz)</option>
+              {% for inv in envanterler %}
+                <option value="{{ inv.id }}"
+                        {% if license and license.inventory_id == inv.id %}selected{% endif %}>
+                  {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
+                </option>
+              {% endfor %}
+            </select>
+            <div class="form-text">Envanteri seçerseniz lisans o envanterin detayında listelenir.</div>
+          </div>
+        </div>
 
+        <div class="d-flex gap-2 mt-4">
+          <button class="btn btn-primary" type="submit">Kaydet</button>
+          <a class="btn btn-secondary" href="{{ url_for('license_list') }}">İptal</a>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
 <script>
+  // Aramalı select (Choices varsa)
   document.addEventListener("DOMContentLoaded", () => {
     if (window.Choices) {
       new Choices("#selBagliEnvanter", { searchEnabled: true, itemSelectText: '' });
     }
   });
 </script>
+{% endblock %}
+

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -1,46 +1,55 @@
 {% extends "base.html" %}
 {% block title %}Lisanslar{% endblock %}
+
 {% block content %}
-<div class="container-fluid p-3">
-  <div class="d-flex justify-content-between mb-3">
-    <h5>Lisanslar</h5>
-    <a class="btn btn-primary btn-sm" href="{{ url_for('license_new') }}">Yeni Lisans</a>
+<div class="container-fluid p-3 content">
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <h4 class="mb-0">Lisanslar</h4>
+    <a class="btn btn-primary" href="{{ url_for('license_new') }}">Yeni Lisans</a>
   </div>
-  <div class="table-responsive">
-    <table class="table table-hover">
-      <thead>
-        <tr>
-          <th>Lisans Adı</th>
-          <th>Vendor</th>
-          <th>Son Kullanma</th>
-          <th>Anahtar</th>
-          <th>Envanter</th>
-          <th>İşlem</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for lic in rows %}
-        <tr data-href="{{ url_for('license_detail', id=lic.id) }}">
-          <td>{{ lic.adi }}</td>
-          <td>{{ lic.vendor or '-' }}</td>
-          <td>{{ lic.son_kullanma|date('Y-MM-dd') if lic.son_kullanma else '-' }}</td>
-          <td class="text-monospace">{{ lic.anahtar or '-' }}</td>
-          <td>
-            {% if lic.inventory %}
-              <a href="{{ url_for('inventory_detail', id=lic.inventory.id) }}" onclick="stopRowClick(event)">{{ lic.inventory.no }}</a>
-            {% else %}
-              -
-            {% endif %}
-          </td>
-          <td>
-            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('license_edit', id=lic.id) }}" onclick="stopRowClick(event)">Düzenle</a>
-          </td>
-        </tr>
+
+  <div class="card shadow-sm">
+    <div class="table-responsive">
+      <table class="table table-hover mb-0">
+        <thead>
+          <tr>
+            <th>Lisans Adı</th>
+            <th>Vendor</th>
+            <th>Son Kullanma</th>
+            <th>Anahtar</th>
+            <th>Envanter</th>
+            <th class="text-end">İşlem</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% if lisanslar|length == 0 %}
+          <tr><td colspan="6" class="text-muted">Kayıt yok</td></tr>
         {% else %}
-        <tr><td colspan="6" class="text-muted">Kayıt yok</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
+          {% for lic in lisanslar %}
+          <tr data-href="{{ url_for('license_detail', id=lic.id) }}">
+            <td>{{ lic.adi }}</td>
+            <td>{{ lic.vendor or '-' }}</td>
+            <td>{{ lic.son_kullanma|date('Y-MM-dd') if lic.son_kullanma else '-' }}</td>
+            <td class="text-monospace">{{ lic.anahtar or '-' }}</td>
+            <td>
+              {% if lic.inventory %}
+                <a href="{{ url_for('inventory_detail', id=lic.inventory.id) }}" onclick="event.stopPropagation()">
+                  {{ lic.inventory.no }}
+                </a>
+              {% else %}-{% endif %}
+            </td>
+            <td class="text-end">
+              <a class="btn btn-sm btn-outline-primary"
+                 href="{{ url_for('license_edit', id=lic.id) }}"
+                 onclick="event.stopPropagation()">Düzenle</a>
+            </td>
+          </tr>
+          {% endfor %}
+        {% endif %}
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- add title and scripts blocks to base template with row-click handler
- redesign license form with bootstrap layout and searchable inventory select
- refresh license list to link to inventory numbers and handle empty state
- pass licenses to list template via lisanslar variable

## Testing
- `python -m py_compile routers/license.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a880e75860832bb54919be013709cb