### PR TITLE
Align license schema with database and add stock navigation

### DIFF
--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -30,6 +30,10 @@ def bootstrap_schema():
         if "inventory_id" not in cols:
             stmts.append("ALTER TABLE licenses ADD COLUMN inventory_id INTEGER;")
             stmts.append("CREATE INDEX IF NOT EXISTS idx_licenses_inventory_id ON licenses(inventory_id);")
+        if "durum" not in cols:
+            stmts.append("ALTER TABLE licenses ADD COLUMN durum TEXT DEFAULT 'aktif';")
+        if "notlar" not in cols:
+            stmts.append("ALTER TABLE licenses ADD COLUMN notlar TEXT;")
 
         for s in stmts:
             conn.exec_driver_sql(s)

--- a/models.py
+++ b/models.py
@@ -150,7 +150,7 @@ class License(Base):
 
     id = Column(Integer, primary_key=True)
     lisans_adi = Column(String(200), nullable=False)
-    lisans_key = Column(String(500), nullable=True)
+    anahtar = Column("lisans_anahtari", String(500), nullable=True)
     sorumlu_personel = Column(String(120), nullable=True)
     bagli_envanter_no = Column(String(120), nullable=True)
     inventory_id = Column(

--- a/routers/license_schemas.py
+++ b/routers/license_schemas.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 class LicenseBase(BaseModel):
     lisans_adi: str
-    lisans_anahtari: str
+    anahtar: str
     sorumlu_personel: Optional[str] = None
     bagli_envanter_no: Optional[str] = None
     ifs_no: Optional[str] = None
@@ -20,7 +20,7 @@ class LicenseCreate(LicenseBase):
 
 class LicenseUpdate(BaseModel):
     lisans_adi: Optional[str] = None
-    lisans_anahtari: Optional[str] = None
+    anahtar: Optional[str] = None
     sorumlu_personel: Optional[str] = None
     bagli_envanter_no: Optional[str] = None
     ifs_no: Optional[str] = None
@@ -44,7 +44,7 @@ class LicenseListOut(BaseModel):
     id: int
     bagli_envanter_no: str | None
     lisans_adi: str
-    lisans_anahtari: str
+    anahtar: str
     sorumlu_personel: str | None
 
     class Config:

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,6 +35,7 @@
             <a class="side-link" href="/inventory">Envanter Takip</a>
             <a class="side-link" href="/lisans">Lisans Takip</a>
             <a class="side-link" href="/printers">Yazıcı Takip</a>
+            <a class="side-link" href="/stock">Stok Takip</a>
         </div>
         <div class="side-group soft-card p-3 mb-3">
           <div class="side-title">İŞLEMLER</div>


### PR DESCRIPTION
## Summary
- Map license key field to existing `lisans_anahtari` column and update Pydantic schemas
- Extend DB bootstrap to create missing license columns
- Link stock tracking page in sidebar

## Testing
- `python -m py_compile models.py routers/license_schemas.py db_bootstrap.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac22d1632c832ba3d4219c09fd1b1d