### PR TITLE
Remove list boxes from product addition cards

### DIFF
--- a/templates/admin/taxonomies.html
+++ b/templates/admin/taxonomies.html
@@ -16,7 +16,6 @@
             <input class="form-control ref-input" placeholder="Yeni kullanım alanı..." />
             <button class="btn btn-success ref-add">Ekle</button>
           </div>
-          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>
@@ -32,7 +31,6 @@
             <input class="form-control ref-input" placeholder="Yeni lisans adı..." />
             <button class="btn btn-success ref-add">Ekle</button>
           </div>
-          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>
@@ -48,7 +46,6 @@
             <input class="form-control ref-input" placeholder="Yeni fabrika..." />
             <button class="btn btn-success ref-add">Ekle</button>
           </div>
-          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>
@@ -64,7 +61,6 @@
             <input class="form-control ref-input" placeholder="Yeni donanım tipi..." />
             <button class="btn btn-success ref-add">Ekle</button>
           </div>
-          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>
@@ -80,7 +76,6 @@
             <input class="form-control ref-input" placeholder="Yeni marka..." />
             <button class="btn btn-success ref-add">Ekle</button>
           </div>
-          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>
@@ -104,7 +99,6 @@
               </div>
             </div>
           </div>
-          <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -35,7 +35,6 @@
               <input class="form-control ref-input" placeholder="Yeni kullanım alanı..." />
               <button class="btn btn-success ref-add" type="button">Ekle</button>
             </div>
-            <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -51,7 +50,6 @@
               <input class="form-control ref-input" placeholder="Yeni lisans adı..." />
               <button class="btn btn-success ref-add" type="button">Ekle</button>
             </div>
-            <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -67,7 +65,6 @@
               <input class="form-control ref-input" placeholder="Yeni fabrika..." />
               <button class="btn btn-success ref-add" type="button">Ekle</button>
             </div>
-            <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -83,7 +80,6 @@
               <input class="form-control ref-input" placeholder="Yeni donanım tipi..." />
               <button class="btn btn-success ref-add" type="button">Ekle</button>
             </div>
-            <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -99,7 +95,6 @@
               <input class="form-control ref-input" placeholder="Yeni marka..." />
               <button class="btn btn-success ref-add" type="button">Ekle</button>
             </div>
-            <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -123,7 +118,6 @@
                 </div>
               </div>
             </div>
-            <ul class="list-group ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- drop reference list boxes from product addition cards in admin panel
- mirror cleanup in taxonomy template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad8ef44588832bb9a10e0323ed9b0b