### PR TITLE
Fix missing endif in admin_panel template

### DIFF
--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -280,6 +280,8 @@
 
 </div>
 
+{% endif %}
+
 <style>
   .nav-tabs .nav-link.active { font-weight:600; }
   .nav-pills .nav-link { padding:.25rem .75rem; }


### PR DESCRIPTION
## Summary
- close `if sub=='kullanicilar'` block in admin panel template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac48c7e91c832bb5e6cf667afc7624