### PR TITLE
Add aliases for inventory and license routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,6 +106,14 @@ app.include_router(profile.router, prefix="/profile", tags=["Profile"], dependen
 app.include_router(lookup_router)
 app.include_router(refdata.router, dependencies=[Depends(current_user)])
 
+@app.get("/licenses", include_in_schema=False)
+def licenses_list_alias(request: Request, db: Session = Depends(get_db), user=Depends(current_user)):
+    return license_router.license_list(request, db, user)
+
+@app.get("/licenses/{lic_id}", include_in_schema=False)
+def licenses_detail_alias(lic_id: int, request: Request, db: Session = Depends(get_db), user=Depends(current_user)):
+    return license_router.license_detail(lic_id, request, db)
+
 # Sadece admin
 app.include_router(logs.router, prefix="/logs", tags=["Logs"], dependencies=[Depends(require_roles("admin"))])
 app.include_router(admin_router, dependencies=[Depends(require_roles("admin"))])

--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -143,6 +143,10 @@ def detail(request: Request, item_id: int, db: Session = Depends(get_db), user=D
         "inventory_detail.html", {"request": request, "inv": item, "logs": logs}
     )
 
+@router.get("/{item_id}", name="inventory.detail_short", include_in_schema=False)
+def detail_short(request: Request, item_id: int, db: Session = Depends(get_db), user=Depends(current_user)):
+  return detail(request, item_id, db, user)
+
 @router.get("/assign/sources", name="inventory.assign_sources")
 def assign_sources(type: str, exclude_id: int | None = None, db: Session = Depends(get_db)):
     if type == "users":


### PR DESCRIPTION
## Summary
- Add `/inventory/{id}` shortcut routing to existing detail view
- Expose `/licenses` and `/licenses/{id}` aliases for license list and details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ada68eb328832ba373e70a519cf1ef