### PR TITLE
Handle missing authentication middleware in license routes

### DIFF
--- a/routers/license.py
+++ b/routers/license.py
@@ -20,7 +20,7 @@ def _logla(db: Session, lic: License, islem: str, detay: str, islem_yapan: str):
 def get_current_user_name(request: Request) -> str:
     return (
         request.session.get("full_name")
-        or getattr(getattr(request, "user", None), "full_name", None)
+        or getattr(request.scope.get("user"), "full_name", None)
         or "Bilinmeyen Kullanıcı"
     )
 


### PR DESCRIPTION
## Summary
- Prevent `get_current_user_name` from accessing `request.user` when authentication middleware isn't installed

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adb3ae25b8832baeb4786c456dfd1d