### PR TITLE
Switch integrations to Bootstrap Table

### DIFF
--- a/templates/integrations/index.html
+++ b/templates/integrations/index.html
@@ -2,9 +2,33 @@
 {% block content %}
 <h2 class="h5 mb-3">Entegrasyonlar</h2>
 <div class="card p-3">
-  <div class="list-group">
-    <a href="/integrations/ldap" class="list-group-item list-group-item-action">LDAP Kullanıcıları</a>
-    <a href="/integrations/ldap/settings" class="list-group-item list-group-item-action">LDAP Ayarları</a>
+  <div class="table-responsive">
+    <table id="integrationsTable"
+           class="table table-sm"
+           data-toggle="table">
+      <thead>
+        <tr>
+          <th data-field="name">Bağlantı</th>
+          <th data-field="action" data-sortable="false"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>LDAP Kullanıcıları</td>
+          <td class="text-end"><a href="/integrations/ldap" class="btn btn-primary btn-sm">Git</a></td>
+        </tr>
+        <tr>
+          <td>LDAP Ayarları</td>
+          <td class="text-end"><a href="/integrations/ldap/settings" class="btn btn-primary btn-sm">Git</a></td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.21.3/dist/bootstrap-table.min.css">
+<script src="https://unpkg.com/bootstrap-table@1.21.3/dist/bootstrap-table.min.js"></script>
 {% endblock %}

--- a/templates/integrations/ldap.html
+++ b/templates/integrations/ldap.html
@@ -5,13 +5,39 @@
 <div class="card p-3">
   {% if error %}
   <div class="alert alert-danger">{{ error }}</div>
+  {% else %}
+  <div class="table-responsive">
+    <table id="ldapTable"
+           class="table table-sm table-striped"
+           data-toggle="table"
+           data-search="true"
+           data-pagination="true">
+      <thead>
+        <tr>
+          <th data-field="cn">Kullanıcı</th>
+          <th data-field="mail">E-posta</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for u in users %}
+        <tr>
+          <td>{{ u.cn }}</td>
+          <td>{{ u.mail or '-' }}</td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="2" class="text-muted">Hiç kullanıcı bulunamadı.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
   {% endif %}
-  <ul class="mb-0">
-    {% for u in users %}
-    <li>{{ u.cn }}{% if u.mail %} ({{ u.mail }}){% endif %}</li>
-    {% else %}
-    <li>Hiç kullanıcı bulunamadı.</li>
-    {% endfor %}
-  </ul>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<link rel="stylesheet" href="https://unpkg.com/bootstrap-table@1.21.3/dist/bootstrap-table.min.css">
+<script src="https://unpkg.com/bootstrap-table@1.21.3/dist/bootstrap-table.min.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace list-based integrations page with Bootstrap Table
- show LDAP users in searchable, paginated Bootstrap Table

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad87eac928832bb35d08d080312943