### PR TITLE
Fix inventory reference in admin page

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -30,7 +30,7 @@ def admin_index(request: Request, db: Session = Depends(get_db)):
         "lookup_markalar": get("marka"),
         "lookup_modeller": get("model"),
         "inventory_refs": db.query(Inventory).with_entities(
-            Inventory.envanter_no, Inventory.marka, Inventory.model
+            Inventory.no, Inventory.marka, Inventory.model
         ).limit(300).all(),
     }
     return templates.TemplateResponse("admin.html", ctx)

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -123,7 +123,7 @@
           <select class="form-select js-choices" name="bagli_envanter_no" id="selBagliEnvanter">
             <option value="">Seçiniz…</option>
             {% for inv in inventory_refs or [] %}
-              <option value="{{ inv.envanter_no }}">{{ inv.envanter_no }} — {{ inv.marka }} {{ inv.model }}</option>
+              <option value="{{ inv.no }}">{{ inv.no }} — {{ inv.marka }} {{ inv.model }}</option>
             {% endfor %}
           </select>
         </div>


### PR DESCRIPTION
## Summary
- fix admin page inventory reference to use `Inventory.no`
- update admin template to display inventory numbers correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad76b6de7c832ba146d25b965a4a90