### PR TITLE
Hide sidebar in add-item modal

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -51,3 +51,9 @@
 .card, .container-fluid, .content-wrapper {
   transform: none !important; /* varsa */
 }
+/* + ve - butonlarında focus çizgisini kaldır */
+.add-row:focus,
+.remove-row:focus {
+  box-shadow: none;
+  outline: none;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -86,9 +86,16 @@
     <script src="{{ url_for('static', path='js/picker.js') }}"></script>
     <script defer src="/static/js/selects.js"></script>
     <script src="{{ url_for('static', path='/js/actions.js') }}"></script>
-    {% block scripts %}
-    <script>
+  {% block scripts %}
+  <script>
 document.addEventListener("DOMContentLoaded", () => {
+  if (window.self !== window.top) {
+    const aside = document.querySelector("aside");
+    const main = document.querySelector("main");
+    if (aside) aside.remove();
+    if (main) main.classList.remove("col-lg-10");
+  }
+
   // Event delegation: works for dynamically added rows
   document.body.addEventListener("click", (e) => {
     const row = e.target.closest("tr[data-href]");


### PR DESCRIPTION
## Summary
- prevent left bar appearing when green "+" button is focused by removing box shadow and outline
- remove sidebar when add/edit pages are loaded in iframe modals to avoid duplicate left menu

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad8cda9dfc832b9896bedc67b68c29