### PR TITLE
Add license and printer creation modals with backend routes

### DIFF
--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -4,10 +4,10 @@
 <div class="container-fluid p-2 content">
   <div class="d-flex align-items-center justify-content-between mb-3">
     <div class="d-flex align-items-center gap-2">
-      <a href="#" id="addBtn" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle">
-        <i class="bi bi-plus-lg"></i>
-        <span>Ekle</span>
-      </a>
+        <a href="#" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#addModal">
+          <i class="bi bi-plus-lg"></i>
+          <span>Ekle</span>
+        </a>
       <h5 class="mb-0">Lisans</h5>
     </div>
     <div class="d-flex align-items-center gap-2">
@@ -61,8 +61,49 @@
         <h5 class="modal-title">Lisans Ekle</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
-      <div class="modal-body p-0">
-        <iframe id="addFrame" src="" style="width:100%;height:70vh;border:0;"></iframe>
+      <div class="modal-body">
+        <form method="post" action="/lisans/create" class="needs-validation" novalidate>
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label class="form-label">Lisans Adı</label>
+              <input name="lisans_adi" type="text" class="form-control" required placeholder="Lisans adı...">
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Lisans Anahtarı</label>
+              <input name="lisans_anahtari" type="text" class="form-control" required placeholder="XXXX-XXXX-XXXX-XXXX">
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label">Sorumlu Personel</label>
+              <input name="sorumlu_personel" type="text" class="form-control" required placeholder="Ad Soyad">
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label">Bağlı Olduğu Envanter No</label>
+              <select name="bagli_envanter_no" class="form-select" required>
+                <option value="">Seçiniz...</option>
+                {% for inv in envanterler %}
+                <option value="{{ inv.no }}">{{ inv.no }}</option>
+                {% endfor %}
+              </select>
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label">IFS No <small class="text-muted">(zorunlu değil)</small></label>
+              <input name="ifs_no" type="text" class="form-control" placeholder="IFS numarası">
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label">Mail Adresi</label>
+              <input name="mail_adresi" type="email" class="form-control" required placeholder="ornek@firma.com">
+            </div>
+          </div>
+
+          <div class="mt-3 d-flex gap-2">
+            <button type="submit" class="btn btn-primary">Kaydet</button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
+          </div>
+        </form>
       </div>
     </div>
   </div>
@@ -126,7 +167,6 @@
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     const filterModal = new bootstrap.Modal(document.getElementById('filterModal'));
-    const addModal    = new bootstrap.Modal(document.getElementById('addModal'));
     const searchInput = document.getElementById('searchInput');
     const filterForm = document.getElementById('filterForm');
     const clearBtn = document.getElementById('clearFilterBtn');
@@ -137,10 +177,6 @@
       .map((th, idx) => ({ idx, name: th.textContent.trim(), field: th.dataset.field }))
       .filter(c => c.field);
 
-    document.getElementById('addBtn').addEventListener('click', () => {
-      document.getElementById('addFrame').src = '/lisans/new';
-      addModal.show();
-    });
 
     document.getElementById('filterBtn').addEventListener('click', () => {
       filterForm.reset();

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -5,10 +5,10 @@
 <div class="container-fluid p-3">
   <div class="d-flex align-items-center justify-content-between mb-3">
     <div class="d-flex align-items-center gap-2">
-      <a href="#" id="addBtn" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle">
-        <i class="bi bi-plus-lg"></i>
-        <span>Ekle</span>
-      </a>
+        <a href="#" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#addModal">
+          <i class="bi bi-plus-lg"></i>
+          <span>Ekle</span>
+        </a>
       <h5 class="mb-0">Yazıcılar</h5>
     </div>
     <div class="d-flex align-items-center gap-2">
@@ -72,8 +72,69 @@
         <h5 class="modal-title">Yazıcı Ekle</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
-      <div class="modal-body p-0">
-        <iframe id="addFrame" src="" style="width:100%;height:70vh;border:0;"></iframe>
+      <div class="modal-body">
+        <form method="post" action="/printers/create" class="needs-validation" novalidate>
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label class="form-label">Envanter No</label>
+              <input name="envanter_no" type="text" class="form-control" required placeholder="ENV-000123">
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label">Yazıcı Markası</label>
+              <select name="yazici_markasi" class="form-select" required id="selYaziciMarka">
+                <option value="">Seçiniz...</option>
+                {% for m in marka_list %}
+                <option value="{{ m.name }}">{{ m.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label">Yazıcı Modeli</label>
+              <select name="yazici_modeli" class="form-select" required id="selYaziciModel">
+                <option value="">Seçiniz...</option>
+                {% for mdl in model_list %}
+                <option value="{{ mdl.name }}" data-marka="{{ mdl.brand.name }}">{{ mdl.name }}</option>
+                {% endfor %}
+              </select>
+              <small class="text-muted">Not: Model listesi seçilen markaya göre filtrelenir.</small>
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label">Kullanım Alanı</label>
+              <select name="kullanim_alani" class="form-select" required>
+                <option value="">Seçiniz...</option>
+                {% for k in kullanim_alanlari %}
+                <option value="{{ k.name }}">{{ k.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+
+            <div class="col-md-4">
+              <label class="form-label">IP Adresi</label>
+              <input name="ip_adresi" type="text" class="form-control" required placeholder="10.0.0.10">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">MAC</label>
+              <input name="mac" type="text" class="form-control" required placeholder="AA:BB:CC:DD:EE:FF">
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Hostname</label>
+              <input name="hostname" type="text" class="form-control" required placeholder="PRN-OFIS-01">
+            </div>
+
+            <div class="col-md-6">
+              <label class="form-label">IFS No <small class="text-muted">(zorunlu değil)</small></label>
+              <input name="ifs_no" type="text" class="form-control" placeholder="IFS numarası">
+            </div>
+          </div>
+
+          <div class="mt-3 d-flex gap-2">
+            <button type="submit" class="btn btn-primary">Kaydet</button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
+          </div>
+        </form>
       </div>
     </div>
   </div>
@@ -157,7 +218,6 @@
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const filterModal = new bootstrap.Modal(document.getElementById('filterModal'));
-  const addModal    = new bootstrap.Modal(document.getElementById('addModal'));
   const searchInput = document.getElementById('searchInput');
   const filterForm = document.getElementById('filterForm');
   const clearBtn = document.getElementById('clearFilterBtn');
@@ -168,10 +228,21 @@ document.addEventListener('DOMContentLoaded', () => {
     .map((th, idx) => ({ idx, name: th.textContent.trim(), field: th.dataset.field }))
     .filter(c => c.field);
 
-  document.getElementById('addBtn').addEventListener('click', () => {
-    document.getElementById('addFrame').src = '/printers/new';
-    addModal.show();
-  });
+  const markaSel = document.getElementById('selYaziciMarka');
+  const modelSel = document.getElementById('selYaziciModel');
+  if (markaSel && modelSel) {
+    const filterModels = () => {
+      const marka = markaSel.value;
+      Array.from(modelSel.options).forEach(opt => {
+        opt.hidden = marka && opt.dataset.marka !== marka;
+      });
+      modelSel.value = '';
+    };
+    markaSel.addEventListener('change', filterModels);
+    filterModels();
+  }
+
+  // Modal tetikleyici attribute ile handle ediliyor; ek JS gerekmez.
 
   document.getElementById('filterBtn').addEventListener('click', () => {
     filterForm.reset();


### PR DESCRIPTION
## Summary
- replace iframe add dialogs with inline forms for licenses and printers
- add FastAPI create endpoints setting `tarih` and `islem_yapan`
- populate printer models dynamically by selected brand

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad9871e688832b8e720d879da2bf6f