### PR TITLE
Use picker modal for inventory add and handle catalog IDs

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -6,7 +6,17 @@ from datetime import datetime
 from fastapi.templating import Jinja2Templates
 
 from database import get_db
-from models import Inventory, InventoryLog, ScrapItem, User, Factory
+from models import (
+    Inventory,
+    InventoryLog,
+    ScrapItem,
+    User,
+    Factory,
+    Brand,
+    Model,
+    UsageArea,
+    HardwareType,
+)
 from security import current_user
 
 templates = Jinja2Templates(directory="templates")
@@ -30,15 +40,23 @@ def new_page(request: Request, user=Depends(current_user)):
 @router.post("/new", name="inventory.new_post")
 async def new_post(request: Request, db: Session = Depends(get_db), user=Depends(current_user)):
   form = dict(await request.form())
+
+  brand = db.get(Brand, int(form.get("marka"))) if form.get("marka") else None
+  model_obj = db.get(Model, int(form.get("model"))) if form.get("model") else None
+  usage = db.get(UsageArea, int(form.get("kullanim_alani"))) if form.get("kullanim_alani") else None
+  hw = db.get(HardwareType, int(form.get("donanim_tipi"))) if form.get("donanim_tipi") else None
+  factory = db.get(Factory, int(form.get("fabrika"))) if form.get("fabrika") else None
+
   inv = Inventory(
     no=form.get("no") or f"INV{int(datetime.utcnow().timestamp())}",
-    fabrika=form.get("fabrika"),
+    fabrika=factory.name if factory else None,
     departman=form.get("departman"),
-    donanim_tipi=form.get("donanim_tipi"),
+    donanim_tipi=hw.name if hw else None,
     bilgisayar_adi=form.get("bilgisayar_adi"),
-    marka=form.get("marka"),
-    model=form.get("model"),
+    marka=brand.name if brand else None,
+    model=model_obj.name if model_obj else None,
     seri_no=form.get("seri_no"),
+    kullanim_alani=usage.name if usage else None,
     ifs_no=form.get("ifs_no"),
     not_=form.get("not") or None,
     tarih=datetime.utcnow(),

--- a/templates/inventory_add.html
+++ b/templates/inventory_add.html
@@ -6,65 +6,61 @@
   <h5 class="mb-3">Ürün / Envanter Ekle</h5>
 
   <div class="row g-4">
-    <!-- Kullanım Alanı -->
+
     <div class="col-md-6">
-      <label class="form-label d-block">Kullanım Alanı</label>
-      <div class="d-flex align-items-center gap-2">
-        <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="kullanim_alani" aria-label="Kullanım Alanı">&#9776;</button>
-        <span class="selected-text text-muted" data-for="kullanim_alani">Seçilmedi</span>
-        <input type="hidden" name="kullanim_alani" id="kullanim_alani">
+      <label class="form-label">Kullanım Alanı</label>
+      <div class="input-group input-group-sm">
+        <input type="text" id="txtKullanimAlani" class="form-control" readonly placeholder="Seçilmedi">
+        <button type="button" class="btn btn-outline-secondary picker-btn" data-entity="kullanim-alani" data-target-text="txtKullanimAlani" data-target-hidden="kullanim_alani" data-label="Kullanım Alanı">&#9776;</button>
       </div>
+      <input type="hidden" name="kullanim_alani" id="kullanim_alani">
     </div>
 
-    <!-- Lisans Adı -->
     <div class="col-md-6">
-      <label class="form-label d-block">Lisans Adı</label>
-      <div class="d-flex align-items-center gap-2">
-        <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="lisans_adi" aria-label="Lisans Adı">&#9776;</button>
-        <span class="selected-text text-muted" data-for="lisans_adi">Seçilmedi</span>
-        <input type="hidden" name="lisans_adi" id="lisans_adi">
+      <label class="form-label">Lisans Adı</label>
+      <div class="input-group input-group-sm">
+        <input type="text" id="txtLisansAdi" class="form-control" readonly placeholder="Seçilmedi">
+        <button type="button" class="btn btn-outline-secondary picker-btn" data-entity="lisans-adi" data-target-text="txtLisansAdi" data-target-hidden="lisans_adi" data-label="Lisans Adı">&#9776;</button>
       </div>
+      <input type="hidden" name="lisans_adi" id="lisans_adi">
     </div>
 
-    <!-- Donanım Tipi -->
     <div class="col-md-6">
-      <label class="form-label d-block">Donanım Tipi</label>
-      <div class="d-flex align-items-center gap-2">
-        <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="donanim_tipi" aria-label="Donanım Tipi">&#9776;</button>
-        <span class="selected-text text-muted" data-for="donanim_tipi">Seçilmedi</span>
-        <input type="hidden" name="donanim_tipi" id="donanim_tipi">
+      <label class="form-label">Donanım Tipi</label>
+      <div class="input-group input-group-sm">
+        <input type="text" id="txtDonanimTipi" class="form-control" readonly placeholder="Seçilmedi">
+        <button type="button" class="btn btn-outline-secondary picker-btn" data-entity="donanim-tipi" data-target-text="txtDonanimTipi" data-target-hidden="donanim_tipi" data-label="Donanım Tipi">&#9776;</button>
       </div>
+      <input type="hidden" name="donanim_tipi" id="donanim_tipi">
     </div>
 
-    <!-- Marka -->
     <div class="col-md-6">
-      <label class="form-label d-block">Marka</label>
-      <div class="d-flex align-items-center gap-2">
-        <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="marka" aria-label="Marka">&#9776;</button>
-        <span class="selected-text text-muted" data-for="marka">Seçilmedi</span>
-        <input type="hidden" name="marka" id="marka">
+      <label class="form-label">Marka</label>
+      <div class="input-group input-group-sm">
+        <input type="text" id="txtMarka" class="form-control" readonly placeholder="Seçilmedi">
+        <button type="button" class="btn btn-outline-secondary picker-btn" data-entity="marka" data-target-text="txtMarka" data-target-hidden="marka" data-label="Marka">&#9776;</button>
       </div>
+      <input type="hidden" name="marka" id="marka">
     </div>
 
-    <!-- Fabrika -->
     <div class="col-md-6">
-      <label class="form-label d-block">Fabrika</label>
-      <div class="d-flex align-items-center gap-2">
-        <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="fabrika" aria-label="Fabrika">&#9776;</button>
-        <span class="selected-text text-muted" data-for="fabrika">Seçilmedi</span>
-        <input type="hidden" name="fabrika" id="fabrika">
+      <label class="form-label">Model</label>
+      <div class="input-group input-group-sm">
+        <input type="text" id="txtModel" class="form-control" readonly placeholder="Seçilmedi">
+        <button type="button" class="btn btn-outline-secondary picker-btn" data-entity="model" data-target-text="txtModel" data-target-hidden="model" data-label="Model">&#9776;</button>
       </div>
+      <input type="hidden" name="model" id="model">
     </div>
 
-    <!-- Model -->
     <div class="col-md-6">
-      <label class="form-label d-block">Model</label>
-      <div class="d-flex align-items-center gap-2">
-        <button type="button" class="btn btn-outline-secondary btn-sm lookup-btn" data-entity="model" aria-label="Model">&#9776;</button>
-        <span class="selected-text text-muted" data-for="model">Seçilmedi</span>
-        <input type="hidden" name="model" id="model">
+      <label class="form-label">Fabrika</label>
+      <div class="input-group input-group-sm">
+        <input type="text" id="txtFabrika" class="form-control" readonly placeholder="Seçilmedi">
+        <button type="button" class="btn btn-outline-secondary picker-btn" data-entity="fabrika" data-target-text="txtFabrika" data-target-hidden="fabrika" data-label="Fabrika">&#9776;</button>
       </div>
+      <input type="hidden" name="fabrika" id="fabrika">
     </div>
+
   </div>
 
   <div class="mt-3">
@@ -74,43 +70,25 @@
 </section>
 </form>
 
-<style>
-  #urun-ekle .lookup-btn{width:38px;height:38px;line-height:1;padding:0}
-  #urun-ekle .selected-text{font-size:.9rem}
-</style>
-
-<script>window.SKIP_SELECT_ENHANCE = true;</script>
-
 <script>
-  (function(){
-    // Bu fonksiyonu kendi modal/selector akışına bağla.
-    // Örnek olarak basit prompt ile seçimi simüle ediyorum.
-    function openPicker(entity, current){
-      // TODO: Burayı kendi modalını çağıracak şekilde değiştir.
-      const val = prompt(entity.toUpperCase() + " seçin:", current || "");
-      // Kullanıcı iptal ettiyse null dön
-      return (val && val.trim()) ? { id: val.trim(), text: val.trim() } : null;
-    }
-
-    document.querySelectorAll('#urun-ekle .lookup-btn').forEach(btn=>{
-      btn.addEventListener('click', ()=>{
-        const entity = btn.dataset.entity;                 // örn: 'marka'
-        const hidden = document.getElementById(entity);    // ilgili hidden
-        const currentText = hidden.value || "";
-        const picked = openPicker(entity, currentText);
-        if(!picked) return;
-
-        // Değeri gizliye yaz
-        hidden.value = picked.id;
-
-        // Yanındaki metni güncelle
-        const labelSpan = document.querySelector(`#urun-ekle .selected-text[data-for="${entity}"]`);
-        if(labelSpan){
-          labelSpan.textContent = picked.text;
-          labelSpan.classList.remove('text-muted');
-        }
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.picker-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const entity = btn.dataset.entity;
+      const targetTextId = btn.dataset.targetText;
+      const targetHiddenId = btn.dataset.targetHidden;
+      const label = btn.dataset.label || 'Seç';
+      const markaGetter = entity === 'model' ? () => document.getElementById('marka').value : null;
+      openPicker({
+        entity,
+        label,
+        targetTextId,
+        targetHiddenId,
+        markaGetter
       });
     });
-  })();
+  });
+});
 </script>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Replace prompt-based inventory add inputs with picker modal selections
- Resolve catalog ID selections to names when creating inventory items

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad9dc8a3d0832bac0911d9a514a1eb