### PR TITLE
Add plus buttons to tracking pages

### DIFF
--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -2,7 +2,12 @@
 {% block title %}Envanter Listesi{% endblock %}
 {% block content %}
 <div class="container-fluid p-2">
-  <h5 class="mb-3">Envanter</h5>
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <h5 class="mb-0">Envanter</h5>
+    <a href="/inventory/new" class="btn btn-success btn-sm" title="Yeni Ekle">
+      <i class="bi bi-plus-lg"></i>
+    </a>
+  </div>
 
   <table class="table table-sm table-striped align-middle">
     <thead>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -2,7 +2,12 @@
 {% block title %}Lisans Takip{% endblock %}
 {% block content %}
 <div class="container-fluid p-2 content">
-  <h5 class="mb-3">Lisans</h5>
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <h5 class="mb-0">Lisans</h5>
+    <a href="/lisans/new" class="btn btn-success btn-sm" title="Yeni Ekle">
+      <i class="bi bi-plus-lg"></i>
+    </a>
+  </div>
   <div class="table-responsive">
     <table class="table table-sm align-middle">
       <thead>

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -4,7 +4,12 @@
 {% block content %}
 <div class="container-fluid p-3">
   <div class="d-flex align-items-center justify-content-between mb-3">
-    <h5 class="mb-0">Yazıcılar</h5>
+    <div class="d-flex align-items-center gap-2">
+      <h5 class="mb-0">Yazıcılar</h5>
+      <a href="/printers/new" class="btn btn-success btn-sm" title="Yeni Ekle">
+        <i class="bi bi-plus-lg"></i>
+      </a>
+    </div>
     <form method="get" class="d-flex gap-2">
       <input type="text" name="q" value="{{ request.query_params.get('q','') }}" class="form-control form-control-sm" placeholder="Ara...">
       <select name="durum" class="form-select form-select-sm">

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -6,6 +6,9 @@
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h5 class="mb-0">Stok Logları (En Güncel)</h5>
     <div class="d-flex gap-2">
+      <a href="/stock/new" class="btn btn-success btn-sm" title="Yeni Ekle">
+        <i class="bi bi-plus-lg"></i>
+      </a>
       <button id="btnDurum" class="btn btn-outline-primary btn-sm">Stock Durumu</button>
       <button id="btnAtama" class="btn btn-primary btn-sm">Atama</button>
     </div>


### PR DESCRIPTION
## Summary
- add green plus button linking to new entry on inventory list
- add add-entry button to stock log page
- add add-entry button to printer list
- add add-entry button to license list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac5637e4b4832b892840564fce4813