### PR TITLE
Fix product box visibility in admin panel

### DIFF
--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -30,7 +30,7 @@
   <nav class="small text-muted mt-3 mb-2">Admin » Ürün Ekle</nav>
 
   <!-- ÜRÜN EKLE KUTUSU (REFERANS TABLOLARI) -->
-  <div class="collapse" id="productBox">
+  <div class="collapse show" id="productBox">
     <div class="row g-3">
 
       <!-- Kullanım Alanı -->


### PR DESCRIPTION
## Summary
- Ensure product reference cards are visible when viewing the Admin » Ürün Ekle page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ac4b905358832bbec24f5199c7ba3c