### PR TITLE
Fix admin panel route conflict

### DIFF
--- a/routers/panel.py
+++ b/routers/panel.py
@@ -3,7 +3,10 @@ from fastapi.responses import HTMLResponse
 
 router = APIRouter()
 
-@router.get("/admin", response_class=HTMLResponse)
+# /admin rotasının admin router'ı tarafından
+# kullanılabilmesi için bu paneli farklı bir
+# adrese taşıyoruz.
+@router.get("/panel", response_class=HTMLResponse)
 async def admin_panel(request: Request, sub: str = "urun"):
     return request.app.state.templates.TemplateResponse(
         "admin_panel.html",


### PR DESCRIPTION
## Summary
- Move legacy panel route to `/panel` so `/admin` uses DB-backed handler

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac5223de54832b93dd3406b4f3994d