### PR TITLE
Add Bootstrap tab navigation to management pages

### DIFF
--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -4,29 +4,20 @@
 {% block content %}
 <div class="container-fluid p-2">
 
-  <!-- ÜST (tek sekme) -->
-  <ul class="nav nav-tabs">
-    <li class="nav-item">
-      <a class="nav-link active" href="/admin?sub={{ sub }}">Admin</a>
-    </li>
-  </ul>
-
-  <!-- ALT SEKMELER -->
-  <div class="bg-light border-bottom px-3 py-2">
-    <ul class="nav nav-pills small">
-      <li class="nav-item me-2">
-        <a class="nav-link {% if sub=='urun' %}active{% endif %}" href="/admin?sub=urun">Ürün Ekle</a>
-      </li>
-      <li class="nav-item me-2">
-        <a class="nav-link {% if sub=='kullanicilar' %}active{% endif %}" href="/admin?sub=kullanicilar">Kullanıcılar</a>
-      </li>
-    </ul>
-  </div>
+<ul class='nav nav-tabs' id='adminTab' role='tablist'>
+  <li class='nav-item' role='presentation'>
+    <button class='nav-link active' id='urun-tab' data-bs-toggle='tab' data-bs-target='#tab-urun' type='button' role='tab'>Ürün Ekle</button>
+  </li>
+  <li class='nav-item' role='presentation'>
+    <button class='nav-link' id='kullanici-tab' data-bs-toggle='tab' data-bs-target='#tab-kullanicilar' type='button' role='tab'>Kullanıcılar</button>
+  </li>
+</ul>
+<div class='tab-content'>
+  <div class='tab-pane fade show active' id='tab-urun' role='tabpanel' aria-labelledby='urun-tab'>
 
   
 
   <!-- İÇERİK: ÜRÜN EKLE -->
-  {% if sub=='urun' %}
   <nav class="small text-muted mt-3 mb-2">Admin » Ürün Ekle</nav>
 
   <!-- ÜRÜN EKLE KUTUSU (REFERANS TABLOLARI) -->
@@ -139,10 +130,10 @@
 
     </div>
   </div>
-  {% endif %}
 
+  </div>
+  <div class='tab-pane fade' id='tab-kullanicilar' role='tabpanel' aria-labelledby='kullanici-tab'>
   <!-- İÇERİK: KULLANICILAR -->
-  {% if sub=='kullanicilar' %}
   <nav class="small text-muted mt-3 mb-2">Admin » Kullanıcılar</nav>
 
   <!-- KULLANICI KUTUSU -->
@@ -280,8 +271,8 @@
 
 </div>
 
-{% endif %}
 
+</div>
 <style>
   .nav-tabs .nav-link.active { font-weight:600; }
   .nav-pills .nav-link { padding:.25rem .75rem; }

--- a/templates/hurdalar.html
+++ b/templates/hurdalar.html
@@ -3,39 +3,54 @@
 {% block content %}
 <div class="container-fluid p-3">
   <h3>Hurdalar</h3>
-  <table class="table table-striped align-top">
-    <thead>
-      <tr>
-        <th>Envanter No</th>
-        <th>Marka</th>
-        <th>Model</th>
-        <th>Seri No</th>
-        <th>Departman</th>
-        <th>Tarih</th>
-        <th>Loglar</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for item in hurdalar %}
-      <tr>
-        <td>{{ item.no }}</td>
-        <td>{{ item.marka }}</td>
-        <td>{{ item.model }}</td>
-        <td>{{ item.seri_no }}</td>
-        <td>{{ item.departman }}</td>
-        <td>{{ item.tarih }}</td>
-        <td>
-          <ul class="mb-0 small">
-            {% for log in logs_map[item.id] %}
-            <li>{{ log.created_at }} – {{ log.action }} – {{ log.note }}</li>
-            {% else %}
-            <li class="text-muted">Log yok</li>
-            {% endfor %}
-          </ul>
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  <ul class="nav nav-tabs" id="hurdTab" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="envanter-tab" data-bs-toggle="tab" data-bs-target="#envanter" type="button" role="tab">Envanter Hurda</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="lisans-tab" data-bs-toggle="tab" data-bs-target="#lisans" type="button" role="tab">Lisans</button>
+    </li>
+  </ul>
+  <div class="tab-content pt-3">
+    <div class="tab-pane fade show active" id="envanter" role="tabpanel" aria-labelledby="envanter-tab">
+      <table class="table table-striped align-top">
+        <thead>
+          <tr>
+            <th>Envanter No</th>
+            <th>Marka</th>
+            <th>Model</th>
+            <th>Seri No</th>
+            <th>Departman</th>
+            <th>Tarih</th>
+            <th>Loglar</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in hurdalar %}
+          <tr>
+            <td>{{ item.no }}</td>
+            <td>{{ item.marka }}</td>
+            <td>{{ item.model }}</td>
+            <td>{{ item.seri_no }}</td>
+            <td>{{ item.departman }}</td>
+            <td>{{ item.tarih }}</td>
+            <td>
+              <ul class="mb-0 small">
+                {% for log in logs_map[item.id] %}
+                <li>{{ log.created_at }} – {{ log.action }} – {{ log.note }}</li>
+                {% else %}
+                <li class="text-muted">Log yok</li>
+                {% endfor %}
+              </ul>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div class="tab-pane fade" id="lisans" role="tabpanel" aria-labelledby="lisans-tab">
+      <div class="card p-3">Lisans hurdaları listesi...</div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/templates/logs/index.html
+++ b/templates/logs/index.html
@@ -1,5 +1,20 @@
 {% extends "base.html" %}{% block title %}Kayıtlar{% endblock %}
 {% block content %}
 <h2 class="h5 mb-3">Sistem Kayıtları</h2>
-<div class="card p-3">Log listesi...</div>
+<ul class="nav nav-tabs" id="logsTab" role="tablist">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link active" id="userlogs-tab" data-bs-toggle="tab" data-bs-target="#userlogs" type="button" role="tab">Kullanıcı Kayıtları</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="inventorylogs-tab" data-bs-toggle="tab" data-bs-target="#inventorylogs" type="button" role="tab">Envanter Kayıtları</button>
+  </li>
+</ul>
+<div class="tab-content pt-3">
+  <div class="tab-pane fade show active" id="userlogs" role="tabpanel" aria-labelledby="userlogs-tab">
+    <div class="card p-3">Kullanıcı kayıtları listesi...</div>
+  </div>
+  <div class="tab-pane fade" id="inventorylogs" role="tabpanel" aria-labelledby="inventorylogs-tab">
+    <div class="card p-3">Envanter kayıtları listesi...</div>
+  </div>
+</div>
 {% endblock %}

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -1,5 +1,26 @@
 {% extends "base.html" %}{% block title %}Talepler – Liste{% endblock %}
 {% block content %}
 <h2 class="h5 mb-3">Talepler</h2>
-<div class="card p-3"><a class="btn btn-primary btn-sm" href="/requests/create">Talep Oluştur</a></div>
+<ul class="nav nav-tabs" id="requestTab" role="tablist">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link active" id="aktif-tab" data-bs-toggle="tab" data-bs-target="#aktif" type="button" role="tab">Aktif Talepler</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="kapali-tab" data-bs-toggle="tab" data-bs-target="#kapali" type="button" role="tab">Kapalı Talepler</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="iptal-tab" data-bs-toggle="tab" data-bs-target="#iptal" type="button" role="tab">İptal Talepler</button>
+  </li>
+</ul>
+<div class="tab-content pt-3">
+  <div class="tab-pane fade show active" id="aktif" role="tabpanel" aria-labelledby="aktif-tab">
+    <div class="card p-3"><a class="btn btn-primary btn-sm" href="/requests/create">Talep Oluştur</a></div>
+  </div>
+  <div class="tab-pane fade" id="kapali" role="tabpanel" aria-labelledby="kapali-tab">
+    <div class="card p-3">Kapalı talepler listesi...</div>
+  </div>
+  <div class="tab-pane fade" id="iptal" role="tabpanel" aria-labelledby="iptal-tab">
+    <div class="card p-3">İptal talepler listesi...</div>
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Switch admin panel to tabbed layout for product entry and user management
- Use tabs on request list, trash, and log pages to separate sections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad652631b0832b82c9b85a0f2749c4