### PR TITLE
Add shared actions menu and unified actions JS

### DIFF
--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -1,0 +1,38 @@
+(function () {
+  function go(url) { window.location.href = url; }
+
+  // Detay (göz)
+  document.addEventListener('click', function (e) {
+    const btn = e.target.closest('.js-view');
+    if (!btn) return;
+    const { entity, id } = btn.dataset;
+    if (!entity || !id) return;
+    go(`/${entity}/${id}`);
+  });
+
+  // İşlemler select
+  document.addEventListener('change', function (e) {
+    const sel = e.target.closest('.js-actions');
+    if (!sel) return;
+    const { entity, id } = sel.dataset;
+    const val = sel.value;
+    if (!entity || !id || !val) return;
+
+    // Tek tip URL şeması:
+    // assign -> /{entity}/{id}/assign
+    // edit   -> /{entity}/{id}/edit
+    // scrap  -> /{entity}/{id}/scrap
+    const map = { assign: 'assign', edit: 'edit', scrap: 'scrap' };
+    if (map[val]) go(`/${entity}/${id}/${map[val]}`);
+    sel.value = '';
+  });
+
+  // Eğer tüm satır tıklanıyorsa iptal etmek istersen:
+  document.addEventListener('click', function (e) {
+    const rowLink = e.target.closest('.js-row-link');
+    if (rowLink && !e.target.closest('.js-view') && !e.target.closest('.js-actions')) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  });
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -86,6 +86,7 @@
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
     <script src="{{ url_for('static', path='js/picker.js') }}"></script>
     <script defer src="/static/js/selects.js"></script>
+    <script src="{{ url_for('static', path='/js/actions.js') }}"></script>
     {% block scripts %}
     <script>
 document.addEventListener("DOMContentLoaded", () => {

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -19,7 +19,6 @@
   <table class="table table-sm table-striped align-middle">
     <thead>
       <tr>
-        <th style="width:42px;"></th> <!-- göz ikonu -->
         <th data-field="no">Envanter No</th>
         <th data-field="fabrika">Fabrika</th>
         <th data-field="departman">Departman</th>
@@ -31,27 +30,15 @@
     <tbody>
       {% for row in items %}
       <tr data-id="{{ row.id }}" class="inv-row">
-        <td class="text-center">
-          <a class="btn btn-sm btn-outline-secondary"
-             href="{{ url_for('inventory.detail', item_id=row.id) }}"
-             title="Görüntüle">
-            <i class="bi bi-eye"></i>
-          </a>
-        </td>
-
         <td>{{ row.no }}</td>
         <td>{{ row.fabrika }}</td>
         <td>{{ row.departman }}</td>
         <td>{{ row.sorumlu_personel }}</td>
         <td>{{ row.marka }} {{ row.model }}</td>
-
-        <td>
-          <select class="form-select form-select-sm action-select" data-id="{{ row.id }}">
-            <option value="" selected>İşlem Seç...</option>
-            <option value="assign">Atama Yap</option>
-            <option value="edit">Düzenle</option>
-            <option value="scrap">Hurdaya Ayır</option>
-          </select>
+        <td class="text-nowrap">
+          {% set entity = 'inventory' %}
+          {% set row_id = row.id %}
+          {% include 'partials/_actions_menu.html' %}
         </td>
       </tr>
       {% endfor %}

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -19,7 +19,6 @@
     <table class="table table-sm align-middle">
       <thead>
         <tr>
-          <th style="width:42px;">Detay</th>
           <th data-field="no">No</th>
           <th data-field="lisans_adi">Lisans Adı</th>
           <th data-field="lisans_anahtari">Key</th>
@@ -32,13 +31,6 @@
       <tbody>
         {% for row in items %}
         <tr>
-          <td>
-            <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('license_detail', lic_id=row.id) }}" title="Detay">
-              <span style="display:inline-flex;width:24px;height:24px;align-items:center;justify-content:center;border:1px solid #ccc;border-radius:4px;">
-                <i class="bi bi-eye"></i>
-              </span>
-            </a>
-          </td>
           <td>{{ row.id }}</td>
           <td>{{ row.lisans_adi }}</td>
           <td class="text-truncate" style="max-width:180px;">{{ row.lisans_key }}</td>
@@ -48,23 +40,11 @@
             {% if row.durum == 'hurda' %}<span class="badge bg-secondary">Hurda</span>
             {% else %}<span class="badge bg-success">Aktif</span>{% endif %}
           </td>
-            <td class="text-end">
-              <div class="dropdown position-static">
-                <button class="btn btn-sm btn-outline-secondary dropdown-toggle"
-                        type="button"
-                        data-bs-toggle="dropdown"
-                        data-bs-display="static"
-                        aria-expanded="false">
-                  İşlemler
-                </button>
-                <ul class="dropdown-menu dropdown-menu-end shadow">
-                  <li><a class="dropdown-item{% if row.durum == 'hurda' %} disabled{% endif %}" href="#" data-action="assign" data-id="{{ row.id }}">Atama Yap</a></li>
-                  <li><a class="dropdown-item" href="/lisans/{{ row.id }}">Düzenle</a></li>
-                  <li><hr class="dropdown-divider"></li>
-                  <li><a class="dropdown-item text-danger{% if row.durum == 'hurda' %} disabled{% endif %}" href="#" data-action="scrap" data-id="{{ row.id }}">Hurdaya Ayır</a></li>
-                </ul>
-              </div>
-            </td>
+          <td class="text-nowrap">
+            {% set entity = 'licenses' %}
+            {% set row_id = row.id %}
+            {% include 'partials/_actions_menu.html' %}
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/partials/_actions_menu.html
+++ b/templates/partials/_actions_menu.html
@@ -1,0 +1,18 @@
+<div class="d-flex align-items-center gap-2">
+  <!-- Göz (detay) -->
+  <button type="button"
+          class="btn btn-outline-secondary btn-sm js-view"
+          data-entity="{{ entity }}" data-id="{{ row_id }}"
+          title="Detay">
+    <i class="bi bi-eye"></i>
+  </button>
+
+  <!-- İşlemler -->
+  <select class="form-select form-select-sm w-auto js-actions"
+          data-entity="{{ entity }}" data-id="{{ row_id }}">
+    <option value="">İşlem Seçin</option>
+    <option value="assign">Atama Yap</option>
+    <option value="edit">Düzenle</option>
+    <option value="scrap">Hurdaya Ayır</option>
+  </select>
+</div>

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -21,7 +21,6 @@
     <table class="table table-sm align-middle">
       <thead class="table-light">
         <tr>
-          <th style="width:48px;">Gör</th>
           <th data-field="id">ID</th>
           <th data-field="marka">Marka</th>
           <th data-field="model">Model</th>
@@ -37,11 +36,6 @@
       <tbody>
         {% for p in printers %}
         <tr data-id="{{ p.id }}">
-          <td>
-            <a class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center justify-content-center" style="width:36px;height:36px;" href="/printers/{{ p.id }}" title="Görüntüle">
-              <i class="bi bi-eye"></i>
-            </a>
-          </td>
           <td>#{{ p.id }}</td>
           <td>{{ p.marka or '-' }}</td>
           <td>{{ p.model or '-' }}</td>
@@ -57,16 +51,10 @@
               <span class="badge text-bg-success">Aktif</span>
             {% endif %}
           </td>
-          <td>
-            <div class="d-flex flex-wrap gap-2">
-              <select class="form-select form-select-sm action-select" style="min-width:160px;">
-                <option value="">İşlem seçin…</option>
-                <option value="assign">Atama Yap</option>
-                <option value="edit">Düzenle</option>
-                <option value="scrap">Hurdaya Ayır</option>
-              </select>
-              <button class="btn btn-sm btn-primary action-go">Git</button>
-            </div>
+          <td class="text-nowrap">
+            {% set entity = 'printers' %}
+            {% set row_id = p.id %}
+            {% include 'partials/_actions_menu.html' %}
           </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- Introduced `_actions_menu.html` partial for unified detail button and action select
- Added global `actions.js` to handle detail navigation and action routing
- Updated list templates and base layout to use the shared partial and script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad61f23eac832b9303862f97aea9ef