### PR TITLE
Fix broken inventory detail links in license pages

### DIFF
--- a/templates/license_detail.html
+++ b/templates/license_detail.html
@@ -28,7 +28,7 @@
                   <th>Bağlı Envanter No</th>
                   <td>
                     {% if license.inventory %}
-                      <a href="{{ url_for('inventory_detail', id=license.inventory.id) }}">
+                      <a href="{{ url_for('inventory.detail', item_id=license.inventory.id) }}">
                         {{ license.inventory.no }}
                       </a>
                     {% else %}-{% endif %}

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -30,7 +30,7 @@
             <td>{{ lic.id }}</td>
             <td>
               {% if lic.inventory %}
-                <a href="{{ url_for('inventory_detail', id=lic.inventory.id) }}" onclick="event.stopPropagation()">
+                <a href="{{ url_for('inventory.detail', item_id=lic.inventory.id) }}" onclick="event.stopPropagation()">
                   {{ lic.inventory.no }}
                 </a>
               {% else %}-{% endif %}


### PR DESCRIPTION
## Summary
- fix license list link to inventory detail route
- fix license detail link to inventory detail route

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac1ab48ed4832b889869e7e0c1c761