### PR TITLE
Normalize lookup API responses

### DIFF
--- a/routers/lookup.py
+++ b/routers/lookup.py
@@ -20,7 +20,7 @@ ENTITY_TABLE = {
 @router.get("/{entity}")
 def lookup_list(
     entity: str,
-    q: str = Query(""),
+    q: str = Query(default=""),
     limit: int = 50,
     marka_id: int | None = None,
     db: Session = Depends(get_db),
@@ -42,4 +42,8 @@ def lookup_list(
     where_sql = (" WHERE " + " AND ".join(where)) if where else ""
     sql = text(f"SELECT id, name FROM {table}{where_sql} ORDER BY name LIMIT :limit")
     rows = db.execute(sql, params).mappings().all()
-    return [{"id": r["id"], "text": r["name"]} for r in rows]
+    # API'ler genellikle {id, name} döndürür; "text" gibi farklı anahtarlar
+    # istemcilerde karışıklığa yol açıyordu. Tutarlılık için "name" alanı
+    # döndürüyoruz ve eski "text" beklentisi olan istemcilerde de sorun
+    # yaşanmaması için çağrı tarafında gerekli uyarlamayı yapıyoruz.
+    return [{"id": r["id"], "name": r["name"]} for r in rows]

--- a/static/js/picker.js
+++ b/static/js/picker.js
@@ -34,7 +34,7 @@
     const r = await fetch(`/api/lookup/${current.entity}?` + params.toString());
     const data = r.ok ? await r.json() : [];
     list.innerHTML = data.map(x =>
-      `<button type="button" class="list-group-item list-group-item-action" data-id="${x.id}" data-ad="${x.text ?? x.ad}">${x.text ?? x.ad}</button>`
+      `<button type="button" class="list-group-item list-group-item-action" data-id="${x.id}" data-ad="${x.text ?? x.ad ?? x.name}">${x.text ?? x.ad ?? x.name}</button>`
     ).join("");
     [...list.children].forEach(btn=>{
       btn.addEventListener("click", ()=>{
@@ -62,7 +62,7 @@
     });
     if (!r.ok){ alert("Kaydedilemedi"); return; }
     const data = await r.json();
-    current.targetText.value = data.text ?? data.ad;
+    current.targetText.value = data.text ?? data.ad ?? data.name;
     if (current.targetId) current.targetId.value   = data.id;
     closeModal();
   });

--- a/templates/product_add.html
+++ b/templates/product_add.html
@@ -15,13 +15,13 @@
 async function fillSelect(url, selectEl, placeholder = "Seçiniz") {
   const res = await fetch(url);
   if (!res.ok) return;
-  const data = await res.json(); // [{id, text}]
+  const data = await res.json(); // [{id, name}]
   selectEl.innerHTML = `<option value="">${placeholder}</option>` +
-    data.map(x => `<option value="${x.id}">${x.text}</option>`).join("");
+    data.map(x => `<option value="${x.id}">${x.name ?? x.text}</option>`).join("");
   // Choices.js kullanıyorsan:
   if (selectEl._choicesInstance) {
     selectEl._choicesInstance.setChoices(
-      data.map(x => ({ value: x.id, label: x.text })), 'value', 'label', true
+      data.map(x => ({ value: x.id, label: x.name ?? x.text })), 'value', 'label', true
     );
   }
 }


### PR DESCRIPTION
## Summary
- standardize lookup API to return `{id, name}` objects instead of `{id, text}`
- update product form select helper to handle `name` field
- adjust picker widget to read `name` values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac530f6ff4832b86188a6a2a5be7ff