### PR TITLE
Add lisans_adi column migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+__pycache__/
+*.pyc
+data/
+*.db
+

--- a/alembic/versions/7e1c4d1aa8f0_add_lisans_adi_to_licenses.py
+++ b/alembic/versions/7e1c4d1aa8f0_add_lisans_adi_to_licenses.py
@@ -1,0 +1,24 @@
+"""Add lisans_adi column to licenses
+
+Revision ID: 7e1c4d1aa8f0
+Revises: None
+Create Date: 2024-05-30
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "7e1c4d1aa8f0"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("licenses", sa.Column("lisans_adi", sa.String(length=200), nullable=True))
+
+
+def downgrade():
+    op.drop_column("licenses", "lisans_adi")
+

--- a/models.py
+++ b/models.py
@@ -149,7 +149,7 @@ class License(Base):
     __tablename__ = "licenses"
 
     id = Column(Integer, primary_key=True)
-    lisans_adi = Column(String(200), nullable=False)
+    lisans_adi = Column(String(200), nullable=True)
     anahtar = Column("lisans_anahtari", String(500), nullable=True)
     sorumlu_personel = Column(String(120), nullable=True)
     bagli_envanter_no = Column(String(120), nullable=True)


### PR DESCRIPTION
## Summary
- allow null license names and expose optional `lisans_adi` field on the License model
- add Alembic migration to create `lisans_adi` column on `licenses`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac2630b558832bb70c5515529f7285