### PR TITLE
Add license migration and database bootstrap

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from starlette import status as st_status
 from sqlalchemy.orm import Session
 
 from models import init_db
+from db_bootstrap import bootstrap_schema
 from auth import (
     get_db,
     get_user_by_username,
@@ -40,6 +41,7 @@ from routers import lookup
 from security import current_user, require_roles
 
 load_dotenv()
+bootstrap_schema()
 
 # --- Secrets & Config ---------------------------------------------------------
 SESSION_SECRET = os.getenv("SESSION_SECRET")

--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -1,0 +1,51 @@
+from sqlalchemy import text
+from models import engine
+
+
+def _table_exists(conn, name: str) -> bool:
+    row = conn.exec_driver_sql(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?;", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def bootstrap_schema():
+    with engine.begin() as conn:
+        if not _table_exists(conn, "licenses"):
+            return  # tablo yoksa dokunma (ORM create_all başka yerde çalışıyor demektir)
+
+        cols = {row[1] for row in conn.exec_driver_sql("PRAGMA table_info('licenses')")}
+        stmts = []
+
+        if "sorumlu_personel" not in cols:
+            stmts.append("ALTER TABLE licenses ADD COLUMN sorumlu_personel TEXT;")
+        if "ifs_no" not in cols:
+            stmts.append("ALTER TABLE licenses ADD COLUMN ifs_no TEXT;")
+        if "tarih" not in cols:
+            stmts.append("ALTER TABLE licenses ADD COLUMN tarih DATE;")
+        if "islem_yapan" not in cols:
+            stmts.append("ALTER TABLE licenses ADD COLUMN islem_yapan TEXT;")
+        if "mail_adresi" not in cols:
+            stmts.append("ALTER TABLE licenses ADD COLUMN mail_adresi TEXT;")
+        if "inventory_id" not in cols:
+            stmts.append("ALTER TABLE licenses ADD COLUMN inventory_id INTEGER;")
+            stmts.append("CREATE INDEX IF NOT EXISTS idx_licenses_inventory_id ON licenses(inventory_id);")
+
+        for s in stmts:
+            conn.exec_driver_sql(s)
+
+        # Log tablosu
+        conn.exec_driver_sql(
+            """
+        CREATE TABLE IF NOT EXISTS license_log (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          license_id INTEGER NOT NULL,
+          field TEXT NOT NULL,
+          old_value TEXT,
+          new_value TEXT,
+          changed_by TEXT,
+          changed_at TEXT DEFAULT (datetime('now')),
+          FOREIGN KEY(license_id) REFERENCES licenses(id) ON DELETE CASCADE
+        );
+        """
+        )

--- a/sql/patch_licenses.sql
+++ b/sql/patch_licenses.sql
@@ -1,0 +1,24 @@
+-- Gerekli yeni sütunlar (yoksa eklerken hata vermez; SQLite ekler)
+ALTER TABLE licenses ADD COLUMN sorumlu_personel TEXT;
+ALTER TABLE licenses ADD COLUMN ifs_no TEXT;
+ALTER TABLE licenses ADD COLUMN tarih DATE;
+ALTER TABLE licenses ADD COLUMN islem_yapan TEXT;
+ALTER TABLE licenses ADD COLUMN mail_adresi TEXT;
+
+-- Envanter bağı (yoksa aç)
+ALTER TABLE licenses ADD COLUMN inventory_id INTEGER REFERENCES inventories(id) ON DELETE SET NULL;
+
+-- İndeks
+CREATE INDEX IF NOT EXISTS idx_licenses_inventory_id ON licenses(inventory_id);
+
+-- Log tablosu
+CREATE TABLE IF NOT EXISTS license_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  license_id INTEGER NOT NULL,
+  field TEXT NOT NULL,
+  old_value TEXT,
+  new_value TEXT,
+  changed_by TEXT,
+  changed_at TEXT DEFAULT (datetime('now')),
+  FOREIGN KEY(license_id) REFERENCES licenses(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- add SQL patch for license enhancements
- bootstrap schema at startup to add missing columns & license_log table
- wire bootstrap into app startup

## Testing
- `python -m py_compile db_bootstrap.py app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac0b764ed4832bbd2f2e59c3c169c5