### PR TITLE
Add inventory creation form with automatic metadata

### DIFF
--- a/models.py
+++ b/models.py
@@ -69,6 +69,8 @@ class Inventory(Base):
     bagli_envanter_no: Mapped[str | None] = mapped_column(String(150))
     kullanim_alani: Mapped[str | None] = mapped_column(String(150))
     ifs_no: Mapped[str | None] = mapped_column(String(150))
+    tarih: Mapped[datetime | None] = mapped_column(DateTime, default=datetime.utcnow)
+    islem_yapan: Mapped[str | None] = mapped_column(String(150))
     durum: Mapped[str | None] = mapped_column(String(50), default="aktif")
     not_: Mapped[str | None] = mapped_column("not", Text)
 
@@ -95,6 +97,8 @@ class Inventory(Base):
             "model": self.model,
             "kullanim_alani": self.kullanim_alani,
             "ifs_no": self.ifs_no,
+            "tarih": self.tarih,
+            "islem_yapan": self.islem_yapan,
             "durum": self.durum,
             "not": self.not_,
         }

--- a/templates/inventory_new.html
+++ b/templates/inventory_new.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+{% block title %}Envanter Ekle{% endblock %}
+{% block content %}
+<div class="container-fluid p-3">
+  <h5 class="mb-3">Envanter Ekle</h5>
+  <form method="post">
+    <div class="row g-3">
+      <div class="col-md-3">
+        <label class="form-label">Fabrika</label>
+        <select id="selFabrika" class="form-select"></select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Departman</label>
+        <select id="selDepartman" class="form-select"></select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Donanım Tipi</label>
+        <select id="selDonanim" class="form-select"></select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Bilgisayar Adı</label>
+        <input name="bilgisayar_adi" class="form-control">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Marka</label>
+        <select id="selMarka" class="form-select"></select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Model</label>
+        <select id="selModel" class="form-select"></select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Seri No</label>
+        <input name="seri_no" class="form-control">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Sorumlu Personel</label>
+        <select id="selSorumlu" name="sorumlu_personel" class="form-select"></select>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Bağlı Envanter No</label>
+        <input name="bagli_envanter_no" class="form-control">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">IFS No</label>
+        <input name="ifs_no" class="form-control">
+      </div>
+      <div class="col-md-12">
+        <label class="form-label">Not</label>
+        <textarea name="not" class="form-control"></textarea>
+      </div>
+    </div>
+    <div class="mt-3">
+      <button class="btn btn-primary btn-sm">Kaydet</button>
+      <a href="/inventory" class="btn btn-outline-secondary btn-sm">İptal</a>
+    </div>
+  </form>
+</div>
+{% include "_catalog_select.js" %}
+<script>
+document.addEventListener('DOMContentLoaded', async () => {
+  await basitSelectDoldur({selectId:'selFabrika', url:'/api/lookup/fabrika', hiddenName:'fabrika', placeholder:'Fabrika seçiniz…'});
+  await basitSelectDoldur({selectId:'selDepartman', url:'/api/lookup/kullanim-alani', hiddenName:'departman', placeholder:'Departman seçiniz…'});
+  await basitSelectDoldur({selectId:'selDonanim', url:'/api/lookup/donanim-tipi', hiddenName:'donanim_tipi', placeholder:'Donanım tipi seçiniz…'});
+  await basitSelectDoldur({selectId:'selMarka', url:'/api/lookup/marka', hiddenName:'marka', placeholder:'Marka seçiniz…'});
+  bağımlıSelectDoldur({ustSelectId:'selMarka', altSelectId:'selModel', altUrlBuilder:(id)=>`/api/lookup/model?marka_id=${id}`, altHiddenName:'model'});
+  const users = await fetch('/inventory/assign/sources?type=users').then(r=>r.json());
+  const selSorumlu = document.getElementById('selSorumlu');
+  selSorumlu.innerHTML = '<option value="">Seçiniz…</option>' + users.map(u => `<option value="${u.text}">${u.text}</option>`).join('');
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- extend `Inventory` model with `tarih` and `islem_yapan` fields to capture creation info
- add `/inventory/new` routes and template to create inventory records
- populate creation form with factory, department, hardware type and user options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac5932e118832badf7f9a7d01d935b