### PR TITLE
Remove serial number and note inputs from product add form

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -49,11 +49,9 @@ def create_product(
     donanim_tipi: str = Form(...),
     marka: str = Form(""),
     model: str = Form(""),
-    seri_no: str = Form(""),
     kullanim_alani: str = Form(""),
     lisans_adi: str = Form(""),
     fabrika: str = Form(""),
-    notlar: str = Form(""),
     db: Session = Depends(get_db),
 ):
     # TODO: Kendi Inventory/Product modeline göre kaydı yap

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -64,11 +64,11 @@
         <div class="col-md-4">
           <label class="form-label d-flex justify-content-between align-items-center">
             <span>{{ f.title }}</span>
-            <a href="#" class="small text-decoration-none lm-open"
-               data-lm-type="{{ f.type }}" data-lm-title="{{ f.title }}"
-               data-lm-select="[name='{{ f.name }}']">
-              Yeni {{ f.title|lower }}… <span class="ms-1">Ekle</span>
-            </a>
+            <button type="button" class="btn btn-sm btn-outline-secondary lm-open"
+                    data-lm-type="{{ f.type }}" data-lm-title="{{ f.title }}"
+                    data-lm-select="[name='{{ f.name }}']" title="{{ f.title }} değerlerini yönet">
+              <i class="bi bi-list"></i>
+            </button>
           </label>
           <select class="form-select js-choices" name="{{ f.name }}">
             <option value="">Seçiniz…</option>
@@ -89,11 +89,11 @@
         <div class="col-md-4">
           <label class="form-label d-flex justify-content-between align-items-center">
             <span>{{ f.title }}</span>
-            <a href="#" class="small text-decoration-none lm-open"
-               data-lm-type="{{ f.type }}" data-lm-title="{{ f.title }}"
-               data-lm-select="[name='{{ f.name }}']">
-              Yeni {{ f.title|lower }}… <span class="ms-1">Ekle</span>
-            </a>
+            <button type="button" class="btn btn-sm btn-outline-secondary lm-open"
+                    data-lm-type="{{ f.type }}" data-lm-title="{{ f.title }}"
+                    data-lm-select="[name='{{ f.name }}']" title="{{ f.title }} değerlerini yönet">
+              <i class="bi bi-list"></i>
+            </button>
           </label>
           <select class="form-select js-choices" name="{{ f.name }}" {% if f.name=='donanim_tipi' %}required{% endif %}>
             <option value="">Seçiniz…</option>
@@ -104,21 +104,6 @@
         </div>
         {% endfor %}
 
-        {# 3. satır: Seri No #}
-        <div class="col-md-4">
-          <label class="form-label">Seri No</label>
-          <input class="form-control" name="seri_no">
-        </div>
-
-        <div class="col-12">
-          <label class="form-label">Not</label>
-          <textarea class="form-control" name="notlar" rows="2"></textarea>
-        </div>
-
-        <div class="col-12 d-flex gap-2">
-          <button class="btn btn-primary" type="submit">Kaydet</button>
-          <button class="btn btn-outline-secondary" type="reset">Temizle</button>
-        </div>
       </form>
     </div>
 
@@ -210,12 +195,12 @@
     let current={type:null,title:null,select:null};
 
     // Açıcılar
-    document.querySelectorAll('.lm-open').forEach(a=>{
-      a.addEventListener('click',e=>{
+    document.querySelectorAll('.lm-open').forEach(btn=>{
+      btn.addEventListener('click',e=>{
         e.preventDefault();
-        current.type=a.dataset.lmType;
-        current.title=a.dataset.lmTitle;
-        current.select=document.querySelector(a.dataset.lmSelect);
+        current.type=btn.dataset.lmType;
+        current.title=btn.dataset.lmTitle;
+        current.select=document.querySelector(btn.dataset.lmSelect);
         titleEl.textContent=`${current.title} — Değerleri Yönet`;
         inputEl.value='';
         loadItems();


### PR DESCRIPTION
## Summary
- drop save/reset buttons from the product/inventory addition form
- remove serial number and note inputs from the product creation form and handler
- replace text links with three-line icon buttons to manage lookup options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad79ef94bc832b952f80a0df8f93c1