### PR TITLE
Align inventory add form with license style

### DIFF
--- a/templates/inventory_add.html
+++ b/templates/inventory_add.html
@@ -1,95 +1,89 @@
 <form method="post" action="/inventory/create" class="needs-validation" novalidate>
   <div class="row g-3" id="envanter-ekle">
 
-    <!-- Envanter No -->
+    <!-- Envanter No / Bilgisayar Adı -->
     <div class="col-md-6">
       <label class="form-label">Envanter No</label>
       <input name="envanter_no" type="text" class="form-control" required placeholder="ENV-000123">
     </div>
-
-    <!-- Fabrika -->
-    <div class="col-md-6">
-      <label class="form-label">Fabrika</label>
-      <div class="input-group lookup-group">
-        <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="fabrika">&#9776;</button>
-        <input id="fabrika_display" type="text" class="form-control" value="Seçilmedi" readonly>
-        <input type="hidden" id="fabrika" name="fabrika" required>
-      </div>
-    </div>
-
-    <!-- Departman -->
-    <div class="col-md-6">
-      <label class="form-label">Departman</label>
-      <div class="input-group lookup-group">
-        <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="departman">&#9776;</button>
-        <input id="departman_display" type="text" class="form-control" value="Seçilmedi" readonly>
-        <input type="hidden" id="departman" name="departman" required>
-      </div>
-    </div>
-
-    <!-- Donanım Tipi -->
-    <div class="col-md-6">
-      <label class="form-label">Donanım Tipi</label>
-      <div class="input-group lookup-group">
-        <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="donanim_tipi">&#9776;</button>
-        <input id="donanim_tipi_display" type="text" class="form-control" value="Seçilmedi" readonly>
-        <input type="hidden" id="donanim_tipi" name="donanim_tipi" required>
-      </div>
-    </div>
-
-    <!-- Bilgisayar Adı -->
     <div class="col-md-6">
       <label class="form-label">Bilgisayar Adı</label>
       <input name="bilgisayar_adi" type="text" class="form-control" required placeholder="PC-OFIS-01">
     </div>
 
-    <!-- Marka -->
+    <!-- Fabrika / Departman -->
     <div class="col-md-6">
-      <label class="form-label">Marka</label>
-      <div class="input-group lookup-group">
-        <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="marka">&#9776;</button>
-        <input id="marka_display" type="text" class="form-control" value="Seçilmedi" readonly>
-        <input type="hidden" id="marka" name="marka" required>
+      <label class="form-label">Fabrika</label>
+      <div class="input-group">
+        <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="fabrika">&#9776;</button>
+        <input id="fabrika_display" type="text" class="form-control lookup-display" placeholder="Seçiniz..." readonly>
+        <input type="hidden" id="fabrika" name="fabrika" required>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Departman</label>
+      <div class="input-group">
+        <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="departman">&#9776;</button>
+        <input id="departman_display" type="text" class="form-control lookup-display" placeholder="Seçiniz..." readonly>
+        <input type="hidden" id="departman" name="departman" required>
       </div>
     </div>
 
-    <!-- Model -->
+    <!-- Donanım Tipi / Sorumlu Personel -->
     <div class="col-md-6">
-      <label class="form-label">Model</label>
-      <div class="input-group lookup-group">
-        <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="model">&#9776;</button>
-        <input id="model_display" type="text" class="form-control" value="Seçilmedi" readonly>
-        <input type="hidden" id="model" name="model" required>
+      <label class="form-label">Donanım Tipi</label>
+      <div class="input-group">
+        <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="donanim_tipi">&#9776;</button>
+        <input id="donanim_tipi_display" type="text" class="form-control lookup-display" placeholder="Seçiniz..." readonly>
+        <input type="hidden" id="donanim_tipi" name="donanim_tipi" required>
       </div>
     </div>
-
-    <!-- Seri No -->
-    <div class="col-md-6">
-      <label class="form-label">Seri No</label>
-      <input name="seri_no" type="text" class="form-control" required placeholder="SN123456789">
-    </div>
-
-    <!-- Sorumlu Personel -->
     <div class="col-md-6">
       <label class="form-label">Sorumlu Personel</label>
-      <div class="input-group lookup-group">
+      <div class="input-group">
         <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="sorumlu_personel">&#9776;</button>
-        <input id="sorumlu_personel_display" type="text" class="form-control" value="Seçilmedi" readonly>
+        <input id="sorumlu_personel_display" type="text" class="form-control lookup-display" placeholder="Seçiniz..." readonly>
         <input type="hidden" id="sorumlu_personel" name="sorumlu_personel" required>
       </div>
     </div>
 
-    <!-- Opsiyoneller -->
+    <!-- Marka / Model -->
     <div class="col-md-6">
-      <label class="form-label">Bağlı Makina No <small class="text-muted">(opsiyonel)</small></label>
-      <input name="bagli_makina_no" type="text" class="form-control" placeholder="Makina No">
+      <label class="form-label">Marka</label>
+      <div class="input-group">
+        <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="marka">&#9776;</button>
+        <input id="marka_display" type="text" class="form-control lookup-display" placeholder="Seçiniz..." readonly>
+        <input type="hidden" id="marka" name="marka" required>
+      </div>
     </div>
     <div class="col-md-6">
-      <label class="form-label">IFS No <small class="text-muted">(opsiyonel)</small></label>
+      <label class="form-label">Model</label>
+      <div class="input-group">
+        <button type="button" class="btn btn-outline-secondary lookup-btn" data-entity="model">&#9776;</button>
+        <input id="model_display" type="text" class="form-control lookup-display" placeholder="Seçiniz..." readonly>
+        <input type="hidden" id="model" name="model" required>
+      </div>
+    </div>
+
+    <!-- Seri No / IFS No -->
+    <div class="col-md-6">
+      <label class="form-label">Seri No</label>
+      <input name="seri_no" type="text" class="form-control" required placeholder="SN123456789">
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">IFS No <span class="text-muted">(zorunlu değil)</span></label>
       <input name="ifs_no" type="text" class="form-control" placeholder="IFS-...">
     </div>
+
+    <!-- Bağlı Makina No -->
+    <div class="col-md-6">
+      <label class="form-label">Bağlı Makina No <span class="text-muted">(zorunlu değil)</span></label>
+      <input name="bagli_makina_no" type="text" class="form-control" placeholder="Makina No">
+    </div>
+
+    <!-- Not -->
     <div class="col-12">
-      <label class="form-label">Not <small class="text-muted">(opsiyonel)</small></label>
+      <label class="form-label">Not <span class="text-muted">(zorunlu değil)</span></label>
       <textarea name="notlar" class="form-control" rows="2" placeholder="Açıklama / notlar"></textarea>
     </div>
   </div>
@@ -101,50 +95,42 @@
 </form>
 
 <style>
-  /* Yalnızca bu modalı düzenle */
-  #envanter-ekle .lookup-group .form-control[readonly]{ background-color: var(--bs-body-bg); cursor: pointer; }
-  #envanter-ekle .lookup-group .form-control[readonly].is-invalid{ border-color: var(--bs-danger); }
-  /* Eski “zorunlu.” yazılarını tamamen gizle (varsa) */
-  #envanter-ekle .invalid-feedback{ display: none !important; }
+  #envanter-ekle .input-group > .lookup-btn { border-top-right-radius: 0; border-bottom-right-radius: 0; }
+  #envanter-ekle .input-group > .lookup-display { border-top-left-radius: 0; border-bottom-left-radius: 0; }
+  #envanter-ekle .lookup-display::placeholder { color: var(--bs-secondary-color); opacity: 1; }
 </style>
 
 <script>window.SKIP_SELECT_ENHANCE = true;</script>
 <script>
 (function(){
-  // Burayı kendi seçim modalına bağla; şimdilik prompt ile seçim simülasyonu
+  // Burayı kendi seçim modalına bağla; şimdilik prompt ile seçim simüle
   function openPicker(entity, current){
     const v = prompt(entity.toUpperCase() + " seçin:", current || "");
     return (v && v.trim()) ? { id:v.trim(), text:v.trim() } : null;
   }
-
-  function handlePick(entity){
+  function pickAndFill(entity){
     const hid = document.getElementById(entity);
-    const disp = document.getElementById(entity + '_display');
-    const pick = openPicker(entity, hid.value);
-    if(!pick) return;
-    hid.value = pick.id;
-    disp.value = pick.text;
-    disp.classList.remove('is-invalid');
+    const dsp = document.getElementById(entity + '_display');
+    const p = openPicker(entity, hid.value);
+    if(!p) return;
+    hid.value = p.id; dsp.value = p.text;
+    dsp.classList.remove('is-invalid');
   }
-
-  // ≡ butonları ve readonly inputlar tıklanabilir
   document.querySelectorAll('#envanter-ekle .lookup-btn').forEach(b=>{
-    b.addEventListener('click', ()=>handlePick(b.dataset.entity));
+    b.addEventListener('click', ()=>pickAndFill(b.dataset.entity));
   });
-  document.querySelectorAll('#envanter-ekle .lookup-group .form-control[readonly]').forEach(v=>{
-    const entity = v.id.replace('_display','');
-    v.addEventListener('click', ()=>handlePick(entity));
+  document.querySelectorAll('#envanter-ekle .lookup-display').forEach(d=>{
+    const entity = d.id.replace('_display','');
+    d.addEventListener('click', ()=>pickAndFill(entity));
   });
 
-  // Submit’te: required hidden’ları kontrol et; eksikse yanındaki display alanını kırmızı yap
-  document.querySelector('#envanter-ekle').closest('form').addEventListener('submit', function(e){
+  // submit’te required hidden’ları kontrol et
+  const form = document.querySelector('#envanter-ekle').closest('form');
+  form.addEventListener('submit', (e)=>{
     let ok = true;
     document.querySelectorAll('#envanter-ekle input[type="hidden"][required]').forEach(h=>{
-      const disp = document.getElementById(h.id + '_display');
-      if(!h.value){
-        ok = false;
-        if(disp){ disp.classList.add('is-invalid'); }
-      }
+      const d = document.getElementById(h.id + '_display');
+      if(!h.value){ ok = false; d.classList.add('is-invalid'); }
     });
     if(!ok){ e.preventDefault(); e.stopPropagation(); }
   });


### PR DESCRIPTION
## Summary
- Rebuild inventory creation form to mirror license UI with lookup buttons and read-only placeholders
- Add helper script for picking values and validating required hidden fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb50b625c832ba4a733ab4849824e