### PR TITLE
Add mini picker modal and picker API

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ from routers import (
     panel as panel_router,
 )
 from routers.lookup import router as lookup_router
+from routers.picker import router as picker_router
 from routes.admin import router as admin_router
 from security import current_user, require_roles
 
@@ -104,6 +105,7 @@ app.include_router(stock.router, dependencies=[Depends(current_user)])
 app.include_router(trash.router, prefix="/trash", tags=["Trash"], dependencies=[Depends(current_user)])
 app.include_router(profile.router, prefix="/profile", tags=["Profile"], dependencies=[Depends(current_user)])
 app.include_router(lookup_router)
+app.include_router(picker_router)
 app.include_router(refdata.router, dependencies=[Depends(current_user)])
 
 @app.get("/licenses", include_in_schema=False)

--- a/routers/picker.py
+++ b/routers/picker.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from typing import List, Dict, Any, Optional
+
+from database import get_db
+from models import UsageArea, LicenseName, Factory, HardwareType, Brand, Model
+
+router = APIRouter(prefix="/api/picker", tags=["Picker"])
+
+ENTITY_MAP = {
+    "kullanim_alani": {"model": UsageArea, "label": "name"},
+    "lisans_adi": {"model": LicenseName, "label": "name"},
+    "fabrika": {"model": Factory, "label": "name"},
+    "donanim_tipi": {"model": HardwareType, "label": "name"},
+    "marka": {"model": Brand, "label": "name"},
+    "model": {"model": Model, "label": "name"},
+}
+
+
+def resolve_entity(entity: str):
+    meta = ENTITY_MAP.get(entity)
+    if not meta or meta["model"] is None:
+        raise HTTPException(status_code=404, detail="Entity bulunamadı / modellenmedi.")
+    return meta
+
+
+@router.get("/{entity}", response_model=List[Dict[str, Any]])
+def picker_list(
+    entity: str,
+    q: Optional[str] = Query(None),
+    db: Session = Depends(get_db),
+):
+    meta = resolve_entity(entity)
+    ModelCls = meta["model"]
+    label = meta["label"]
+    query = db.query(ModelCls)
+    if q:
+        query = query.filter(getattr(ModelCls, label).ilike(f"%{q}%"))
+    rows = query.order_by(getattr(ModelCls, label).asc()).limit(200).all()
+    return [{"id": getattr(r, "id"), "text": getattr(r, label)} for r in rows]
+
+
+@router.delete("/{entity}/{row_id}")
+def picker_delete(entity: str, row_id: int, db: Session = Depends(get_db)):
+    meta = resolve_entity(entity)
+    ModelCls = meta["model"]
+    obj = db.get(ModelCls, row_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Kayıt bulunamadı.")
+    db.delete(obj)
+    db.commit()
+    return {"ok": True}

--- a/templates/product_add.html
+++ b/templates/product_add.html
@@ -1,48 +1,208 @@
 {% extends "base.html" %}
 {% block title %}Ürün Ekle{% endblock %}
 {% block content %}
-<div class="row g-3">
-  <div class="col-lg-4 col-md-6">
-    <div class="ref-card d-flex justify-content-between align-items-center" data-entity="kullanim-alani">
-      <span>Kullanım Alanı</span>
-      <button class="btn btn-success ref-add" type="button">Ekle</button>
+<section id="urun-ekle">
+  <h5 class="mb-3">Ürün / Envanter Ekle</h5>
+
+  <div class="actions-grid">
+    <!-- Kullanım Alanı -->
+    <div class="pick-item">
+      <div class="pick-label">
+        Kullanım Alanı
+        <span class="pick-chip d-none" data-for="kullanim_alani"></span>
+      </div>
+      <button type="button" class="pick-btn" data-entity="kullanim_alani" aria-label="Kullanım Alanı">≡</button>
+      <input type="hidden" name="kullanim_alani" id="kullanim_alani">
+    </div>
+
+    <!-- Lisans Adı -->
+    <div class="pick-item">
+      <div class="pick-label">
+        Lisans Adı
+        <span class="pick-chip d-none" data-for="lisans_adi"></span>
+      </div>
+      <button type="button" class="pick-btn" data-entity="lisans_adi" aria-label="Lisans Adı">≡</button>
+      <input type="hidden" name="lisans_adi" id="lisans_adi">
+    </div>
+
+    <!-- Fabrika -->
+    <div class="pick-item">
+      <div class="pick-label">
+        Fabrika
+        <span class="pick-chip d-none" data-for="fabrika"></span>
+      </div>
+      <button type="button" class="pick-btn" data-entity="fabrika" aria-label="Fabrika">≡</button>
+      <input type="hidden" name="fabrika" id="fabrika">
+    </div>
+
+    <!-- Donanım Tipi -->
+    <div class="pick-item">
+      <div class="pick-label">
+        Donanım Tipi
+        <span class="pick-chip d-none" data-for="donanim_tipi"></span>
+      </div>
+      <button type="button" class="pick-btn" data-entity="donanim_tipi" aria-label="Donanım Tipi">≡</button>
+      <input type="hidden" name="donanim_tipi" id="donanim_tipi">
+    </div>
+
+    <!-- Marka -->
+    <div class="pick-item">
+      <div class="pick-label">
+        Marka
+        <span class="pick-chip d-none" data-for="marka"></span>
+      </div>
+      <button type="button" class="pick-btn" data-entity="marka" aria-label="Marka">≡</button>
+      <input type="hidden" name="marka" id="marka">
+    </div>
+
+    <!-- Model -->
+    <div class="pick-item">
+      <div class="pick-label">
+        Model
+        <span class="pick-chip d-none" data-for="model"></span>
+      </div>
+      <button type="button" class="pick-btn" data-entity="model" aria-label="Model">≡</button>
+      <input type="hidden" name="model" id="model">
     </div>
   </div>
-  <div class="col-lg-4 col-md-6">
-    <div class="ref-card d-flex justify-content-between align-items-center" data-entity="lisans-adi">
-      <span>Lisans Adı</span>
-      <button class="btn btn-success ref-add" type="button">Ekle</button>
+</section>
+
+<!-- ====== MINI PICKER MODAL (küçük ekran) ====== -->
+<div id="picker-modal" class="picker-modal" hidden>
+  <div class="picker-card">
+    <div class="picker-head">
+      <strong id="picker-title">Seçim</strong>
+      <button type="button" class="picker-close" aria-label="Kapat">×</button>
     </div>
-  </div>
-  <div class="col-lg-4 col-md-6">
-    <div class="ref-card d-flex justify-content-between align-items-center" data-entity="fabrika">
-      <span>Fabrika</span>
-      <button class="btn btn-success ref-add" type="button">Ekle</button>
+
+    <div class="picker-search">
+      <input id="picker-search" type="text" placeholder="Ara..." />
     </div>
-  </div>
-  <div class="col-lg-4 col-md-6">
-    <div class="ref-card d-flex justify-content-between align-items-center" data-entity="donanim-tipi">
-      <span>Donanım Tipi</span>
-      <button class="btn btn-success ref-add" type="button">Ekle</button>
-    </div>
-  </div>
-  <div class="col-lg-4 col-md-6">
-    <div class="ref-card d-flex justify-content-between align-items-center" data-entity="marka">
-      <span>Marka</span>
-      <button class="btn btn-success ref-add" type="button">Ekle</button>
-    </div>
-  </div>
-  <div class="col-lg-4 col-md-6">
-    <div class="ref-card d-flex justify-content-between align-items-center" data-entity="model">
-      <span>Model</span>
-      <button class="btn btn-success ref-add" type="button">Ekle</button>
+
+    <div id="picker-list" class="picker-list"><!-- JS doldurur --></div>
+
+    <div class="picker-foot">
+      <button type="button" class="btn btn-light" id="picker-cancel">Kapat</button>
     </div>
   </div>
 </div>
-<script defer src="/static/js/refdata.js"></script>
+
+<style>
+  /* Kart ızgarası */
+  #urun-ekle .actions-grid{display:grid;gap:16px 24px;grid-template-columns:repeat(3,minmax(220px,1fr))}
+  @media (max-width:1200px){#urun-ekle .actions-grid{grid-template-columns:repeat(2,minmax(220px,1fr))}}
+  @media (max-width:640px){#urun-ekle .actions-grid{grid-template-columns:1fr}}
+  #urun-ekle .pick-item{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border:1px solid #e5e7eb;border-radius:12px;background:#fff;box-shadow:0 1px 2px rgba(16,24,40,.04)}
+  #urun-ekle .pick-label{font-weight:600;color:#111827;display:flex;align-items:center;gap:8px}
+  #urun-ekle .pick-chip{font-size:.75rem;padding:2px 8px;border-radius:999px;background:#eef2ff;color:#3730a3}
+  #urun-ekle .pick-btn{width:48px;height:48px;display:inline-flex;align-items:center;justify-content:center;border:1px solid #d1d5db;border-radius:12px;background:#f9fafb;transition:all .15s ease;font-size:20px;line-height:1}
+  #urun-ekle .pick-btn:hover{background:#f3f4f6;transform:translateY(-1px)}
+  #urun-ekle .pick-btn:active{transform:translateY(0)}
+
+  /* Mini modal */
+  .picker-modal{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(15,23,42,.4);z-index:1085}
+  .picker-card{width:420px;max-width:92vw;background:#fff;border-radius:14px;box-shadow:0 10px 30px rgba(0,0,0,.18);overflow:hidden}
+  .picker-head{display:flex;align-items:center;justify-content:space-between;padding:10px 14px;border-bottom:1px solid #eef2f7}
+  .picker-close{border:0;background:transparent;font-size:22px;line-height:1;cursor:pointer;padding:2px 6px}
+  .picker-search{padding:10px 14px;border-bottom:1px solid #eef2f7}
+  .picker-search input{width:100%;padding:10px 12px;border:1px solid #dbe2ea;border-radius:10px}
+  .picker-list{max-height:320px;overflow:auto}
+  .picker-row{display:flex;align-items:center;justify-content:space-between;padding:10px 14px;border-bottom:1px dashed #eef2f7}
+  .picker-row:nth-child(even){background:#fafbff}
+  .picker-name{margin:0;font-size:14px}
+  .picker-actions{display:flex;gap:8px;align-items:center}
+  .picker-select{border:1px solid #d1d5db;background:#f9fafb;border-radius:8px;padding:6px 10px;cursor:pointer}
+  .picker-del{border:1px solid #ef4444;background:#fff;color:#ef4444;border-radius:999px;width:28px;height:28px;line-height:1;font-weight:700}
+  .picker-del:hover{background:#fee2e2}
+  .picker-empty{padding:14px;color:#6b7280;font-size:14px}
+  .picker-foot{padding:10px 14px;display:flex;justify-content:flex-end;gap:8px;border-top:1px solid #eef2f7}
+</style>
+
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
-    if (window.initRefAdmin) window.initRefAdmin();
+/* === picker modal === */
+(() => {
+  // Frontend tarafında endpoint başlıklarını tanımla
+  const PICKER_MAP = {
+    kullanim_alani: { title: "KULLANIM ALANI", endpoint: "/api/picker/kullanim_alani" },
+    lisans_adi:     { title: "LİSANS ADI",     endpoint: "/api/picker/lisans_adi"     },
+    fabrika:        { title: "FABRİKA",        endpoint: "/api/picker/fabrika"        },
+    donanim_tipi:   { title: "DONANIM TİPİ",   endpoint: "/api/picker/donanim_tipi"   },
+    marka:          { title: "MARKA",          endpoint: "/api/picker/marka"          },
+    model:          { title: "MODEL",          endpoint: "/api/picker/model"          },
+  };
+
+  const $modal  = document.getElementById('picker-modal');
+  const $title  = document.getElementById('picker-title');
+  const $search = document.getElementById('picker-search');
+  const $list   = document.getElementById('picker-list');
+  const $close  = document.querySelector('.picker-close');
+  const $cancel = document.getElementById('picker-cancel');
+
+  let current = { entity:null, hidden:null, chip:null, endpoint:null };
+
+  function openModal(entity, hiddenEl, chipEl){
+    const meta = PICKER_MAP[entity] || { title: entity.toUpperCase(), endpoint: `/api/picker/${entity}` };
+    current = { entity, hidden: hiddenEl, chip: chipEl||null, endpoint: meta.endpoint };
+    $title.textContent = `${meta.title} seçin`;
+    $search.value = ''; $list.innerHTML = '';
+    $modal.hidden = false; $modal.style.display = 'flex';
+    load('');
+    $search.focus();
+  }
+
+  async function load(q){
+    const url = new URL(current.endpoint, window.location.origin);
+    if(q) url.searchParams.set('q', q);
+    const res = await fetch(url, { headers:{Accept:'application/json'} });
+    const data = (await res.json()) || []; // [{id,text}]
+    render(data);
+  }
+
+  function render(items){
+    if(!items.length){ $list.innerHTML = `<div class="picker-empty">Kayıt bulunamadı.</div>`; return; }
+    $list.innerHTML = items.map(r=>`
+      <div class="picker-row" data-id="${r.id}" data-text="${r.text}">
+        <p class="picker-name">${r.text}</p>
+        <div class="picker-actions">
+          <button type="button" class="picker-select">Seç</button>
+          <button type="button" class="picker-del" title="Sil">–</button>
+        </div>
+      </div>
+    `).join('');
+  }
+
+  function closeModal(){
+    $modal.style.display='none'; $modal.hidden=true; $list.innerHTML=''; $search.value='';
+    current = { entity:null, hidden:null, chip:null, endpoint:null };
+  }
+
+  // Etkinlikler
+  $search.oninput = (e)=> load(e.target.value.trim());
+  $list.onclick = async (e)=>{
+    const row = e.target.closest('.picker-row'); if(!row) return;
+    if(e.target.classList.contains('picker-select')){
+      if(current.hidden){ current.hidden.value = row.dataset.id; }
+      if(current.chip){ current.chip.textContent = row.dataset.text; current.chip.classList.remove('d-none'); }
+      closeModal();
+    }else if(e.target.classList.contains('picker-del')){
+      if(!confirm('Silinsin mi?')) return;
+      const del = await fetch(`${current.endpoint}/${encodeURIComponent(row.dataset.id)}`, { method:'DELETE' });
+      if(del.ok){ row.remove(); if(!$list.children.length){ $list.innerHTML = `<div class="picker-empty">Kayıt bulunamadı.</div>`; } }
+      else{ alert('Silme başarısız!'); }
+    }
+  };
+  $close.onclick = $cancel.onclick = closeModal;
+  $modal.addEventListener('click', e=>{ if(e.target===$modal) closeModal(); });
+
+  // ≡ butonlarını bağla
+  document.querySelectorAll('#urun-ekle .pick-btn').forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      const entity = btn.dataset.entity;
+      const hidden = document.getElementById(entity);
+      const chip   = document.querySelector(`.pick-chip[data-for="${entity}"]`);
+      openModal(entity, hidden, chip);
+    });
   });
+})();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace product add page with picker-based UI and modal for selection
- introduce FastAPI picker router providing generic list and delete operations for reference data
- wire picker router into application

## Testing
- `python -m py_compile routers/picker.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aea16470e0832baedf3f604daa3bc5