### PR TITLE
Add panel tabs router and shared template

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,6 +35,7 @@ from routers import (
     integrations,
     logs,
     refdata,
+    panel as panel_router,
 )
 from routers import lookup
 from security import current_user, require_roles
@@ -88,9 +89,11 @@ app.add_middleware(
 # Statik dosyalar ve şablonlar
 app.mount("/static", StaticFiles(directory="static"), name="static")
 templates = Jinja2Templates(directory="templates")
+app.state.templates = templates
 
 # --- Routers (korumalı) -------------------------------------------------------
 app.include_router(home.router, prefix="", dependencies=[Depends(current_user)])
+app.include_router(panel_router.router, dependencies=[Depends(current_user)])
 app.include_router(inventory_router.router, dependencies=[Depends(current_user)])
 app.include_router(license_router.router, dependencies=[Depends(current_user)])
 app.include_router(printers_router.router, dependencies=[Depends(current_user)])

--- a/routers/panel.py
+++ b/routers/panel.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+@router.get("/admin", response_class=HTMLResponse)
+async def admin_panel(request: Request, tab: str = "admin", sub: str = "urun"):
+    return request.app.state.templates.TemplateResponse(
+        "panel_tabs.html", {"request": request, "page": "admin", "tab": tab, "sub": sub}
+    )
+
+@router.get("/talep", response_class=HTMLResponse)
+async def talep_panel(request: Request, tab: str = "talep", sub: str = "aktif"):
+    return request.app.state.templates.TemplateResponse(
+        "panel_tabs.html", {"request": request, "page": "talep", "tab": tab, "sub": sub}
+    )

--- a/templates/panel_tabs.html
+++ b/templates/panel_tabs.html
@@ -1,0 +1,188 @@
+{% extends "base.html" %}
+{% block title %}Panel{% endblock %}
+
+{% block content %}
+<div class="container-fluid p-2">
+
+  <!-- ÜST SEKMELER -->
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+      <a class="nav-link {% if page=='admin' %}active{% endif %}"
+         href="/admin?tab=admin&sub={{ 'urun' if page!='admin' else sub }}">Admin</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link {% if page=='talep' %}active{% endif %}"
+         href="/talep?tab=talep&sub={{ 'aktif' if page!='talep' else sub }}">Talep Takip</a>
+    </li>
+  </ul>
+
+  <!-- ALT SEKMELER -->
+  <div class="bg-light border-bottom px-3 py-2">
+    {% if page == 'admin' %}
+      <ul class="nav nav-pills small">
+        <li class="nav-item me-2">
+          <a class="nav-link {% if sub=='urun' %}active{% endif %}"
+             href="/admin?tab=admin&sub=urun">Ürün Ekle</a>
+        </li>
+        <li class="nav-item me-2">
+          <a class="nav-link {% if sub=='kullanici' %}active{% endif %}"
+             href="/admin?tab=admin&sub=kullanici">Kullanıcı</a>
+        </li>
+      </ul>
+    {% elif page == 'talep' %}
+      <ul class="nav nav-pills small">
+        <li class="nav-item me-2">
+          <a class="nav-link {% if sub=='aktif' %}active{% endif %}"
+             href="/talep?tab=talep&sub=aktif">Aktif Talepler</a>
+        </li>
+        <li class="nav-item me-2">
+          <a class="nav-link {% if sub=='tamamlanan' %}active{% endif %}"
+             href="/talep?tab=talep&sub=tamamlanan">Tamamlanan Talepler</a>
+        </li>
+      </ul>
+    {% endif %}
+  </div>
+
+  <!-- İÇERİK ALANI -->
+  <div class="p-3">
+
+    {# ADMIN → ÜRÜN EKLE #}
+    {% if page=='admin' and sub=='urun' %}
+      <nav class="small text-muted mb-2">Admin » Ürün Ekle</nav>
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <form>
+            <div class="row g-3">
+              <div class="col-md-4">
+                <label class="form-label">Ürün Adı</label>
+                <input class="form-control" placeholder="Örn: Dell Latitude 5440">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label">Kategori</label>
+                <select class="form-select">
+                  <option>Bilgisayar</option><option>Yazıcı</option><option>Lisans</option>
+                </select>
+              </div>
+              <div class="col-md-2">
+                <label class="form-label">Miktar</label>
+                <input type="number" class="form-control" value="1" min="1">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label">Seri No</label>
+                <input class="form-control" placeholder="Opsiyonel">
+              </div>
+              <div class="col-12">
+                <label class="form-label">Açıklama</label>
+                <textarea class="form-control" rows="2" placeholder="Notlar…"></textarea>
+              </div>
+            </div>
+            <div class="mt-3 d-flex gap-2">
+              <button class="btn btn-primary" type="button">Kaydet</button>
+              <button class="btn btn-outline-secondary" type="reset">Temizle</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    {% endif %}
+
+    {# ADMIN → KULLANICI #}
+    {% if page=='admin' and sub=='kullanici' %}
+      <nav class="small text-muted mb-2">Admin » Kullanıcı</nav>
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <form>
+            <div class="row g-3">
+              <div class="col-md-4">
+                <label class="form-label">Ad Soyad</label>
+                <input class="form-control" placeholder="Örn: Ayşe Yılmaz">
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">E‑posta</label>
+                <input type="email" class="form-control" placeholder="ad@firma.com">
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">Rol</label>
+                <select class="form-select">
+                  <option>Admin</option><option>Kullanıcı</option>
+                </select>
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">Departman</label>
+                <input class="form-control" placeholder="IT / Üretim / Satınalma…">
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">Şifre</label>
+                <input type="password" class="form-control" placeholder="••••••••">
+              </div>
+              <div class="col-md-4">
+                <label class="form-label">Durum</label>
+                <select class="form-select">
+                  <option>Aktif</option><option>Pasif</option>
+                </select>
+              </div>
+            </div>
+            <div class="mt-3 d-flex gap-2">
+              <button class="btn btn-primary" type="button">Kaydet</button>
+              <button class="btn btn-outline-secondary" type="reset">Temizle</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    {% endif %}
+
+    {# TALEP → AKTİF #}
+    {% if page=='talep' and sub=='aktif' %}
+      <nav class="small text-muted mb-2">Talep Takip » Aktif Talepler</nav>
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-center mb-2">
+            <input class="form-control form-control-sm" style="max-width:280px" placeholder="Ara…">
+            <div class="small text-muted">Toplam: 0</div>
+          </div>
+          <div class="table-responsive">
+            <table class="table table-sm table-hover align-middle">
+              <thead class="table-light">
+                <tr>
+                  <th>#</th><th>Konu</th><th>Oluşturan</th><th>Öncelik</th><th>Tarih</th><th>İşlem</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td colspan="6" class="text-center text-muted">Henüz veri yok (örnek görünüm).</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    {# TALEP → TAMAMLANAN #}
+    {% if page=='talep' and sub=='tamamlanan' %}
+      <nav class="small text-muted mb-2">Talep Takip » Tamamlanan Talepler</nav>
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <div class="table-responsive">
+            <table class="table table-sm table-hover align-middle">
+              <thead class="table-light">
+                <tr>
+                  <th>#</th><th>Konu</th><th>Kapatma Notu</th><th>Kapatma Tarihi</th><th>İşlem</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td colspan="5" class="text-center text-muted">Henüz veri yok (örnek görünüm).</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+  </div>
+</div>
+
+<style>
+  .nav-tabs .nav-link.active { font-weight:600; }
+  .nav-pills .nav-link { padding:.25rem .75rem; }
+  .bg-light { background:#f8f9fa !important; }
+  .card { border-radius:1rem; }
+</style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add router for /admin and /talep pages with tab-based navigation
- create shared Jinja template with admin and request tabs
- expose templates via app state and include new router

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac2b62f4f8832b9c4204b86913b725