### PR TITLE
Fix inventory assignment dropdown and scrap listing

### DIFF
--- a/templates/hurdalar.html
+++ b/templates/hurdalar.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container-fluid p-3">
   <h3>Hurdalar</h3>
-  <table class="table table-striped">
+  <table class="table table-striped align-top">
     <thead>
       <tr>
         <th>Envanter No</th>
@@ -12,6 +12,7 @@
         <th>Seri No</th>
         <th>Departman</th>
         <th>Tarih</th>
+        <th>Loglar</th>
       </tr>
     </thead>
     <tbody>
@@ -23,6 +24,15 @@
         <td>{{ item.seri_no }}</td>
         <td>{{ item.departman }}</td>
         <td>{{ item.tarih }}</td>
+        <td>
+          <ul class="mb-0 small">
+            {% for log in logs_map[item.id] %}
+            <li>{{ log.created_at }} – {{ log.action }} – {{ log.note }}</li>
+            {% else %}
+            <li class="text-muted">Log yok</li>
+            {% endfor %}
+          </ul>
+        </td>
       </tr>
       {% endfor %}
     </tbody>

--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -1,5 +1,50 @@
-{% extends "base.html" %}{% block title %}Envanter – Düzenle{% endblock %}
+{% extends "base.html" %}{% block title %}Envanter Düzenle{% endblock %}
 {% block content %}
-<h2 class="h5 mb-3">Düzenle (ID: {{ item_id }})</h2>
-<form class="card p-3">Form alanları...</form>
+<div class="container-fluid p-3">
+  <h5 class="mb-3">Envanter Düzenle</h5>
+  <form method="post">
+    <div class="row g-3">
+      <div class="col-md-3">
+        <label class="form-label">Fabrika</label>
+        <input name="fabrika" class="form-control" value="{{ item.fabrika or '' }}">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Departman</label>
+        <input name="departman" class="form-control" value="{{ item.departman or '' }}">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Sorumlu Personel</label>
+        <input name="sorumlu_personel" class="form-control" value="{{ item.sorumlu_personel or '' }}">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Bağlı Envanter No</label>
+        <input name="bagli_envanter_no" class="form-control" value="{{ item.bagli_envanter_no or '' }}">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Marka</label>
+        <input name="marka" class="form-control" value="{{ item.marka or '' }}">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Model</label>
+        <input name="model" class="form-control" value="{{ item.model or '' }}">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Kullanım Alanı</label>
+        <input name="kullanim_alani" class="form-control" value="{{ item.kullanim_alani or '' }}">
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">IFS No</label>
+        <input name="ifs_no" class="form-control" value="{{ item.ifs_no or '' }}">
+      </div>
+      <div class="col-md-12">
+        <label class="form-label">Not</label>
+        <textarea name="not" class="form-control">{{ item.not_ or '' }}</textarea>
+      </div>
+    </div>
+    <div class="mt-3">
+      <button class="btn btn-primary btn-sm">Kaydet</button>
+      <a href="{{ url_for('inventory.list') }}" class="btn btn-outline-secondary btn-sm">İptal</a>
+    </div>
+  </form>
+</div>
 {% endblock %}

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -159,7 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function fillSelect(id, arr) {
     const el = document.getElementById(id);
     el.innerHTML = '<option value="">Seçiniz</option>' + arr.map(x =>
-      `<option value="${x.value}">${x.label}</option>`).join('');
+      `<option value="${x.id}">${x.text}</option>`).join('');
   }
 
   // Atama submit


### PR DESCRIPTION
## Summary
- ensure scrap items are excluded from inventory list and include logs on scrap page
- fix inventory assignment dropdown data loading
- add full edit form for inventory items

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac5de560e8832ba5b5059c1e564a16