### PR TITLE
Handle legacy license columns

### DIFF
--- a/scripts/migrate_add_missing_cols.py
+++ b/scripts/migrate_add_missing_cols.py
@@ -23,6 +23,16 @@ def main():
     cur.execute("PRAGMA table_info(licenses);")
     existing = {row[1] for row in cur.fetchall()}  # kolon adları
 
+    # Eski sürümlerdeki kolon adlarını yeni adlara taşı
+    renames = [("adi", "lisans_adi"), ("anahtari", "lisans_anahtari")]
+    for old, new in renames:
+        if old in existing and new not in existing:
+            sql = f"ALTER TABLE licenses RENAME COLUMN {old} TO {new};"
+            print("[…] " + sql)
+            cur.execute(sql)
+            existing.remove(old)
+            existing.add(new)
+
     to_add = [c for c in REQUIRED_COLS if c[0] not in existing]
     if not to_add:
         print("[✓] licenses tablosu zaten güncel.")


### PR DESCRIPTION
## Summary
- ensure license table columns exist, renaming old `adi`/`anahtari` fields and adding missing ones
- migrate legacy license databases via updated script

## Testing
- `python -m py_compile models.py scripts/migrate_add_missing_cols.py`
- `ENV_DB_PATH=data/app.db python scripts/migrate_add_missing_cols.py`
- `python - <<'PY'
from models import init_db, engine
from sqlalchemy import text, inspect
init_db()
with engine.begin() as conn:
    cols = conn.execute(text('PRAGMA table_info(licenses)')).fetchall()
print([c[1] for c in cols])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac3c00029c832b97b3cb800411b814