### PR TITLE
Fix missing foreign key for license inventory relation

### DIFF
--- a/models.py
+++ b/models.py
@@ -153,10 +153,17 @@ class License(Base):
     lisans_key = Column(String(500), nullable=True)
     sorumlu_personel = Column(String(120), nullable=True)
     bagli_envanter_no = Column(String(120), nullable=True)
+    inventory_id = Column(
+        Integer,
+        ForeignKey("inventories.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
     durum = Column(String(20), default="aktif")
     notlar = Column(Text, nullable=True)
 
     logs = relationship("LicenseLog", back_populates="license", cascade="all, delete-orphan")
+    inventory = relationship("Inventory", back_populates="licenses")
 
 
 class LicenseLog(Base):
@@ -314,6 +321,15 @@ def init_db():
             conn.execute(
                 text(
                     "ALTER TABLE licenses ADD COLUMN sorumlu_personel VARCHAR(150)"
+                )
+            )
+        if "inventory_id" not in cols:
+            conn.execute(
+                text("ALTER TABLE licenses ADD COLUMN inventory_id INTEGER")
+            )
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS idx_licenses_inventory_id ON licenses(inventory_id)"
                 )
             )
 


### PR DESCRIPTION
## Summary
- add `inventory_id` foreign key to license model and link to `Inventory`
- ensure database migration adds `inventory_id` column and index

## Testing
- `python -m py_compile models.py db_bootstrap.py app.py routers/license.py`
- `python - <<'PY'
from models import init_db, SessionLocal, Inventory, License
init_db()
db=SessionLocal()
inv=Inventory(no='INV1')
lic=License(lisans_adi='Test', inventory=inv)
db.add(inv)
db.add(lic)
db.commit()
print('ids', inv.id, lic.inventory_id)
print('linked', lic.inventory is inv)
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac2170d528832b9ea19188aa794375