### PR TITLE
Add Excel import/export stubs and buttons for tracking sections

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -1,5 +1,5 @@
-from fastapi import APIRouter, Request, Depends, Form, HTTPException
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi import APIRouter, Request, Depends, Form, HTTPException, UploadFile, File
+from fastapi.responses import JSONResponse, RedirectResponse, PlainTextResponse
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 from datetime import datetime
@@ -22,6 +22,16 @@ from security import current_user
 templates = Jinja2Templates(directory="templates")
 
 router = APIRouter(prefix="/inventory", tags=["inventory"])
+
+
+@router.get("/export", response_class=PlainTextResponse)
+async def export_inventory():
+    return "Excel export is not implemented yet."
+
+
+@router.post("/import", response_class=PlainTextResponse)
+async def import_inventory(file: UploadFile = File(...)):
+    return f"Received {file.filename}, but import is not implemented."
 
 
 def current_full_name(request: Request) -> str:

--- a/routers/license.py
+++ b/routers/license.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter, Depends, Request, Form, HTTPException
+from fastapi import APIRouter, Depends, Request, Form, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
 from starlette import status
-from fastapi.responses import RedirectResponse, HTMLResponse
+from fastapi.responses import RedirectResponse, HTMLResponse, PlainTextResponse
 from database import get_db
 from models import License, LicenseLog, Inventory
 from fastapi.templating import Jinja2Templates
@@ -11,6 +11,16 @@ from sqlalchemy import text
 
 router = APIRouter(prefix="/lisans", tags=["Lisans"])
 templates = Jinja2Templates(directory="templates")
+
+
+@router.get("/export", response_class=PlainTextResponse)
+async def export_licenses():
+    return "Excel export is not implemented yet."
+
+
+@router.post("/import", response_class=PlainTextResponse)
+async def import_licenses(file: UploadFile = File(...)):
+    return f"Received {file.filename}, but import is not implemented."
 
 
 def _logla(db: Session, lic: License, islem: str, detay: str, islem_yapan: str):

--- a/routers/licenses.py
+++ b/routers/licenses.py
@@ -1,10 +1,20 @@
 # routers/licenses.py
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, Request, UploadFile, File
+from fastapi.responses import HTMLResponse, PlainTextResponse
 from fastapi.templating import Jinja2Templates
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
+
+
+@router.get("/export", response_class=PlainTextResponse)
+async def export_licenses_stub():
+    return "Excel export is not implemented yet."
+
+
+@router.post("/import", response_class=PlainTextResponse)
+async def import_licenses_stub(file: UploadFile = File(...)):
+    return f"Received {file.filename}, but import is not implemented."
 
 @router.get("/", response_class=HTMLResponse)
 async def list_licenses(request: Request):

--- a/routers/printers.py
+++ b/routers/printers.py
@@ -1,5 +1,5 @@
-from fastapi import APIRouter, Depends, Request, Form, HTTPException
-from fastapi.responses import RedirectResponse, JSONResponse, HTMLResponse
+from fastapi import APIRouter, Depends, Request, Form, HTTPException, UploadFile, File
+from fastapi.responses import RedirectResponse, JSONResponse, HTMLResponse, PlainTextResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 from typing import Optional, Dict, Any
@@ -14,6 +14,16 @@ templates = Jinja2Templates(directory="templates")
 router = APIRouter(prefix="/printers", tags=["Printers"])
 
 USE_SCRAP_TABLE = True
+
+
+@router.get("/export", response_class=PlainTextResponse)
+async def export_printers():
+    return "Excel export is not implemented yet."
+
+
+@router.post("/import", response_class=PlainTextResponse)
+async def import_printers(file: UploadFile = File(...)):
+    return f"Received {file.filename}, but import is not implemented."
 
 
 def get_current_user_name(request: Request) -> str:

--- a/routers/requests.py
+++ b/routers/requests.py
@@ -1,10 +1,20 @@
 # routers/requests.py
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, Request, UploadFile, File
+from fastapi.responses import HTMLResponse, PlainTextResponse
 from fastapi.templating import Jinja2Templates
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
+
+
+@router.get("/export", response_class=PlainTextResponse)
+async def export_requests():
+    return "Excel export is not implemented yet."
+
+
+@router.post("/import", response_class=PlainTextResponse)
+async def import_requests(file: UploadFile = File(...)):
+    return f"Received {file.filename}, but import is not implemented."
 
 @router.get("/", response_class=HTMLResponse)
 async def list_requests(request: Request):

--- a/routers/stock.py
+++ b/routers/stock.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, UploadFile, File
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, PlainTextResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -13,6 +13,14 @@ from models import StockAssignment, StockLog
 
 router = APIRouter(prefix="/stock", tags=["Stock"])
 templates = Jinja2Templates(directory="templates")
+
+@router.get("/export", response_class=PlainTextResponse)
+async def export_stock():
+    return "Excel export is not implemented yet."
+
+@router.post("/import", response_class=PlainTextResponse)
+async def import_stock(file: UploadFile = File(...)):
+    return f"Received {file.filename}, but import is not implemented."
 
 
 def current_stock(db: Session):

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -11,6 +11,11 @@
       <h5 class="mb-0">Envanter</h5>
     </div>
     <div class="d-flex align-items-center gap-2">
+      <a href="/inventory/export" class="btn btn-outline-success btn-sm">Excel Çıkar</a>
+      <form action="/inventory/import" method="post" enctype="multipart/form-data" class="d-inline">
+        <input type="file" name="file" id="invExcel" class="d-none" onchange="this.form.submit()">
+        <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('invExcel').click()">Excel İçeri Al</button>
+      </form>
       <button class="btn btn-outline-secondary btn-sm" id="filterBtn">Filtre</button>
       <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">Temizle</button>
       <input type="text" id="searchInput" class="form-control form-control-sm" placeholder="Ara...">

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -11,6 +11,11 @@
       <h5 class="mb-0">Lisans</h5>
     </div>
     <div class="d-flex align-items-center gap-2">
+      <a href="/lisans/export" class="btn btn-outline-success btn-sm">Excel Çıkar</a>
+      <form action="/lisans/import" method="post" enctype="multipart/form-data" class="d-inline">
+        <input type="file" name="file" id="licExcel" class="d-none" onchange="this.form.submit()">
+        <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('licExcel').click()">Excel İçeri Al</button>
+      </form>
       <button class="btn btn-outline-secondary btn-sm" id="filterBtn">Filtre</button>
       <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">Temizle</button>
       <input type="text" id="searchInput" class="form-control form-control-sm" placeholder="Ara...">

--- a/templates/licenses/list.html
+++ b/templates/licenses/list.html
@@ -1,5 +1,12 @@
 {% extends "base.html" %}{% block title %}Lisans – Liste{% endblock %}
 {% block content %}
 <h2 class="h5 mb-3">Lisans Listesi</h2>
+<div class="mb-3">
+  <a href="/licenses/export" class="btn btn-outline-success btn-sm me-2">Excel Çıkar</a>
+  <form action="/licenses/import" method="post" enctype="multipart/form-data" class="d-inline">
+    <input type="file" name="file" id="licensesExcel" class="d-none" onchange="this.form.submit()">
+    <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('licensesExcel').click()">Excel İçeri Al</button>
+  </form>
+</div>
 <div class="card p-3">Liste/filtre...</div>
 {% endblock %}

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -12,6 +12,11 @@
       <h5 class="mb-0">Yazıcılar</h5>
     </div>
     <div class="d-flex align-items-center gap-2">
+      <a href="/printers/export" class="btn btn-outline-success btn-sm">Excel Çıkar</a>
+      <form action="/printers/import" method="post" enctype="multipart/form-data" class="d-inline">
+        <input type="file" name="file" id="printerExcel" class="d-none" onchange="this.form.submit()">
+        <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('printerExcel').click()">Excel İçeri Al</button>
+      </form>
       <button class="btn btn-outline-secondary btn-sm" id="filterBtn">Filtre</button>
       <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">Temizle</button>
       <input type="text" id="searchInput" class="form-control form-control-sm" placeholder="Ara...">

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}{% block title %}Talepler – Liste{% endblock %}
 {% block content %}
 <h2 class="h5 mb-3">Talepler</h2>
+<div class="mb-3">
+  <a href="/requests/export" class="btn btn-outline-success btn-sm me-2">Excel Çıkar</a>
+  <form action="/requests/import" method="post" enctype="multipart/form-data" class="d-inline">
+    <input type="file" name="file" id="reqExcel" class="d-none" onchange="this.form.submit()">
+    <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('reqExcel').click()">Excel İçeri Al</button>
+  </form>
+</div>
 <ul class="nav nav-tabs" id="requestTab" role="tablist">
   <li class="nav-item" role="presentation">
     <button class="nav-link active" id="aktif-tab" data-bs-toggle="tab" data-bs-target="#aktif" type="button" role="tab">Aktif Talepler</button>

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -6,6 +6,11 @@
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h5 class="mb-0">Stok Logları (En Güncel)</h5>
     <div class="d-flex gap-2">
+      <a href="/stock/export" class="btn btn-outline-success btn-sm">Excel Çıkar</a>
+      <form action="/stock/import" method="post" enctype="multipart/form-data" class="d-inline">
+        <input type="file" name="file" id="stockExcel" class="d-none" onchange="this.form.submit()">
+        <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('stockExcel').click()">Excel İçeri Al</button>
+      </form>
       <a href="#" id="addBtn" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle">
         <i class="bi bi-plus-lg"></i>
         <span>Ekle</span>


### PR DESCRIPTION
## Summary
- add placeholder /export and /import endpoints for requests, inventory, license, printers, and stock
- expose Excel Import/Export buttons on related list pages

## Testing
- `python -m py_compile routers/requests.py routers/inventory.py routers/license.py routers/licenses.py routers/printers.py routers/stock.py`


------
https://chatgpt.com/codex/tasks/task_e_68adb9aec32c832b8feffafb38f71ced