### PR TITLE
feat: show user info and add ldap integration

### DIFF
--- a/models.py
+++ b/models.py
@@ -49,6 +49,7 @@ class User(Base):
     username: Mapped[str] = mapped_column(String(64), unique=True, index=True)
     password_hash: Mapped[str] = mapped_column(String(255))
     full_name: Mapped[str] = mapped_column(String(120), default="")
+    email: Mapped[str | None] = mapped_column(String(255), default="")
     role: Mapped[str] = mapped_column(String(16), default="admin")  # admin/staff/user
     created_at: Mapped[str] = mapped_column(DateTime(timezone=True), server_default=func.now())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ bcrypt==3.2.2
 python-dotenv==1.0.1
 itsdangerous==2.2.0
 python-multipart==0.0.9
+ldap3==2.9.1

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -46,7 +46,7 @@ def admin_panel(request: Request, q: Optional[str] = None, db: Session = Depends
                 username=u.username,
                 first_name=first_name,
                 last_name=last_name,
-                email="",
+                email=getattr(u, "email", "") or "",
                 is_admin=1 if getattr(u, "role", "") == "admin" else 0,
             )
         )
@@ -93,6 +93,7 @@ def create_user(
         username=username,
         password_hash=hash_password(password),
         full_name=full_name,
+        email=email,
         role="admin" if is_admin else "user",
     )
     db.add(user)
@@ -122,6 +123,7 @@ def update_user(
     user.username = username
     user.full_name = f"{first_name} {last_name}".strip()
     user.role = "admin" if is_admin else "user"
+    user.email = email
     if password.strip():
         user.password_hash = hash_password(password)
 

--- a/routers/integrations.py
+++ b/routers/integrations.py
@@ -1,7 +1,10 @@
 # routers/integrations.py
+import os
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from ldap3 import Connection, Server
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
@@ -9,3 +12,34 @@ templates = Jinja2Templates(directory="templates")
 @router.get("/", response_class=HTMLResponse)
 async def integrations_home(request: Request):
     return templates.TemplateResponse("integrations/index.html", {"request": request})
+
+
+@router.get("/ldap", response_class=HTMLResponse)
+async def ldap_users(request: Request):
+    server_uri = os.getenv("LDAP_SERVER")
+    bind_dn = os.getenv("LDAP_BIND_DN")
+    bind_password = os.getenv("LDAP_BIND_PASSWORD")
+    base_dn = os.getenv("LDAP_BASE_DN")
+    users: list[dict[str, str]] = []
+    error = None
+    if server_uri and bind_dn and bind_password and base_dn:
+        try:
+            server = Server(server_uri)
+            conn = Connection(server, user=bind_dn, password=bind_password, auto_bind=True)
+            conn.search(base_dn, "(objectClass=person)", attributes=["cn", "mail"])
+            for entry in conn.entries:
+                users.append(
+                    {
+                        "cn": entry.cn.value,
+                        "mail": entry.mail.value if "mail" in entry else "",
+                    }
+                )
+            conn.unbind()
+        except Exception as exc:  # pragma: no cover - best effort
+            error = str(exc)
+    else:
+        error = "LDAP ayarları eksik"
+    return templates.TemplateResponse(
+        "integrations/ldap.html",
+        {"request": request, "users": users, "error": error},
+    )

--- a/routers/profile.py
+++ b/routers/profile.py
@@ -1,11 +1,28 @@
 # routers/profile.py
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Depends
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+
+from security import SessionUser, current_user
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
 
 @router.get("/", response_class=HTMLResponse)
-async def profile_home(request: Request):
-    return templates.TemplateResponse("profile/index.html", {"request": request})
+async def profile_home(request: Request, user: SessionUser = Depends(current_user)):
+    first_name = ""
+    last_name = ""
+    if user.full_name:
+        parts = user.full_name.split(" ", 1)
+        first_name = parts[0]
+        if len(parts) > 1:
+            last_name = parts[1]
+    return templates.TemplateResponse(
+        "profile/index.html",
+        {
+            "request": request,
+            "user": user,
+            "first_name": first_name,
+            "last_name": last_name,
+        },
+    )

--- a/security.py
+++ b/security.py
@@ -4,11 +4,19 @@ from sqlalchemy.orm import Session
 from auth import get_db, get_user_by_id
 
 class SessionUser:
-    def __init__(self, id: int, username: str, role: str, full_name: str | None = None):
+    def __init__(
+        self,
+        id: int,
+        username: str,
+        role: str,
+        full_name: str | None = None,
+        email: str | None = None,
+    ):
         self.id = id
         self.username = username
         self.role = role
         self.full_name = full_name or username
+        self.email = email
 
 def current_user(request: Request, db: Session = Depends(get_db)) -> SessionUser:
     user_id = request.session.get("user_id")
@@ -18,7 +26,13 @@ def current_user(request: Request, db: Session = Depends(get_db)) -> SessionUser
     u = get_user_by_id(db, int(user_id))
     if not u:
         raise HTTPException(status_code=status.HTTP_303_SEE_OTHER, detail="redirect:/login")
-    return SessionUser(u.id, u.username, getattr(u, "role", "admin"), u.full_name)
+    return SessionUser(
+        u.id,
+        u.username,
+        getattr(u, "role", "admin"),
+        u.full_name,
+        getattr(u, "email", None),
+    )
 
 def require_roles(*roles: str):
     def dep(user: SessionUser = Depends(current_user)) -> SessionUser:

--- a/templates/integrations/index.html
+++ b/templates/integrations/index.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}{% block title %}Bağlantılar{% endblock %}
 {% block content %}
 <h2 class="h5 mb-3">Entegrasyonlar</h2>
-<div class="card p-3">LDAP/AD, E-posta, SSO...</div>
+<div class="card p-3">
+  <ul class="mb-0">
+    <li><a href="/integrations/ldap">LDAP Kullanıcıları</a></li>
+  </ul>
+</div>
 {% endblock %}

--- a/templates/integrations/ldap.html
+++ b/templates/integrations/ldap.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}{% block title %}LDAP{% endblock %}
+{% block content %}
+<h2 class="h5 mb-3">LDAP Kullanıcıları</h2>
+<div class="card p-3">
+  {% if error %}
+  <div class="alert alert-danger">{{ error }}</div>
+  {% endif %}
+  <ul class="mb-0">
+    {% for u in users %}
+    <li>{{ u.cn }}{% if u.mail %} ({{ u.mail }}){% endif %}</li>
+    {% else %}
+    <li>Hiç kullanıcı bulunamadı.</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/templates/profile/index.html
+++ b/templates/profile/index.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}{% block title %}Profil{% endblock %}
 {% block content %}
 <h2 class="h5 mb-3">Profil</h2>
-<form class="card p-3">Ad, parola değiştir vb...</form>
+<div class="card p-3">
+  <div class="mb-2"><strong>Kullanıcı Adı:</strong> {{ user.username }}</div>
+  <div class="mb-2"><strong>Ad:</strong> {{ first_name }}</div>
+  <div class="mb-2"><strong>Soyad:</strong> {{ last_name }}</div>
+  <div class="mb-2"><strong>E-posta:</strong> {{ user.email or '' }}</div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- display current user's username, name, surname and email on profile page
- introduce LDAP integration page to fetch users
- add email support to User model and admin management

## Testing
- `python -m py_compile models.py routers/admin.py routers/profile.py routers/integrations.py security.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad68a53ba0832b8c791dc74286b71a