### PR TITLE
Use Bootstrap list-group for integration links

### DIFF
--- a/templates/integrations/index.html
+++ b/templates/integrations/index.html
@@ -2,9 +2,9 @@
 {% block content %}
 <h2 class="h5 mb-3">Entegrasyonlar</h2>
 <div class="card p-3">
-  <ul class="mb-0">
-    <li><a href="/integrations/ldap">LDAP Kullanıcıları</a></li>
-    <li><a href="/integrations/ldap/settings">LDAP Ayarları</a></li>
-  </ul>
+  <div class="list-group">
+    <a href="/integrations/ldap" class="list-group-item list-group-item-action">LDAP Kullanıcıları</a>
+    <a href="/integrations/ldap/settings" class="list-group-item list-group-item-action">LDAP Ayarları</a>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- restyle integrations page using Bootstrap list-group

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad73733f40832baabb3fa2a65df4df