### PR TITLE
Restrict model lookup to selected brand

### DIFF
--- a/routers/lookup.py
+++ b/routers/lookup.py
@@ -74,7 +74,9 @@ def lookup_list(
     if q:
         where.append("LOWER(name) LIKE LOWER(:q)")
         params["q"] = f"%{q}%"
-    if entity == "model" and marka_id:
+    if entity == "model":
+        if marka_id is None:
+            return []  # Model listesi marka seçimi olmadan boş dönsün
         where.append("brand_id = :brand_id")
         params["brand_id"] = marka_id
 

--- a/static/js/refdata.js
+++ b/static/js/refdata.js
@@ -84,7 +84,11 @@ async function refreshCard(card) {
   if (entity === 'model') {
     const brandSel = card.querySelector('.ref-brand');
     const brandId  = brandSel && brandSel.value ? brandSel.value : '';
-    const rows = await fetchList('model', brandId ? { marka_id: brandId } : {});
+    if (!brandId) {
+      renderList(listEl, []); // Marka seçilmeden model listesi gösterilmesin
+      return;
+    }
+    const rows = await fetchList('model', { marka_id: brandId });
     renderList(listEl, rows);
     return;
   }


### PR DESCRIPTION
## Summary
- Require brand selection for model lookup on backend
- Hide model list until a brand is chosen in product reference UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad7d4c4c64832bbf01f73e9c1e81a2