### PR TITLE
Show user and inventory action logs

### DIFF
--- a/routers/logs.py
+++ b/routers/logs.py
@@ -1,11 +1,35 @@
 # routers/logs.py
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Depends
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import Inventory, InventoryLog
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
 
+
 @router.get("/", response_class=HTMLResponse)
-async def logs_home(request: Request):
-    return templates.TemplateResponse("logs/index.html", {"request": request})
+def logs_home(request: Request, db: Session = Depends(get_db)):
+    user_logs = (
+        db.query(InventoryLog, Inventory.no.label("inv_no"))
+        .join(Inventory, Inventory.id == InventoryLog.inventory_id)
+        .order_by(InventoryLog.created_at.desc())
+        .all()
+    )
+    inventory_logs = (
+        db.query(InventoryLog, Inventory.no.label("inv_no"))
+        .join(Inventory, Inventory.id == InventoryLog.inventory_id)
+        .order_by(Inventory.no.asc(), InventoryLog.created_at.desc())
+        .all()
+    )
+    return templates.TemplateResponse(
+        "logs/index.html",
+        {
+            "request": request,
+            "user_logs": user_logs,
+            "inventory_logs": inventory_logs,
+        },
+    )

--- a/templates/logs/index.html
+++ b/templates/logs/index.html
@@ -11,10 +11,65 @@
 </ul>
 <div class="tab-content pt-3">
   <div class="tab-pane fade show active" id="userlogs" role="tabpanel" aria-labelledby="userlogs-tab">
-    <div class="card p-3">Kullanıcı kayıtları listesi...</div>
+    <div class="card p-0">
+      <div class="table-responsive">
+        <table class="table table-sm table-striped mb-0">
+          <thead>
+            <tr>
+              <th>Kullanıcı</th>
+              <th>İşlem</th>
+              <th>Envanter No</th>
+              <th>Tarih</th>
+            </tr>
+          </thead>
+          <tbody>
+          {% for log, inv_no in user_logs %}
+            <tr>
+              <td>{{ log.actor }}</td>
+              <td>{{ log.action }}</td>
+              <td>{{ inv_no }}</td>
+              <td>{{ log.created_at }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="4" class="text-muted">Kayıt yok</td></tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
   <div class="tab-pane fade" id="inventorylogs" role="tabpanel" aria-labelledby="inventorylogs-tab">
-    <div class="card p-3">Envanter kayıtları listesi...</div>
+    <div class="card p-0">
+      <div class="table-responsive">
+        <table class="table table-sm table-striped mb-0">
+          <thead>
+            <tr>
+              <th>Envanter No</th>
+              <th>İşlem</th>
+              <th>Önce</th>
+              <th>Sonra</th>
+              <th>Kullanıcı</th>
+              <th>Tarih</th>
+            </tr>
+          </thead>
+          <tbody>
+          {% for log, inv_no in inventory_logs %}
+            <tr>
+              <td>{{ inv_no }}</td>
+              <td>{{ log.action }}</td>
+              <td class="text-muted"><pre class="mb-0">{{ log.before_json }}</pre></td>
+              <td><pre class="mb-0">{{ log.after_json }}</pre></td>
+              <td>{{ log.actor }}</td>
+              <td>{{ log.created_at }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="6" class="text-muted">Kayıt yok</td></tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Display recent user actions and inventory changes on the logs page
- Query inventory log data and show before/after snapshots with actor and timestamp

## Testing
- `python -m py_compile routers/logs.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adc347ab2c832b9673b46f9908fb32