### PR TITLE
Add license deletion route

### DIFF
--- a/routers/license.py
+++ b/routers/license.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request, Depends, Form
+from fastapi import APIRouter, Request, Depends, Form, HTTPException
 from sqlalchemy.orm import Session
 from fastapi.templating import Jinja2Templates
 from fastapi.responses import RedirectResponse, HTMLResponse
@@ -99,3 +99,13 @@ def license_detail(id: int, request: Request, db: Session = Depends(get_db)):
     return templates.TemplateResponse(
         "license_detail.html", {"request": request, "license": lic}
     )
+
+
+@router.get("/licenses/{id}/delete", name="license_delete")
+def license_delete(id: int, request: Request, db: Session = Depends(get_db)):
+    lic = db.get(License, id)
+    if not lic:
+        raise HTTPException(404, "Kayıt bulunamadı.")
+    db.delete(lic)
+    db.commit()
+    return RedirectResponse(request.url_for("license_list"), status_code=303)


### PR DESCRIPTION
## Summary
- add HTTPException to license router and implement license_delete endpoint to remove records and redirect

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abfeacfae8832ba3507e3ff8aac896