### PR TITLE
Fix missing Jinja date filter in license templates

### DIFF
--- a/templates/inventory_detail.html
+++ b/templates/inventory_detail.html
@@ -86,7 +86,7 @@
         <tr data-href="{{ url_for('license_detail', id=lic.id) }}">
           <td>{{ lic.adi }}</td>
           <td>{{ lic.vendor or '-' }}</td>
-          <td>{{ lic.son_kullanma|date('Y-MM-dd') if lic.son_kullanma else '-' }}</td>
+          <td>{{ lic.son_kullanma.strftime('%Y-%m-%d') if lic.son_kullanma else '-' }}</td>
           <td class="text-monospace">{{ lic.anahtar or '-' }}</td>
           <td class="text-nowrap">
             <a class="btn btn-sm btn-outline-primary" href="{{ url_for('license_edit', id=lic.id) }}" onclick="event.stopPropagation()">Düzenle</a>

--- a/templates/license_detail.html
+++ b/templates/license_detail.html
@@ -14,7 +14,7 @@
         <div class="card-body">
           <div class="row">
             <div class="col-5 text-muted">Vendor</div><div class="col-7">{{ license.vendor or '-' }}</div>
-            <div class="col-5 text-muted">Son Kullanma</div><div class="col-7">{{ license.son_kullanma|date('Y-MM-dd') if license.son_kullanma else '-' }}</div>
+            <div class="col-5 text-muted">Son Kullanma</div><div class="col-7">{{ license.son_kullanma.strftime('%Y-%m-%d') if license.son_kullanma else '-' }}</div>
             <div class="col-5 text-muted">Anahtar</div><div class="col-7"><code>{{ license.anahtar or '-' }}</code></div>
             <div class="col-5 text-muted">Bağlı Envanter</div>
             <div class="col-7">

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -30,7 +30,7 @@
           <div class="col-md-6">
             <label class="form-label">Son Kullanma</label>
             <input type="date" name="son_kullanma" class="form-control"
-                   value="{{ license.son_kullanma|date('Y-m-d') if license and license.son_kullanma }}">
+                   value="{{ license.son_kullanma.strftime('%Y-%m-%d') if license and license.son_kullanma }}">
           </div>
 
           <div class="col-md-6">

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -54,7 +54,7 @@
             </td>
             <td>{{ lic.adi }}</td>
             <td>{{ lic.vendor or '-' }}</td>
-            <td>{{ lic.son_kullanma|date('Y-MM-dd') if lic.son_kullanma else '-' }}</td>
+            <td>{{ lic.son_kullanma.strftime('%Y-%m-%d') if lic.son_kullanma else '-' }}</td>
             <td class="text-monospace">{{ lic.anahtar or '-' }}</td>
             <td>
               {% if lic.inventory %}


### PR DESCRIPTION
## Summary
- replace unsupported `date` filter with `strftime` in license-related templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abfc525b38832b9b2c90e0c203e238