### PR TITLE
Fix lookup endpoints and clean product forms

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -39,8 +39,6 @@ async def new_post(request: Request, db: Session = Depends(get_db), user=Depends
     marka=form.get("marka"),
     model=form.get("model"),
     seri_no=form.get("seri_no"),
-    sorumlu_personel=form.get("sorumlu_personel"),
-    bagli_envanter_no=form.get("bagli_envanter_no"),
     ifs_no=form.get("ifs_no"),
     not_=form.get("not") or None,
     tarih=datetime.utcnow(),

--- a/routers/refdata.py
+++ b/routers/refdata.py
@@ -65,3 +65,17 @@ def create_ref(entity: str, body: RefCreate, db: Session = Depends(get_db)):
     db.add(obj)
     db.commit(); db.refresh(obj)
     return {"id": obj.id, "name": getattr(obj, cfg["name_col"]), "created": True}
+
+
+@router.delete("/{entity}/{item_id}")
+def delete_ref(entity: str, item_id: int, db: Session = Depends(get_db)):
+    cfg = ENTITY.get(entity)
+    if not cfg:
+        raise HTTPException(404, "Geçersiz entity")
+    ModelCls = cfg["model"]
+    obj = db.get(ModelCls, item_id)
+    if not obj:
+        raise HTTPException(404, "Kayıt bulunamadı")
+    db.delete(obj)
+    db.commit()
+    return {"ok": True}

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Request, Depends, Form
 from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
-from models import User, Lookup, Inventory
+from models import User, Lookup
 from auth import get_db
 from fastapi.templating import Jinja2Templates
 
@@ -29,9 +29,6 @@ def admin_index(request: Request, db: Session = Depends(get_db)):
         "lookup_donanim_tipleri": get("donanim_tipi"),
         "lookup_markalar": get("marka"),
         "lookup_modeller": get("model"),
-        "inventory_refs": db.query(Inventory).with_entities(
-            Inventory.no, Inventory.marka, Inventory.model
-        ).limit(300).all(),
     }
     return templates.TemplateResponse("admin.html", ctx)
 
@@ -56,8 +53,6 @@ def create_product(
     kullanim_alani: str = Form(""),
     lisans_adi: str = Form(""),
     fabrika: str = Form(""),
-    sorumlu_personel: str = Form(""),
-    bagli_envanter_no: str = Form(""),
     notlar: str = Form(""),
     db: Session = Depends(get_db),
 ):

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -56,8 +56,8 @@
 
         {# 1. satır: Kullanım Alanı, Lisans Adı, Fabrika #}
         {% set fields1 = [
-          {"title":"Kullanım Alanı","type":"kullanim_alani","name":"kullanim_alani","data":lookup_kullanim_alanlari},
-          {"title":"Lisans Adı","type":"lisans_adi","name":"lisans_adi","data":lookup_lisans_adlari},
+          {"title":"Kullanım Alanı","type":"kullanim-alani","name":"kullanim_alani","data":lookup_kullanim_alanlari},
+          {"title":"Lisans Adı","type":"lisans-adi","name":"lisans_adi","data":lookup_lisans_adlari},
           {"title":"Fabrika","type":"fabrika","name":"fabrika","data":lookup_fabrikalar}
         ] %}
         {% for f in fields1 %}
@@ -81,7 +81,7 @@
 
         {# 2. satır: Donanım Tipi, Marka, Model #}
         {% set fields2 = [
-          {"title":"Donanım Tipi","type":"donanim_tipi","name":"donanim_tipi","data":lookup_donanim_tipleri},
+          {"title":"Donanım Tipi","type":"donanim-tipi","name":"donanim_tipi","data":lookup_donanim_tipleri},
           {"title":"Marka","type":"marka","name":"marka","data":lookup_markalar},
           {"title":"Model","type":"model","name":"model","data":lookup_modeller}
         ] %}
@@ -104,28 +104,10 @@
         </div>
         {% endfor %}
 
-        {# 3. satır: Seri No, Sorumlu Personel, Bağlı Envanter No #}
+        {# 3. satır: Seri No #}
         <div class="col-md-4">
           <label class="form-label">Seri No</label>
           <input class="form-control" name="seri_no">
-        </div>
-        <div class="col-md-4">
-          <label class="form-label">Sorumlu Personel</label>
-          <select class="form-select js-choices" name="sorumlu_personel" id="selPersonel">
-            <option value="">Seçiniz…</option>
-            {% for u in users or [] %}
-              <option value="{{ u.full_name }}">{{ u.full_name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="col-md-4">
-          <label class="form-label">Bağlı Envanter No</label>
-          <select class="form-select js-choices" name="bagli_envanter_no" id="selBagliEnvanter">
-            <option value="">Seçiniz…</option>
-            {% for inv in inventory_refs or [] %}
-              <option value="{{ inv.no }}">{{ inv.no }} — {{ inv.marka }} {{ inv.model }}</option>
-            {% endfor %}
-          </select>
         </div>
 
         <div class="col-12">
@@ -245,7 +227,7 @@
       chipsEl.innerHTML='<div class="text-muted">Yükleniyor…</div>';
       try{
         const r=await fetch(`/api/lookup/${encodeURIComponent(current.type)}`);
-        const data=await r.json(); // [{id,value}]
+        const data=await r.json(); // [{id,name}]
         renderChips(data);
       }catch{ chipsEl.innerHTML='<div class="text-danger">Liste alınamadı.</div>'; }
     }
@@ -255,9 +237,9 @@
       items.forEach(it=>{
         const chip=document.createElement('span');
         chip.className='chip'; chip.dataset.id=it.id;
-        chip.innerHTML=`<span class="chip-text">${it.value}</span>
+        chip.innerHTML=`<span class="chip-text">${it.name}</span>
                         <button type="button" class="btn btn-sm btn-outline-danger px-2 py-0">✕</button>`;
-        chip.querySelector('button').addEventListener('click',()=>delItem(it.id,it.value));
+        chip.querySelector('button').addEventListener('click',()=>delItem(it.id,it.name));
         chipsEl.appendChild(chip);
       });
     }
@@ -266,16 +248,16 @@
       const val=(inputEl.value||'').trim(); if(!val) return;
       addBtn.disabled=true;
       try{
-        const r=await fetch(`/api/lookup/${encodeURIComponent(current.type)}`,{
+        const r=await fetch(`/api/ref/${encodeURIComponent(current.type)}`,{
           method:'POST',headers:{'Content-Type':'application/json'},
-          body:JSON.stringify({value:val})
+          body:JSON.stringify({name:val})
         });
         if(!r.ok) throw 0;
-        const created=await r.json(); // {id,value}
+        const created=await r.json(); // {id,name}
         // chips’i yenile
         loadItems();
         // select’e ekle + seç
-        upsertSelectOption(current.select, created.value, true);
+        upsertSelectOption(current.select, created.name, true);
         inputEl.value='';
       }catch{ alert('Eklenemedi'); } finally{ addBtn.disabled=false; }
     });
@@ -283,7 +265,7 @@
     async function delItem(id,value){
       if(!confirm(`Silinsin mi?\n${value}`)) return;
       try{
-        const r=await fetch(`/api/lookup/${encodeURIComponent(current.type)}/${id}`,{method:'DELETE'});
+        const r=await fetch(`/api/ref/${encodeURIComponent(current.type)}/${id}`,{method:'DELETE'});
         if(!r.ok) throw 0;
         // Chips’ten/Select’ten kaldır
         const c=chipsEl.querySelector(`.chip[data-id="${id}"]`); if(c) c.remove();

--- a/templates/inventory_new.html
+++ b/templates/inventory_new.html
@@ -34,14 +34,6 @@
         <input name="seri_no" class="form-control">
       </div>
       <div class="col-md-3">
-        <label class="form-label">Sorumlu Personel</label>
-        <select id="selSorumlu" name="sorumlu_personel" class="form-select"></select>
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Bağlı Envanter No</label>
-        <input name="bagli_envanter_no" class="form-control">
-      </div>
-      <div class="col-md-3">
         <label class="form-label">IFS No</label>
         <input name="ifs_no" class="form-control">
       </div>
@@ -64,9 +56,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   await basitSelectDoldur({selectId:'selDonanim', url:'/api/lookup/donanim-tipi', hiddenName:'donanim_tipi', placeholder:'Donanım tipi seçiniz…'});
   await basitSelectDoldur({selectId:'selMarka', url:'/api/lookup/marka', hiddenName:'marka', placeholder:'Marka seçiniz…'});
   bağımlıSelectDoldur({ustSelectId:'selMarka', altSelectId:'selModel', altUrlBuilder:(id)=>`/api/lookup/model?marka_id=${id}`, altHiddenName:'model'});
-  const users = await fetch('/inventory/assign/sources?type=users').then(r=>r.json());
-  const selSorumlu = document.getElementById('selSorumlu');
-  selSorumlu.innerHTML = '<option value="">Seçiniz…</option>' + users.map(u => `<option value="${u.text}">${u.text}</option>`).join('');
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Remove responsible person and linked inventory fields from product and inventory creation forms
- Use hyphenated lookup keys and `/api/ref` endpoints in admin lookup modal
- Add delete support to reference data API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad780a0078832b92811b8072084b33