### PR TITLE
Refactor inventory form to use lookup buttons

### DIFF
--- a/templates/inventory_new.html
+++ b/templates/inventory_new.html
@@ -2,60 +2,100 @@
 {% block title %}Envanter Ekle{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
-  <h5 class="mb-3">Envanter Ekle</h5>
   <form method="post">
-    <div class="row g-3">
-      <div class="col-md-3">
-        <label class="form-label">Fabrika</label>
-        <select id="selFabrika" class="form-select"></select>
+    <!-- Satır 1 -->
+    <div class="row g-3 align-items-center mb-2">
+      <!-- Kullanım Alanı -->
+      <div class="col-md-6">
+        <label class="form-label d-block">Kullanım Alanı</label>
+        <div class="d-flex align-items-center gap-2">
+          <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="kullanim_alani" aria-label="Kullanım Alanı">
+            &#9776;
+          </button>
+          <input type="hidden" name="kullanim_alani" id="kullanim_alani">
+        </div>
       </div>
-      <div class="col-md-3">
-        <label class="form-label">Departman</label>
-        <select id="selDepartman" class="form-select"></select>
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Donanım Tipi</label>
-        <select id="selDonanim" class="form-select"></select>
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Bilgisayar Adı</label>
-        <input name="bilgisayar_adi" class="form-control">
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Marka</label>
-        <select id="selMarka" class="form-select"></select>
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Model</label>
-        <select id="selModel" class="form-select"></select>
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Seri No</label>
-        <input name="seri_no" class="form-control">
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">IFS No</label>
-        <input name="ifs_no" class="form-control">
-      </div>
-      <div class="col-md-12">
-        <label class="form-label">Not</label>
-        <textarea name="not" class="form-control"></textarea>
+
+      <!-- Lisans Adı -->
+      <div class="col-md-6">
+        <label class="form-label d-block">Lisans Adı</label>
+        <div class="d-flex align-items-center gap-2">
+          <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="lisans_adi" aria-label="Lisans Adı">
+            &#9776;
+          </button>
+          <input type="hidden" name="lisans_adi" id="lisans_adi">
+        </div>
       </div>
     </div>
+
+    <!-- Satır 2 -->
+    <div class="row g-3 align-items-center mb-2">
+      <!-- Donanım Tipi -->
+      <div class="col-md-6">
+        <label class="form-label d-block">Donanım Tipi</label>
+        <div class="d-flex align-items-center gap-2">
+          <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="donanim_tipi" aria-label="Donanım Tipi">
+            &#9776;
+          </button>
+          <input type="hidden" name="donanim_tipi" id="donanim_tipi">
+        </div>
+      </div>
+
+      <!-- Marka -->
+      <div class="col-md-6">
+        <label class="form-label d-block">Marka</label>
+        <div class="d-flex align-items-center gap-2">
+          <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="marka" aria-label="Marka">
+            &#9776;
+          </button>
+          <input type="hidden" name="marka" id="marka">
+        </div>
+      </div>
+    </div>
+
+    <!-- Satır 3 -->
+    <div class="row g-3 align-items-center mb-2">
+      <!-- Fabrika -->
+      <div class="col-md-6">
+        <label class="form-label d-block">Fabrika</label>
+        <div class="d-flex align-items-center gap-2">
+          <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="fabrika" aria-label="Fabrika">
+            &#9776;
+          </button>
+          <input type="hidden" name="fabrika" id="fabrika">
+        </div>
+      </div>
+
+      <!-- Model -->
+      <div class="col-md-6">
+        <label class="form-label d-block">Model</label>
+        <div class="d-flex align-items-center gap-2">
+          <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="model" aria-label="Model">
+            &#9776;
+          </button>
+          <input type="hidden" name="model" id="model">
+        </div>
+      </div>
+    </div>
+
     <div class="mt-3">
       <button class="btn btn-primary btn-sm">Kaydet</button>
       <a href="/inventory" class="btn btn-outline-secondary btn-sm">İptal</a>
     </div>
   </form>
 </div>
-{% include "_catalog_select.js" %}
+
+<style>
+.lookup-btn { width: 38px; height: 38px; padding: 0; line-height: 1; }
+</style>
+
 <script>
-document.addEventListener('DOMContentLoaded', async () => {
-  await basitSelectDoldur({selectId:'selFabrika', url:'/api/lookup/fabrika', hiddenName:'fabrika', placeholder:'Fabrika seçiniz…'});
-  await basitSelectDoldur({selectId:'selDepartman', url:'/api/lookup/kullanim-alani', hiddenName:'departman', placeholder:'Departman seçiniz…'});
-  await basitSelectDoldur({selectId:'selDonanim', url:'/api/lookup/donanim-tipi', hiddenName:'donanim_tipi', placeholder:'Donanım tipi seçiniz…'});
-  await basitSelectDoldur({selectId:'selMarka', url:'/api/lookup/marka', hiddenName:'marka', placeholder:'Marka seçiniz…'});
-  bağımlıSelectDoldur({ustSelectId:'selMarka', altSelectId:'selModel', altUrlBuilder:(id)=>`/api/lookup/model?marka_id=${id}`, altHiddenName:'model'});
-});
+  document.querySelectorAll('.lookup-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const entity = btn.dataset.entity;
+      // TODO: kendi modalını/Offcanvas'ını aç
+      // document.getElementById(entity).value = secilenIdVeyaAd;
+    });
+  });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace select fields with lookup buttons and hidden inputs in inventory form
- Add minimal styling and JS hooks for modal-based selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad977fb0c4832bb26dca094721120b