### PR TITLE
Add admin user and taxonomy panels

### DIFF
--- a/templates/admin/taxonomies.html
+++ b/templates/admin/taxonomies.html
@@ -1,5 +1,124 @@
 {% extends "base.html" %}{% block title %}Admin – Tanımlar{% endblock %}
 {% block content %}
-<h2 class="h5 mb-3">Tanımlar</h2>
-<div class="card p-3">Departman, lokasyon, tip, statü...</div>
+
+<!-- ÜRÜN EKLE KUTUSU (REFERANS TABLOLARI) -->
+<div class="collapse show" id="productBox">
+  <div class="row g-3">
+
+    <!-- Kullanım Alanı -->
+    <div class="col-lg-4 col-md-6">
+      <div class="card ref-card h-100" data-entity="kullanim-alani">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span>Kullanım Alanı</span>
+        </div>
+        <div class="card-body d-flex flex-column">
+          <div class="input-group mb-2">
+            <input class="form-control ref-input" placeholder="Yeni kullanım alanı..." />
+            <button class="btn btn-success ref-add">Ekle</button>
+          </div>
+          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Lisans Adı -->
+    <div class="col-lg-4 col-md-6">
+      <div class="card ref-card h-100" data-entity="lisans-adi">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span>Lisans Adı</span>
+        </div>
+        <div class="card-body d-flex flex-column">
+          <div class="input-group mb-2">
+            <input class="form-control ref-input" placeholder="Yeni lisans adı..." />
+            <button class="btn btn-success ref-add">Ekle</button>
+          </div>
+          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Fabrika -->
+    <div class="col-lg-4 col-md-6">
+      <div class="card ref-card h-100" data-entity="fabrika">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span>Fabrika</span>
+        </div>
+        <div class="card-body d-flex flex-column">
+          <div class="input-group mb-2">
+            <input class="form-control ref-input" placeholder="Yeni fabrika..." />
+            <button class="btn btn-success ref-add">Ekle</button>
+          </div>
+          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Donanım Tipi -->
+    <div class="col-lg-4 col-md-6">
+      <div class="card ref-card h-100" data-entity="donanim-tipi">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span>Donanım Tipi</span>
+        </div>
+        <div class="card-body d-flex flex-column">
+          <div class="input-group mb-2">
+            <input class="form-control ref-input" placeholder="Yeni donanım tipi..." />
+            <button class="btn btn-success ref-add">Ekle</button>
+          </div>
+          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Marka -->
+    <div class="col-lg-4 col-md-6">
+      <div class="card ref-card h-100" data-entity="marka">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span>Marka</span>
+        </div>
+        <div class="card-body d-flex flex-column">
+          <div class="input-group mb-2">
+            <input class="form-control ref-input" placeholder="Yeni marka..." />
+            <button class="btn btn-success ref-add">Ekle</button>
+          </div>
+          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Model (Marka'ya bağlı) -->
+    <div class="col-lg-4 col-md-6">
+      <div class="card ref-card h-100" data-entity="model">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <span>Model</span>
+        </div>
+        <div class="card-body d-flex flex-column">
+          <div class="row g-2 mb-2">
+            <div class="col-12">
+              <!-- Marka seçimi; Choices.js ile aramalı yapılır -->
+              <select class="form-select ref-brand" aria-label="Marka seçin"></select>
+            </div>
+            <div class="col-12">
+              <div class="input-group">
+                <input class="form-control ref-input" placeholder="Yeni model adı..." />
+                <button class="btn btn-success ref-add">Ekle</button>
+              </div>
+            </div>
+          </div>
+          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<link href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+<script defer src="/static/js/refdata.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    if (window.initRefAdmin) window.initRefAdmin();
+  });
+</script>
+
 {% endblock %}

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -1,5 +1,200 @@
 {% extends "base.html" %}{% block title %}Admin – Kullanıcılar{% endblock %}
 {% block content %}
-<h2 class="h5 mb-3">Kullanıcı & Rol Yönetimi</h2>
-<div class="card p-3">Kullanıcı tablosu...</div>
+
+<!-- KULLANICI KUTUSU -->
+<div class="collapse show" id="userBox">
+  <div class="card mb-4">
+    <div class="card-header d-flex flex-wrap align-items-center justify-content-between gap-2">
+      <div class="d-flex align-items-center gap-2">
+        <!-- Kullanıcı Ekle: formu aç/kapa -->
+        <button class="btn btn-success btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#userCreateForm">
+          Kullanıcı Ekle
+        </button>
+        <!-- Düzenle: seçili kullanıcıyı formda aç -->
+        <button class="btn btn-warning btn-sm" type="button" id="btnEditUser">Düzenle</button>
+        <!-- Sil: seçili kullanıcıyı sil -->
+        <form id="deleteForm" method="post" class="d-inline">
+          <button class="btn btn-danger btn-sm" type="submit" id="btnDeleteUser">Sil</button>
+        </form>
+      </div>
+
+      <!-- Liste içinde arama (client-side) -->
+      <div class="d-flex align-items-center gap-2">
+        <input type="text" id="tblSearch" class="form-control form-control-sm" placeholder="Listede ara...">
+      </div>
+    </div>
+
+    <div class="card-body">
+
+      <!-- Kullanıcı Ekle Formu -->
+      <div class="collapse" id="userCreateForm">
+        <form method="post" action="/admin/users/create" class="border rounded p-3 mb-3">
+          <div class="row g-2">
+            <div class="col-md-3">
+              <label class="form-label">Kullanıcı Adı</label>
+              <input name="username" class="form-control form-control-sm" required>
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Şifre</label>
+              <input type="password" name="password" class="form-control form-control-sm" required>
+            </div>
+            <div class="col-md-2">
+              <label class="form-label">Adı</label>
+              <input name="first_name" class="form-control form-control-sm">
+            </div>
+            <div class="col-md-2">
+              <label class="form-label">Soyadı</label>
+              <input name="last_name" class="form-control form-control-sm">
+            </div>
+            <div class="col-md-2">
+              <label class="form-label">Mail</label>
+              <input type="email" name="email" class="form-control form-control-sm">
+            </div>
+            <div class="col-12 d-flex align-items-center gap-2 mt-2">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="is_admin" name="is_admin">
+                <label class="form-check-label" for="is_admin">Admin</label>
+              </div>
+              <button class="btn btn-success btn-sm ms-auto" type="submit">Ekle</button>
+            </div>
+          </div>
+        </form>
+      </div>
+
+      <!-- Kullanıcı Düzenle Formu (seçili kullanıcıyla doldurulur) -->
+      <form method="post" id="userEditForm" class="border rounded p-3 mb-3 d-none">
+        <input type="hidden" id="editAction" value="">
+        <div class="row g-2">
+          <div class="col-md-3">
+            <label class="form-label">Kullanıcı Adı</label>
+            <input name="username" id="edit_username" class="form-control form-control-sm" required>
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">Yeni Şifre (isteğe bağlı)</label>
+            <input type="password" name="password" id="edit_password" class="form-control form-control-sm" placeholder="Boş bırakılırsa değişmez">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label">Adı</label>
+            <input name="first_name" id="edit_first_name" class="form-control form-control-sm">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label">Soyadı</label>
+            <input name="last_name" id="edit_last_name" class="form-control form-control-sm">
+          </div>
+          <div class="col-md-2">
+            <label class="form-label">Mail</label>
+            <input type="email" name="email" id="edit_email" class="form-control form-control-sm">
+          </div>
+          <div class="col-12 d-flex align-items-center gap-2 mt-2">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="edit_is_admin" name="is_admin">
+              <label class="form-check-label" for="edit_is_admin">Admin</label>
+            </div>
+            <button class="btn btn-warning btn-sm ms-auto" type="submit">Kaydet</button>
+          </div>
+        </div>
+      </form>
+
+      <!-- Kullanıcı Listesi -->
+      <div class="table-responsive">
+        <table class="table table-sm table-hover align-middle" id="userTable">
+          <thead>
+            <tr>
+              <th style="width:36px;"></th>
+              <th>ID</th>
+              <th>Kullanıcı Adı</th>
+              <th>Adı</th>
+              <th>Soyadı</th>
+              <th>Mail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for u in users %}
+            <tr data-id="{{ u.id }}"
+                data-username="{{ u.username }}"
+                data-first_name="{{ u.first_name or '' }}"
+                data-last_name="{{ u.last_name or '' }}"
+                data-email="{{ u.email or '' }}"
+                data-is_admin="{{ 1 if u.is_admin else 0 }}">
+              <td><input type="radio" name="selUser" value="{{ u.id }}"></td>
+              <td>{{ u.id }}</td>
+              <td>{{ u.username }}</td>
+              <td>{{ u.first_name or '' }}</td>
+              <td>{{ u.last_name or '' }}</td>
+              <td>{{ u.email or '' }}</td>
+            </tr>
+            {% else %}
+            <tr><td colspan="6" class="text-muted">Kullanıcı yok</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script>
+  // Liste içi arama (client-side)
+  const search = document.getElementById('tblSearch');
+  const table = document.getElementById('userTable');
+  if (search && table) {
+    search.addEventListener('input', () => {
+      const q = search.value.toLowerCase();
+      table.querySelectorAll('tbody tr').forEach(tr => {
+        tr.style.display = tr.innerText.toLowerCase().includes(q) ? '' : 'none';
+      });
+    });
+  }
+
+  // Seçili kullanıcıyı bul
+  function getSelectedRow() {
+    const checked = table?.querySelector('input[name="selUser"]:checked');
+    if (!checked) return null;
+    return checked.closest('tr');
+  }
+
+  // Düzenle
+  const btnEdit = document.getElementById('btnEditUser');
+  const editForm = document.getElementById('userEditForm');
+  const editAction = document.getElementById('editAction');
+  if (btnEdit && editForm) {
+    btnEdit.addEventListener('click', () => {
+      const row = getSelectedRow();
+      if (!row) { alert('Lütfen bir kullanıcı seçin.'); return; }
+      const id = row.dataset.id;
+      editAction.value = `/admin/users/${id}/update`;
+      editForm.setAttribute('action', editAction.value);
+      document.getElementById('edit_username').value = row.dataset.username || '';
+      document.getElementById('edit_first_name').value = row.dataset.first_name || '';
+      document.getElementById('edit_last_name').value = row.dataset.last_name || '';
+      document.getElementById('edit_email').value = row.dataset.email || '';
+      document.getElementById('edit_is_admin').checked = row.dataset.is_admin === '1';
+      document.getElementById('edit_password').value = '';
+      editForm.classList.remove('d-none');
+      editForm.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+  }
+
+  // Sil
+  const btnDelete = document.getElementById('btnDeleteUser');
+  const deleteForm = document.getElementById('deleteForm');
+  if (btnDelete && deleteForm) {
+    btnDelete.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      const row = getSelectedRow();
+      if (!row) { alert('Lütfen bir kullanıcı seçin.'); return; }
+      const username = row.dataset.username;
+      if (username && username.toLowerCase() === 'admin') {
+        alert('Admin hesabı silinemez.');
+        return;
+      }
+      if (!confirm(`'${username}' kullanıcısını silmek istediğinize emin misiniz?`)) return;
+      const id = row.dataset.id;
+      deleteForm.setAttribute('action', `/admin/users/${id}/delete`);
+      deleteForm.submit();
+    });
+  }
+</script>
+
 {% endblock %}


### PR DESCRIPTION
## Summary
- Implement admin user management page with add/edit forms and search
- Introduce taxonomy management page with reference data cards and JS initialization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac43705c58832b9a2c43e02113d5b1