### PR TITLE
Add printer tracking with history and scrap management

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ from routers import (
     inventory as inventory_router,
     license as license_router,
     printers as printers_router,
+    printers_scrap_list,
     catalog as catalog_router,
     requests as reqs,
     stock,
@@ -97,6 +98,7 @@ app.include_router(panel_router.router, dependencies=[Depends(current_user)])
 app.include_router(inventory_router.router, dependencies=[Depends(current_user)])
 app.include_router(license_router.router, dependencies=[Depends(current_user)])
 app.include_router(printers_router.router, dependencies=[Depends(current_user)])
+app.include_router(printers_scrap_list.router, dependencies=[Depends(current_user)])
 app.include_router(catalog_router.router, dependencies=[Depends(current_user)])
 app.include_router(reqs.router, prefix="/requests", tags=["Requests"], dependencies=[Depends(current_user)])
 app.include_router(stock.router, prefix="/stock", tags=["Stock"], dependencies=[Depends(current_user)])

--- a/routers/printers_scrap_list.py
+++ b/routers/printers_scrap_list.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends, Request
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from auth import get_db
+from models import Printer, ScrapPrinter
+
+templates = Jinja2Templates(directory="templates")
+router = APIRouter(prefix="/printers", tags=["Printers - Scrap"])
+
+USE_SCRAP_TABLE = True
+
+
+@router.get("/scrap", name="Hurdalar")
+def scrap_list(request: Request, db: Session = Depends(get_db)):
+    if USE_SCRAP_TABLE:
+        rows = db.query(ScrapPrinter).order_by(ScrapPrinter.created_at.desc()).all()
+        return templates.TemplateResponse(
+            "printers_scrap.html", {"request": request, "rows": rows, "mode": "table"}
+        )
+    else:
+        rows = (
+            db.query(Printer)
+            .filter(Printer.durum == "hurda")
+            .order_by(Printer.id.desc())
+            .all()
+        )
+        return templates.TemplateResponse(
+            "printers_scrap.html", {"request": request, "rows": rows, "mode": "filter"}
+        )
+

--- a/sql/2025-08-25_printer_migration.sql
+++ b/sql/2025-08-25_printer_migration.sql
@@ -1,0 +1,27 @@
+-- printer ekstra kolonlar
+ALTER TABLE printers ADD COLUMN fabrika TEXT;
+ALTER TABLE printers ADD COLUMN kullanim_alani TEXT;
+ALTER TABLE printers ADD COLUMN sorumlu_personel TEXT;
+ALTER TABLE printers ADD COLUMN bagli_envanter_no TEXT;
+ALTER TABLE printers ADD COLUMN durum TEXT DEFAULT 'aktif';
+ALTER TABLE printers ADD COLUMN notlar TEXT;
+
+-- tarihçe
+CREATE TABLE IF NOT EXISTS printer_histories (
+  id INTEGER PRIMARY KEY,
+  printer_id INTEGER,
+  action TEXT,
+  changes TEXT,
+  actor TEXT,
+  created_at TEXT
+);
+
+-- hurdalar (opsiyonel)
+CREATE TABLE IF NOT EXISTS scrap_printers (
+  id INTEGER PRIMARY KEY,
+  printer_id INTEGER UNIQUE,
+  snapshot TEXT,
+  reason TEXT,
+  created_at TEXT
+);
+

--- a/templates/printers_detail.html
+++ b/templates/printers_detail.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block title %}Yazıcı Detay{% endblock %}
+{% block content %}
+<div class="container py-3">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h5 class="mb-0">Yazıcı #{{ p.id }} — {{ p.marka }} {{ p.model }}</h5>
+    <a class="btn btn-sm btn-outline-secondary" href="/printers">Geri</a>
+  </div>
+  <div class="row g-3">
+    <div class="col-lg-6">
+      <div class="card">
+        <div class="card-header">Bilgiler</div>
+        <div class="card-body">
+          <div><strong>Seri No:</strong> {{ p.seri_no or '-' }}</div>
+          <div><strong>Fabrika:</strong> {{ p.fabrika or '-' }}</div>
+          <div><strong>Kullanım Alanı:</strong> {{ p.kullanim_alani or '-' }}</div>
+          <div><strong>Sorumlu:</strong> {{ p.sorumlu_personel or '-' }}</div>
+          <div><strong>Bağlı Env.:</strong> {{ p.bagli_envanter_no or '-' }}</div>
+          <div><strong>Durum:</strong> {{ p.durum }}</div>
+          <div><strong>Not:</strong> {{ p.notlar or '-' }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-6">
+      <div class="card">
+        <div class="card-header">Geçmiş Kayıtları</div>
+        <div class="card-body">
+          {% if logs|length == 0 %}
+            <em>Kayıt yok.</em>
+          {% else %}
+            <ul class="list-group list-group-flush">
+              {% for h in logs %}
+              <li class="list-group-item">
+                <div class="small text-muted">{{ h.created_at.strftime("%d.%m.%Y %H:%M") }} — {{ h.actor or '-' }} — {{ h.action }}</div>
+                {% if h.changes %}
+                <pre class="mt-2 mb-0 small">{{ h.changes | tojson(indent=2) }}</pre>
+                {% endif %}
+              </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}Yazıcı Düzenle{% endblock %}
+{% block content %}
+<div class="container-fluid p-3">
+  <h5 class="mb-3">Yazıcı Düzenle</h5>
+  <form method="post">
+    <div class="mb-2">
+      <label class="form-label">Marka</label>
+      <input type="text" name="marka" value="{{ p.marka or '' }}" class="form-control">
+    </div>
+    <div class="mb-2">
+      <label class="form-label">Model</label>
+      <input type="text" name="model" value="{{ p.model or '' }}" class="form-control">
+    </div>
+    <div class="mb-2">
+      <label class="form-label">Seri No</label>
+      <input type="text" name="seri_no" value="{{ p.seri_no or '' }}" class="form-control">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Notlar</label>
+      <textarea name="notlar" class="form-control" rows="3">{{ p.notlar or '' }}</textarea>
+    </div>
+    <button class="btn btn-primary btn-sm">Kaydet</button>
+    <a href="/printers/{{ p.id }}" class="btn btn-outline-secondary btn-sm">İptal</a>
+  </form>
+</div>
+{% endblock %}
+

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -1,0 +1,187 @@
+{% extends "base.html" %}
+{% block title %}Yazıcı Takip{% endblock %}
+
+{% block content %}
+<div class="container-fluid p-3">
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <h5 class="mb-0">Yazıcılar</h5>
+    <form method="get" class="d-flex gap-2">
+      <input type="text" name="q" value="{{ request.query_params.get('q','') }}" class="form-control form-control-sm" placeholder="Ara...">
+      <select name="durum" class="form-select form-select-sm">
+        <option value="">Tümü</option>
+        <option value="aktif" {% if request.query_params.get('durum')=='aktif' %}selected{% endif %}>Aktif</option>
+        <option value="hurda" {% if request.query_params.get('durum')=='hurda' %}selected{% endif %}>Hurda</option>
+      </select>
+      <button class="btn btn-sm btn-primary">Filtrele</button>
+    </form>
+  </div>
+
+  <div class="table-responsive">
+    <table class="table table-sm align-middle">
+      <thead class="table-light">
+        <tr>
+          <th style="width:48px;">Gör</th>
+          <th>ID</th>
+          <th>Marka</th>
+          <th>Model</th>
+          <th>Seri No</th>
+          <th>Fabrika</th>
+          <th>Kullanım Alanı</th>
+          <th>Sorumlu</th>
+          <th>Bağlı Env.</th>
+          <th>Durum</th>
+          <th style="width:220px;">İşlemler</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for p in printers %}
+        <tr data-id="{{ p.id }}">
+          <td>
+            <a class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center justify-content-center" style="width:36px;height:36px;" href="/printers/{{ p.id }}" title="Görüntüle">
+              <i class="bi bi-eye"></i>
+            </a>
+          </td>
+          <td>#{{ p.id }}</td>
+          <td>{{ p.marka or '-' }}</td>
+          <td>{{ p.model or '-' }}</td>
+          <td>{{ p.seri_no or '-' }}</td>
+          <td>{{ p.fabrika or '-' }}</td>
+          <td>{{ p.kullanim_alani or '-' }}</td>
+          <td>{{ p.sorumlu_personel or '-' }}</td>
+          <td>{{ p.bagli_envanter_no or '-' }}</td>
+          <td>
+            {% if p.durum == 'hurda' %}
+              <span class="badge text-bg-secondary">Hurda</span>
+            {% else %}
+              <span class="badge text-bg-success">Aktif</span>
+            {% endif %}
+          </td>
+          <td>
+            <div class="d-flex flex-wrap gap-2">
+              <select class="form-select form-select-sm action-select" style="min-width:160px;">
+                <option value="">İşlem seçin…</option>
+                <option value="assign">Atama Yap</option>
+                <option value="edit">Düzenle</option>
+                <option value="scrap">Hurdaya Ayır</option>
+              </select>
+              <button class="btn btn-sm btn-primary action-go">Git</button>
+            </div>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- ATAMA MODAL -->
+<div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable">
+    <form class="modal-content" id="assignForm">
+      <div class="modal-header">
+        <h6 class="modal-title">Atama Yap — <span id="assignPrinterLabel"></span></h6>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" id="assignPrinterId" name="printer_id">
+
+        <div class="mb-2">
+          <label class="form-label">Fabrika</label>
+          <select id="selFabrika" name="fabrika" class="form-select">
+            <option value="">Seçiniz</option>
+            {% for f in factories %}<option value="{{ f }}">{{ f }}</option>{% endfor %}
+          </select>
+        </div>
+
+        <div class="mb-2">
+          <label class="form-label">Kullanım Alanı</label>
+          <select id="selKullanim" name="kullanim_alani" class="form-select">
+            <option value="">Seçiniz</option>
+            {% for a in areas %}<option value="{{ a }}">{{ a }}</option>{% endfor %}
+          </select>
+        </div>
+
+        <div class="mb-2">
+          <label class="form-label">Sorumlu Personel</label>
+          <select id="selPersonel" name="sorumlu_personel" class="form-select">
+            <option value="">Seçiniz</option>
+            {% for u in users %}<option value="{{ u }}">{{ u }}</option>{% endfor %}
+          </select>
+        </div>
+
+        <div class="mb-2">
+          <label class="form-label">Bağlı Olduğu Envanter</label>
+          <select id="selBagliEnv" name="bagli_envanter_no" class="form-select">
+            <option value="">Seçiniz</option>
+            {% for inv in inventory_nos %}<option value="{{ inv }}">{{ inv }}</option>{% endfor %}
+          </select>
+        </div>
+
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" type="button" data-bs-dismiss="modal">İptal</button>
+        <button class="btn btn-success" type="submit">Atamayı Kaydet</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
+<script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+<script>
+(function(){
+  const assignModalEl = document.getElementById('assignModal');
+  const assignModal = new bootstrap.Modal(assignModalEl);
+  const assignForm = document.getElementById('assignForm');
+
+  document.querySelectorAll('.action-go').forEach(btn => {
+    btn.addEventListener('click', function(){
+      const tr = this.closest('tr');
+      const printerId = tr.dataset.id;
+      const sel = tr.querySelector('.action-select');
+      const val = sel.value;
+
+      if(!val){ sel.classList.add('is-invalid'); setTimeout(()=>sel.classList.remove('is-invalid'), 1200); return; }
+
+      if(val === 'edit'){
+        window.location.href = `/printers/edit/${printerId}`;
+        return;
+      }
+      if(val === 'assign'){
+        document.getElementById('assignPrinterId').value = printerId;
+        document.getElementById('assignPrinterLabel').innerText = `#${printerId}`;
+        assignModal.show();
+        return;
+      }
+      if(val === 'scrap'){
+        if(!confirm('Bu yazıcıyı hurdaya ayırmak istiyor musunuz?')) return;
+        const formData = new FormData();
+        formData.append('reason','İşlemler menüsünden hurdaya ayrıldı');
+        fetch(`/printers/scrap/${printerId}`, { method: 'POST', body: formData })
+          .then(r => r.json()).then(j => { if(j.ok){ location.reload(); } else { alert('İşlem başarısız'); } })
+          .catch(() => alert('Sunucu hatası'));
+      }
+    });
+  });
+
+  assignForm.addEventListener('submit', function(e){
+    e.preventDefault();
+    const pid = document.getElementById('assignPrinterId').value;
+    const formData = new FormData(assignForm);
+    fetch(`/printers/assign/${pid}`, { method: 'POST', body: formData })
+      .then(r => r.json()).then(j => {
+        if(j.ok){ assignModal.hide(); location.reload(); }
+        else{ alert('Atama kaydedilemedi.'); }
+      }).catch(()=> alert('Sunucu hatası'));
+  });
+
+  ['selFabrika','selKullanim','selPersonel','selBagliEnv'].forEach(id => {
+    const el = document.getElementById(id);
+    if(el){ new Choices(el, { removeItemButton: true, searchEnabled: true, shouldSort: false }); }
+  });
+})();
+</script>
+{% endblock %}
+

--- a/templates/printers_scrap.html
+++ b/templates/printers_scrap.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% block title %}Hurdalar{% endblock %}
+{% block content %}
+<div class="container-fluid p-3">
+  <h5 class="mb-3">Hurdalar</h5>
+  <div class="table-responsive">
+    <table class="table table-sm align-middle">
+      <thead class="table-light">
+        <tr>
+          <th>ID</th>
+          <th>Marka/Model</th>
+          <th>Seri</th>
+          <th>Fabrika</th>
+          <th>Kullanım Alanı</th>
+          <th>Sorumlu</th>
+          <th>Bağlı Env.</th>
+          <th>Tarih</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% if mode == "table" %}
+        {% for r in rows %}
+        <tr>
+          <td>#{{ r.printer_id }}</td>
+          <td>{{ r.snapshot.marka }} {{ r.snapshot.model }}</td>
+          <td>{{ r.snapshot.seri_no }}</td>
+          <td>{{ r.snapshot.fabrika or '-' }}</td>
+          <td>{{ r.snapshot.kullanim_alani or '-' }}</td>
+          <td>{{ r.snapshot.sorumlu_personel or '-' }}</td>
+          <td>{{ r.snapshot.bagli_envanter_no or '-' }}</td>
+          <td>{{ r.created_at.strftime("%d.%m.%Y %H:%M") }}</td>
+        </tr>
+        {% endfor %}
+      {% else %}
+        {% for p in rows %}
+        <tr>
+          <td>#{{ p.id }}</td>
+          <td>{{ p.marka }} {{ p.model }}</td>
+          <td>{{ p.seri_no }}</td>
+          <td>{{ p.fabrika or '-' }}</td>
+          <td>{{ p.kullanim_alani or '-' }}</td>
+          <td>{{ p.sorumlu_personel or '-' }}</td>
+          <td>{{ p.bagli_envanter_no or '-' }}</td>
+          <td>-</td>
+        </tr>
+        {% endfor %}
+      {% endif %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- overhaul printer model to include assignment fields, histories, and scrap snapshots
- add printer management router and templates for listing, editing, and scrapping
- register scrap listing router and provide SQL migration for legacy databases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac455d2900832b8fd3d581ac820352