### PR TITLE
Consolidate Excel import/export into dropdown

### DIFF
--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -11,11 +11,20 @@
       <h5 class="mb-0">Envanter</h5>
     </div>
     <div class="d-flex align-items-center gap-2">
-      <a href="/inventory/export" class="btn btn-outline-success btn-sm">Excel Çıkar</a>
-      <form action="/inventory/import" method="post" enctype="multipart/form-data" class="d-inline">
-        <input type="file" name="file" id="invExcel" class="d-none" onchange="this.form.submit()">
-        <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('invExcel').click()">Excel İçeri Al</button>
-      </form>
+      <div class="dropdown">
+        <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+          Excel
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end">
+          <li><a class="dropdown-item" href="/inventory/export">Dışa Aktar</a></li>
+          <li>
+            <form action="/inventory/import" method="post" enctype="multipart/form-data">
+              <input type="file" name="file" id="invExcel" class="d-none" onchange="this.form.submit()">
+              <label for="invExcel" class="dropdown-item mb-0">İçe Aktar</label>
+            </form>
+          </li>
+        </ul>
+      </div>
       <button class="btn btn-outline-secondary btn-sm" id="filterBtn">Filtre</button>
       <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">Temizle</button>
       <input type="text" id="searchInput" class="form-control form-control-sm" placeholder="Ara...">

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -11,11 +11,20 @@
       <h5 class="mb-0">Lisans</h5>
     </div>
     <div class="d-flex align-items-center gap-2">
-      <a href="/lisans/export" class="btn btn-outline-success btn-sm">Excel Çıkar</a>
-      <form action="/lisans/import" method="post" enctype="multipart/form-data" class="d-inline">
-        <input type="file" name="file" id="licExcel" class="d-none" onchange="this.form.submit()">
-        <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('licExcel').click()">Excel İçeri Al</button>
-      </form>
+      <div class="dropdown">
+        <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+          Excel
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end">
+          <li><a class="dropdown-item" href="/lisans/export">Dışa Aktar</a></li>
+          <li>
+            <form action="/lisans/import" method="post" enctype="multipart/form-data">
+              <input type="file" name="file" id="licExcel" class="d-none" onchange="this.form.submit()">
+              <label for="licExcel" class="dropdown-item mb-0">İçe Aktar</label>
+            </form>
+          </li>
+        </ul>
+      </div>
       <button class="btn btn-outline-secondary btn-sm" id="filterBtn">Filtre</button>
       <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">Temizle</button>
       <input type="text" id="searchInput" class="form-control form-control-sm" placeholder="Ara...">

--- a/templates/licenses/list.html
+++ b/templates/licenses/list.html
@@ -2,11 +2,20 @@
 {% block content %}
 <h2 class="h5 mb-3">Lisans Listesi</h2>
 <div class="mb-3">
-  <a href="/licenses/export" class="btn btn-outline-success btn-sm me-2">Excel Çıkar</a>
-  <form action="/licenses/import" method="post" enctype="multipart/form-data" class="d-inline">
-    <input type="file" name="file" id="licensesExcel" class="d-none" onchange="this.form.submit()">
-    <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('licensesExcel').click()">Excel İçeri Al</button>
-  </form>
+  <div class="dropdown d-inline">
+    <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      Excel
+    </button>
+    <ul class="dropdown-menu">
+      <li><a class="dropdown-item" href="/licenses/export">Dışa Aktar</a></li>
+      <li>
+        <form action="/licenses/import" method="post" enctype="multipart/form-data">
+          <input type="file" name="file" id="licensesExcel" class="d-none" onchange="this.form.submit()">
+          <label for="licensesExcel" class="dropdown-item mb-0">İçe Aktar</label>
+        </form>
+      </li>
+    </ul>
+  </div>
 </div>
 <div class="card p-3">Liste/filtre...</div>
 {% endblock %}

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -12,11 +12,20 @@
       <h5 class="mb-0">Yazıcılar</h5>
     </div>
     <div class="d-flex align-items-center gap-2">
-      <a href="/printers/export" class="btn btn-outline-success btn-sm">Excel Çıkar</a>
-      <form action="/printers/import" method="post" enctype="multipart/form-data" class="d-inline">
-        <input type="file" name="file" id="printerExcel" class="d-none" onchange="this.form.submit()">
-        <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('printerExcel').click()">Excel İçeri Al</button>
-      </form>
+      <div class="dropdown">
+        <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+          Excel
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end">
+          <li><a class="dropdown-item" href="/printers/export">Dışa Aktar</a></li>
+          <li>
+            <form action="/printers/import" method="post" enctype="multipart/form-data">
+              <input type="file" name="file" id="printerExcel" class="d-none" onchange="this.form.submit()">
+              <label for="printerExcel" class="dropdown-item mb-0">İçe Aktar</label>
+            </form>
+          </li>
+        </ul>
+      </div>
       <button class="btn btn-outline-secondary btn-sm" id="filterBtn">Filtre</button>
       <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">Temizle</button>
       <input type="text" id="searchInput" class="form-control form-control-sm" placeholder="Ara...">

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -2,11 +2,20 @@
 {% block content %}
 <h2 class="h5 mb-3">Talepler</h2>
 <div class="mb-3">
-  <a href="/requests/export" class="btn btn-outline-success btn-sm me-2">Excel Çıkar</a>
-  <form action="/requests/import" method="post" enctype="multipart/form-data" class="d-inline">
-    <input type="file" name="file" id="reqExcel" class="d-none" onchange="this.form.submit()">
-    <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('reqExcel').click()">Excel İçeri Al</button>
-  </form>
+  <div class="dropdown d-inline">
+    <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      Excel
+    </button>
+    <ul class="dropdown-menu">
+      <li><a class="dropdown-item" href="/requests/export">Dışa Aktar</a></li>
+      <li>
+        <form action="/requests/import" method="post" enctype="multipart/form-data">
+          <input type="file" name="file" id="reqExcel" class="d-none" onchange="this.form.submit()">
+          <label for="reqExcel" class="dropdown-item mb-0">İçe Aktar</label>
+        </form>
+      </li>
+    </ul>
+  </div>
 </div>
 <ul class="nav nav-tabs" id="requestTab" role="tablist">
   <li class="nav-item" role="presentation">

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -6,11 +6,20 @@
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h5 class="mb-0">Stok Logları (En Güncel)</h5>
     <div class="d-flex gap-2">
-      <a href="/stock/export" class="btn btn-outline-success btn-sm">Excel Çıkar</a>
-      <form action="/stock/import" method="post" enctype="multipart/form-data" class="d-inline">
-        <input type="file" name="file" id="stockExcel" class="d-none" onchange="this.form.submit()">
-        <button type="button" class="btn btn-outline-primary btn-sm" onclick="document.getElementById('stockExcel').click()">Excel İçeri Al</button>
-      </form>
+      <div class="dropdown">
+        <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+          Excel
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end">
+          <li><a class="dropdown-item" href="/stock/export">Dışa Aktar</a></li>
+          <li>
+            <form action="/stock/import" method="post" enctype="multipart/form-data">
+              <input type="file" name="file" id="stockExcel" class="d-none" onchange="this.form.submit()">
+              <label for="stockExcel" class="dropdown-item mb-0">İçe Aktar</label>
+            </form>
+          </li>
+        </ul>
+      </div>
       <a href="#" id="addBtn" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle">
         <i class="bi bi-plus-lg"></i>
         <span>Ekle</span>


### PR DESCRIPTION
## Summary
- Replace separate Excel import/export buttons with single dropdown across templates

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adbc0dcc08832b994f6b669abc36e5