### PR TITLE
fix: register lookup distinct endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,7 +37,7 @@ from routers import (
     refdata,
     panel as panel_router,
 )
-from routes.lookup import router as lookup_router
+from routers.lookup import router as lookup_router
 from routes.admin import router as admin_router
 from security import current_user, require_roles
 


### PR DESCRIPTION
## Summary
- register lookup router so `lookup.distinct` route resolves correctly

## Testing
- `pytest`
- `python - <<'PY'
from app import app
print(app.url_path_for('lookup.distinct', entity='inventory', column='no'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ad75dd8070832bbb75e003e852dbc0