### PR TITLE
Enable dynamic column-based filtering

### DIFF
--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -20,12 +20,11 @@
     <thead>
       <tr>
         <th style="width:42px;"></th> <!-- göz ikonu -->
-        <!-- Örnek kolon başlıkları -->
-        <th>Envanter No</th>
-        <th>Fabrika</th>
-        <th>Departman</th>
-        <th>Sorumlu</th>
-        <th>Marka/Model</th>
+        <th data-field="no">Envanter No</th>
+        <th data-field="fabrika">Fabrika</th>
+        <th data-field="departman">Departman</th>
+        <th data-field="sorumlu_personel">Sorumlu</th>
+        <th data-field="marka">Marka/Model</th>
         <th style="width:180px;">İşlemler</th>
       </tr>
     </thead>
@@ -166,14 +165,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const addModal    = new bootstrap.Modal(document.getElementById('addModal'));
   const filterModal = new bootstrap.Modal(document.getElementById('filterModal'));
 
-  const searchInput = document.getElementById('searchInput');
-  const filterForm  = document.getElementById('filterForm');
-  const clearBtn    = document.getElementById('clearFilterBtn');
+  const searchInput   = document.getElementById('searchInput');
+  const filterForm    = document.getElementById('filterForm');
+  const clearBtn      = document.getElementById('clearFilterBtn');
   const filterRowsDiv = document.getElementById('filterRows');
+  const distinctUrl   = "{{ url_for('lookup.distinct', entity='inventory', column='__COL__') }}";
   let activeFilters = [];
   const columns = Array.from(document.querySelectorAll('table thead th'))
-    .map((th, idx) => ({ idx, name: th.textContent.trim() }))
-    .filter(c => c.name && c.name !== 'İşlemler');
+    .map((th, idx) => ({ idx, name: th.textContent.trim(), field: th.dataset.field }))
+    .filter(c => c.field);
 
   document.getElementById('addBtn').addEventListener('click', () => {
     document.getElementById('addFrame').src = '/inventory/new';
@@ -205,14 +205,26 @@ document.addEventListener('DOMContentLoaded', () => {
         </select>
       </div>
       <div class="col-5">
-        <input type="text" class="form-control form-control-sm value-input">
+        <select class="form-select form-select-sm value-select"></select>
       </div>
       <div class="col-2 d-flex gap-1">
         <button type="button" class="btn btn-success btn-sm add-row">+</button>
         <button type="button" class="btn btn-danger btn-sm remove-row">-</button>
       </div>`;
     filterRowsDiv.appendChild(row);
+    const colSel = row.querySelector('.column-select');
+    const valSel = row.querySelector('.value-select');
+    loadValues(colSel, valSel);
+    colSel.addEventListener('change', () => loadValues(colSel, valSel));
     updateRemoveButtons();
+  }
+
+  async function loadValues(colSelect, valSelect) {
+    const col = columns.find(c => c.idx == colSelect.value);
+    const res = await fetch(distinctUrl.replace('__COL__', col.field));
+    const data = await res.json();
+    valSelect.innerHTML = '<option value="">Seçiniz</option>' +
+      data.map(v => `<option value="${v}">${v}</option>`).join('');
   }
 
   function updateRemoveButtons() {
@@ -234,7 +246,7 @@ document.addEventListener('DOMContentLoaded', () => {
     activeFilters = [];
     filterRowsDiv.querySelectorAll('.filter-row').forEach(row => {
       const col = parseInt(row.querySelector('.column-select').value, 10);
-      const val = row.querySelector('.value-input').value.trim().toLowerCase();
+      const val = row.querySelector('.value-select').value.trim().toLowerCase();
       if (val) activeFilters.push({ col, val });
     });
     filterModal.hide();

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -20,12 +20,12 @@
       <thead>
         <tr>
           <th style="width:42px;">Detay</th>
-          <th>No</th>
-          <th>Lisans Adı</th>
-          <th>Key</th>
-          <th>Sorumlu</th>
-          <th>Bağlı Envanter</th>
-          <th>Durum</th>
+          <th data-field="no">No</th>
+          <th data-field="lisans_adi">Lisans Adı</th>
+          <th data-field="lisans_anahtari">Key</th>
+          <th data-field="sorumlu_personel">Sorumlu</th>
+          <th data-field="bagli_envanter_no">Bağlı Envanter</th>
+          <th data-field="durum">Durum</th>
           <th style="width:170px;">İşlemler</th>
         </tr>
       </thead>
@@ -134,10 +134,11 @@
     const filterForm = document.getElementById('filterForm');
     const clearBtn = document.getElementById('clearFilterBtn');
     const filterRowsDiv = document.getElementById('filterRows');
+    const distinctUrl = "{{ url_for('lookup.distinct', entity='license', column='__COL__') }}";
     let activeFilters = [];
     const columns = Array.from(document.querySelectorAll('table thead th'))
-      .map((th, idx) => ({ idx, name: th.textContent.trim() }))
-      .filter(c => c.name && !['Detay', 'İşlemler'].includes(c.name));
+      .map((th, idx) => ({ idx, name: th.textContent.trim(), field: th.dataset.field }))
+      .filter(c => c.field);
 
     document.getElementById('filterBtn').addEventListener('click', () => {
       filterForm.reset();
@@ -164,14 +165,26 @@
           </select>
         </div>
         <div class="col-5">
-          <input type="text" class="form-control form-control-sm value-input">
+          <select class="form-select form-select-sm value-select"></select>
         </div>
         <div class="col-2 d-flex gap-1">
           <button type="button" class="btn btn-success btn-sm add-row">+</button>
           <button type="button" class="btn btn-danger btn-sm remove-row">-</button>
         </div>`;
       filterRowsDiv.appendChild(row);
+      const colSel = row.querySelector('.column-select');
+      const valSel = row.querySelector('.value-select');
+      loadValues(colSel, valSel);
+      colSel.addEventListener('change', () => loadValues(colSel, valSel));
       updateRemoveButtons();
+    }
+
+    async function loadValues(colSelect, valSelect) {
+      const col = columns.find(c => c.idx == colSelect.value);
+      const res = await fetch(distinctUrl.replace('__COL__', col.field));
+      const data = await res.json();
+      valSelect.innerHTML = '<option value="">Seçiniz</option>' +
+        data.map(v => `<option value="${v}">${v}</option>`).join('');
     }
 
     function updateRemoveButtons() {
@@ -193,7 +206,7 @@
       activeFilters = [];
       filterRowsDiv.querySelectorAll('.filter-row').forEach(row => {
         const col = parseInt(row.querySelector('.column-select').value, 10);
-        const val = row.querySelector('.value-input').value.trim().toLowerCase();
+        const val = row.querySelector('.value-select').value.trim().toLowerCase();
         if (val) activeFilters.push({ col, val });
       });
       filterModal.hide();

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -22,15 +22,15 @@
       <thead class="table-light">
         <tr>
           <th style="width:48px;">Gör</th>
-          <th>ID</th>
-          <th>Marka</th>
-          <th>Model</th>
-          <th>Seri No</th>
-          <th>Fabrika</th>
-          <th>Kullanım Alanı</th>
-          <th>Sorumlu</th>
-          <th>Bağlı Env.</th>
-          <th>Durum</th>
+          <th data-field="id">ID</th>
+          <th data-field="marka">Marka</th>
+          <th data-field="model">Model</th>
+          <th data-field="seri_no">Seri No</th>
+          <th data-field="fabrika">Fabrika</th>
+          <th data-field="kullanim_alani">Kullanım Alanı</th>
+          <th data-field="sorumlu_personel">Sorumlu</th>
+          <th data-field="bagli_envanter_no">Bağlı Env.</th>
+          <th data-field="durum">Durum</th>
           <th style="width:220px;">İşlemler</th>
         </tr>
       </thead>
@@ -157,10 +157,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const filterForm = document.getElementById('filterForm');
   const clearBtn = document.getElementById('clearFilterBtn');
   const filterRowsDiv = document.getElementById('filterRows');
+  const distinctUrl = "{{ url_for('lookup.distinct', entity='printer', column='__COL__') }}";
   let activeFilters = [];
   const columns = Array.from(document.querySelectorAll('table thead th'))
-    .map((th, idx) => ({ idx, name: th.textContent.trim() }))
-    .filter(c => c.name && !['Gör', 'İşlemler'].includes(c.name));
+    .map((th, idx) => ({ idx, name: th.textContent.trim(), field: th.dataset.field }))
+    .filter(c => c.field);
 
   document.getElementById('filterBtn').addEventListener('click', () => {
     filterForm.reset();
@@ -187,14 +188,26 @@ document.addEventListener('DOMContentLoaded', () => {
         </select>
       </div>
       <div class="col-5">
-        <input type="text" class="form-control form-control-sm value-input">
+        <select class="form-select form-select-sm value-select"></select>
       </div>
       <div class="col-2 d-flex gap-1">
         <button type="button" class="btn btn-success btn-sm add-row">+</button>
         <button type="button" class="btn btn-danger btn-sm remove-row">-</button>
       </div>`;
     filterRowsDiv.appendChild(row);
+    const colSel = row.querySelector('.column-select');
+    const valSel = row.querySelector('.value-select');
+    loadValues(colSel, valSel);
+    colSel.addEventListener('change', () => loadValues(colSel, valSel));
     updateRemoveButtons();
+  }
+
+  async function loadValues(colSelect, valSelect) {
+    const col = columns.find(c => c.idx == colSelect.value);
+    const res = await fetch(distinctUrl.replace('__COL__', col.field));
+    const data = await res.json();
+    valSelect.innerHTML = '<option value="">Seçiniz</option>' +
+      data.map(v => `<option value="${v}">${v}</option>`).join('');
   }
 
   function updateRemoveButtons() {
@@ -216,7 +229,7 @@ document.addEventListener('DOMContentLoaded', () => {
     activeFilters = [];
     filterRowsDiv.querySelectorAll('.filter-row').forEach(row => {
       const col = parseInt(row.querySelector('.column-select').value, 10);
-      const val = row.querySelector('.value-input').value.trim().toLowerCase();
+      const val = row.querySelector('.value-select').value.trim().toLowerCase();
       if (val) activeFilters.push({ col, val });
     });
     filterModal.hide();


### PR DESCRIPTION
## Summary
- add lookup endpoint to return distinct column values
- load database values in list filters for inventories, printers, and licenses

## Testing
- `python -m py_compile routers/lookup.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad5c1a9f04832bb3e92160abfea7e4