### PR TITLE
Add dynamic filter builder to inventory, license, and printer lists

### DIFF
--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -90,26 +90,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
-        <div class="mb-2">
-          <label class="form-label">Envanter No</label>
-          <input type="text" name="no" class="form-control form-control-sm">
-        </div>
-        <div class="mb-2">
-          <label class="form-label">Fabrika</label>
-          <input type="text" name="fabrika" class="form-control form-control-sm">
-        </div>
-        <div class="mb-2">
-          <label class="form-label">Departman</label>
-          <input type="text" name="departman" class="form-control form-control-sm">
-        </div>
-        <div class="mb-2">
-          <label class="form-label">Sorumlu</label>
-          <input type="text" name="sorumlu" class="form-control form-control-sm">
-        </div>
-        <div class="mb-2">
-          <label class="form-label">Marka/Model</label>
-          <input type="text" name="marka" class="form-control form-control-sm">
-        </div>
+        <div id="filterRows"></div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Kapat</button>
@@ -188,7 +169,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const searchInput = document.getElementById('searchInput');
   const filterForm  = document.getElementById('filterForm');
   const clearBtn    = document.getElementById('clearFilterBtn');
-  const activeFilters = {};
+  const filterRowsDiv = document.getElementById('filterRows');
+  let activeFilters = [];
+  const columns = Array.from(document.querySelectorAll('table thead th'))
+    .map((th, idx) => ({ idx, name: th.textContent.trim() }))
+    .filter(c => c.name && c.name !== 'İşlemler');
 
   document.getElementById('addBtn').addEventListener('click', () => {
     document.getElementById('addFrame').src = '/inventory/new';
@@ -197,27 +182,63 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('filterBtn').addEventListener('click', () => {
     filterForm.reset();
+    filterRowsDiv.innerHTML = '';
+    createFilterRow();
     filterModal.show();
   });
 
   clearBtn.addEventListener('click', () => {
-    Object.keys(activeFilters).forEach(k => delete activeFilters[k]);
-    filterForm.reset();
+    activeFilters = [];
     filterRows();
     clearBtn.classList.add('d-none');
   });
 
   searchInput.addEventListener('input', filterRows);
 
+  function createFilterRow() {
+    const row = document.createElement('div');
+    row.className = 'row g-2 align-items-center mb-2 filter-row';
+    row.innerHTML = `
+      <div class="col-5">
+        <select class="form-select form-select-sm column-select">
+          ${columns.map(c => `<option value="${c.idx}">${c.name}</option>`).join('')}
+        </select>
+      </div>
+      <div class="col-5">
+        <input type="text" class="form-control form-control-sm value-input">
+      </div>
+      <div class="col-2 d-flex gap-1">
+        <button type="button" class="btn btn-success btn-sm add-row">+</button>
+        <button type="button" class="btn btn-danger btn-sm remove-row">-</button>
+      </div>`;
+    filterRowsDiv.appendChild(row);
+    updateRemoveButtons();
+  }
+
+  function updateRemoveButtons() {
+    const rows = filterRowsDiv.querySelectorAll('.filter-row');
+    rows.forEach(r => r.querySelector('.remove-row').classList.toggle('d-none', rows.length === 1));
+  }
+
+  filterForm.addEventListener('click', (e) => {
+    if (e.target.classList.contains('add-row')) {
+      createFilterRow();
+    } else if (e.target.classList.contains('remove-row')) {
+      e.target.closest('.filter-row').remove();
+      updateRemoveButtons();
+    }
+  });
+
   filterForm.addEventListener('submit', (e) => {
     e.preventDefault();
-    const fd = new FormData(filterForm);
-    ['no','fabrika','departman','sorumlu','marka'].forEach(k => {
-      const v = (fd.get(k) || '').trim().toLowerCase();
-      if (v) activeFilters[k] = v; else delete activeFilters[k];
+    activeFilters = [];
+    filterRowsDiv.querySelectorAll('.filter-row').forEach(row => {
+      const col = parseInt(row.querySelector('.column-select').value, 10);
+      const val = row.querySelector('.value-input').value.trim().toLowerCase();
+      if (val) activeFilters.push({ col, val });
     });
     filterModal.hide();
-    clearBtn.classList.toggle('d-none', Object.keys(activeFilters).length === 0);
+    clearBtn.classList.toggle('d-none', activeFilters.length === 0);
     filterRows();
   });
 
@@ -227,11 +248,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const cells = tr.querySelectorAll('td');
       const texts = Array.from(cells).map(td => td.textContent.toLowerCase());
       let match = texts.some(t => t.includes(q));
-      if (activeFilters.no) match = match && texts[1].includes(activeFilters.no);
-      if (activeFilters.fabrika) match = match && texts[2].includes(activeFilters.fabrika);
-      if (activeFilters.departman) match = match && texts[3].includes(activeFilters.departman);
-      if (activeFilters.sorumlu) match = match && texts[4].includes(activeFilters.sorumlu);
-      if (activeFilters.marka) match = match && texts[5].includes(activeFilters.marka);
+      if (activeFilters.length) {
+        match = match && activeFilters.every(f => texts[f.col] && texts[f.col].includes(f.val));
+      }
       tr.classList.toggle('d-none', !match);
     });
   }

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -3,10 +3,17 @@
 {% block content %}
 <div class="container-fluid p-2 content">
   <div class="d-flex align-items-center justify-content-between mb-3">
-    <h5 class="mb-0">Lisans</h5>
-    <a href="/lisans/new" class="btn btn-success btn-sm" title="Yeni Ekle">
-      <i class="bi bi-plus-lg"></i>
-    </a>
+    <div class="d-flex align-items-center gap-2">
+      <a href="/lisans/new" class="btn btn-success btn-sm" title="Yeni Ekle">
+        <i class="bi bi-plus-lg"></i>
+      </a>
+      <h5 class="mb-0">Lisans</h5>
+    </div>
+    <div class="d-flex align-items-center gap-2">
+      <button class="btn btn-outline-secondary btn-sm" id="filterBtn">Filtre</button>
+      <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">Temizle</button>
+      <input type="text" id="searchInput" class="form-control form-control-sm" placeholder="Ara...">
+    </div>
   </div>
   <div class="table-responsive">
     <table class="table table-sm align-middle">
@@ -65,6 +72,25 @@
   </div>
 </div>
 
+<!-- Filtre Modal -->
+<div class="modal fade" id="filterModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="filterForm" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Filtrele</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div id="filterRows"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Kapat</button>
+        <button type="submit" class="btn btn-primary btn-sm">Uygula</button>
+      </div>
+    </form>
+  </div>
+</div>
+
 <!-- ATAMA MODALI -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
@@ -102,7 +128,93 @@
 </div>
 
 <script>
-  document.addEventListener("DOMContentLoaded", function() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const filterModal = new bootstrap.Modal(document.getElementById('filterModal'));
+    const searchInput = document.getElementById('searchInput');
+    const filterForm = document.getElementById('filterForm');
+    const clearBtn = document.getElementById('clearFilterBtn');
+    const filterRowsDiv = document.getElementById('filterRows');
+    let activeFilters = [];
+    const columns = Array.from(document.querySelectorAll('table thead th'))
+      .map((th, idx) => ({ idx, name: th.textContent.trim() }))
+      .filter(c => c.name && !['Detay', 'İşlemler'].includes(c.name));
+
+    document.getElementById('filterBtn').addEventListener('click', () => {
+      filterForm.reset();
+      filterRowsDiv.innerHTML = '';
+      createFilterRow();
+      filterModal.show();
+    });
+
+    clearBtn.addEventListener('click', () => {
+      activeFilters = [];
+      filterRows();
+      clearBtn.classList.add('d-none');
+    });
+
+    searchInput.addEventListener('input', filterRows);
+
+    function createFilterRow() {
+      const row = document.createElement('div');
+      row.className = 'row g-2 align-items-center mb-2 filter-row';
+      row.innerHTML = `
+        <div class="col-5">
+          <select class="form-select form-select-sm column-select">
+            ${columns.map(c => `<option value="${c.idx}">${c.name}</option>`).join('')}
+          </select>
+        </div>
+        <div class="col-5">
+          <input type="text" class="form-control form-control-sm value-input">
+        </div>
+        <div class="col-2 d-flex gap-1">
+          <button type="button" class="btn btn-success btn-sm add-row">+</button>
+          <button type="button" class="btn btn-danger btn-sm remove-row">-</button>
+        </div>`;
+      filterRowsDiv.appendChild(row);
+      updateRemoveButtons();
+    }
+
+    function updateRemoveButtons() {
+      const rows = filterRowsDiv.querySelectorAll('.filter-row');
+      rows.forEach(r => r.querySelector('.remove-row').classList.toggle('d-none', rows.length === 1));
+    }
+
+    filterForm.addEventListener('click', (e) => {
+      if (e.target.classList.contains('add-row')) {
+        createFilterRow();
+      } else if (e.target.classList.contains('remove-row')) {
+        e.target.closest('.filter-row').remove();
+        updateRemoveButtons();
+      }
+    });
+
+    filterForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      activeFilters = [];
+      filterRowsDiv.querySelectorAll('.filter-row').forEach(row => {
+        const col = parseInt(row.querySelector('.column-select').value, 10);
+        const val = row.querySelector('.value-input').value.trim().toLowerCase();
+        if (val) activeFilters.push({ col, val });
+      });
+      filterModal.hide();
+      clearBtn.classList.toggle('d-none', activeFilters.length === 0);
+      filterRows();
+    });
+
+    function filterRows() {
+      const q = searchInput.value.toLowerCase();
+      document.querySelectorAll('tbody tr').forEach(tr => {
+        const cells = tr.querySelectorAll('td');
+        const texts = Array.from(cells).map(td => td.textContent.toLowerCase());
+        let match = texts.some(t => t.includes(q));
+        if (activeFilters.length) {
+          match = match && activeFilters.every(f => texts[f.col] && texts[f.col].includes(f.val));
+        }
+        tr.classList.toggle('d-none', !match);
+      });
+    }
+
+    // Mevcut atama/hurda işlemleri
     const assignModal = new bootstrap.Modal(document.getElementById('assignModal'));
     const assignForm  = document.getElementById('assignForm');
 
@@ -133,8 +245,8 @@
     });
 
     if (window.Choices) {
-      new Choices("#selPersonel", { searchEnabled: true, shouldSort: false });
-      new Choices("#selBagli", { searchEnabled: true, shouldSort: false });
+      new Choices('#selPersonel', { searchEnabled: true, shouldSort: false });
+      new Choices('#selBagli', { searchEnabled: true, shouldSort: false });
     }
   });
 </script>

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -5,20 +5,16 @@
 <div class="container-fluid p-3">
   <div class="d-flex align-items-center justify-content-between mb-3">
     <div class="d-flex align-items-center gap-2">
-      <h5 class="mb-0">Yazıcılar</h5>
       <a href="/printers/new" class="btn btn-success btn-sm" title="Yeni Ekle">
         <i class="bi bi-plus-lg"></i>
       </a>
+      <h5 class="mb-0">Yazıcılar</h5>
     </div>
-    <form method="get" class="d-flex gap-2">
-      <input type="text" name="q" value="{{ request.query_params.get('q','') }}" class="form-control form-control-sm" placeholder="Ara...">
-      <select name="durum" class="form-select form-select-sm">
-        <option value="">Tümü</option>
-        <option value="aktif" {% if request.query_params.get('durum')=='aktif' %}selected{% endif %}>Aktif</option>
-        <option value="hurda" {% if request.query_params.get('durum')=='hurda' %}selected{% endif %}>Hurda</option>
-      </select>
-      <button class="btn btn-sm btn-primary">Filtrele</button>
-    </form>
+    <div class="d-flex align-items-center gap-2">
+      <button class="btn btn-outline-secondary btn-sm" id="filterBtn">Filtre</button>
+      <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">Temizle</button>
+      <input type="text" id="searchInput" class="form-control form-control-sm" placeholder="Ara...">
+    </div>
   </div>
 
   <div class="table-responsive">
@@ -79,6 +75,25 @@
   </div>
 </div>
 
+<!-- Filtre Modal -->
+<div class="modal fade" id="filterModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="filterForm" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Filtrele</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div id="filterRows"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Kapat</button>
+        <button type="submit" class="btn btn-primary btn-sm">Uygula</button>
+      </div>
+    </form>
+  </div>
+</div>
+
 <!-- ATAMA MODAL -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-scrollable">
@@ -136,7 +151,93 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
 <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
 <script>
-(function(){
+document.addEventListener('DOMContentLoaded', () => {
+  const filterModal = new bootstrap.Modal(document.getElementById('filterModal'));
+  const searchInput = document.getElementById('searchInput');
+  const filterForm = document.getElementById('filterForm');
+  const clearBtn = document.getElementById('clearFilterBtn');
+  const filterRowsDiv = document.getElementById('filterRows');
+  let activeFilters = [];
+  const columns = Array.from(document.querySelectorAll('table thead th'))
+    .map((th, idx) => ({ idx, name: th.textContent.trim() }))
+    .filter(c => c.name && !['Gör', 'İşlemler'].includes(c.name));
+
+  document.getElementById('filterBtn').addEventListener('click', () => {
+    filterForm.reset();
+    filterRowsDiv.innerHTML = '';
+    createFilterRow();
+    filterModal.show();
+  });
+
+  clearBtn.addEventListener('click', () => {
+    activeFilters = [];
+    filterRows();
+    clearBtn.classList.add('d-none');
+  });
+
+  searchInput.addEventListener('input', filterRows);
+
+  function createFilterRow() {
+    const row = document.createElement('div');
+    row.className = 'row g-2 align-items-center mb-2 filter-row';
+    row.innerHTML = `
+      <div class="col-5">
+        <select class="form-select form-select-sm column-select">
+          ${columns.map(c => `<option value="${c.idx}">${c.name}</option>`).join('')}
+        </select>
+      </div>
+      <div class="col-5">
+        <input type="text" class="form-control form-control-sm value-input">
+      </div>
+      <div class="col-2 d-flex gap-1">
+        <button type="button" class="btn btn-success btn-sm add-row">+</button>
+        <button type="button" class="btn btn-danger btn-sm remove-row">-</button>
+      </div>`;
+    filterRowsDiv.appendChild(row);
+    updateRemoveButtons();
+  }
+
+  function updateRemoveButtons() {
+    const rows = filterRowsDiv.querySelectorAll('.filter-row');
+    rows.forEach(r => r.querySelector('.remove-row').classList.toggle('d-none', rows.length === 1));
+  }
+
+  filterForm.addEventListener('click', (e) => {
+    if (e.target.classList.contains('add-row')) {
+      createFilterRow();
+    } else if (e.target.classList.contains('remove-row')) {
+      e.target.closest('.filter-row').remove();
+      updateRemoveButtons();
+    }
+  });
+
+  filterForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    activeFilters = [];
+    filterRowsDiv.querySelectorAll('.filter-row').forEach(row => {
+      const col = parseInt(row.querySelector('.column-select').value, 10);
+      const val = row.querySelector('.value-input').value.trim().toLowerCase();
+      if (val) activeFilters.push({ col, val });
+    });
+    filterModal.hide();
+    clearBtn.classList.toggle('d-none', activeFilters.length === 0);
+    filterRows();
+  });
+
+  function filterRows() {
+    const q = searchInput.value.toLowerCase();
+    document.querySelectorAll('tbody tr').forEach(tr => {
+      const cells = tr.querySelectorAll('td');
+      const texts = Array.from(cells).map(td => td.textContent.toLowerCase());
+      let match = texts.some(t => t.includes(q));
+      if (activeFilters.length) {
+        match = match && activeFilters.every(f => texts[f.col] && texts[f.col].includes(f.val));
+      }
+      tr.classList.toggle('d-none', !match);
+    });
+  }
+
+  // Atama/Hurda işlemleri
   const assignModalEl = document.getElementById('assignModal');
   const assignModal = new bootstrap.Modal(assignModalEl);
   const assignForm = document.getElementById('assignForm');
@@ -186,7 +287,7 @@
     const el = document.getElementById(id);
     if(el){ new Choices(el, { removeItemButton: true, searchEnabled: true, shouldSort: false }); }
   });
-})();
+});
 </script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Convert license and printer lists to use the dynamic filter modal and search
- Support adding/removing multiple column filters with plus/minus controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ad570ad0b0832bbf48d5d0b063eba4