### PR TITLE
Prevent Jinja comment parsing in admin templates

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -116,8 +116,8 @@
       <!-- ==== Stil (Ürün / Envanter Ekle sekmesi) ==== -->
       <style>
         #admin-urun-ekle .actions-grid{display:grid;gap:16px 24px;grid-template-columns:repeat(3,minmax(220px,1fr))}
-        @media (max-width:1200px){#admin-urun-ekle .actions-grid{grid-template-columns:repeat(2,minmax(220px,1fr))}}
-        @media (max-width:640px){#admin-urun-ekle .actions-grid{grid-template-columns:1fr}}
+        @media (max-width:1200px){ #admin-urun-ekle .actions-grid{grid-template-columns:repeat(2,minmax(220px,1fr))}}
+        @media (max-width:640px){ #admin-urun-ekle .actions-grid{grid-template-columns:1fr}}
         #admin-urun-ekle .pick-item{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border:1px solid #e5e7eb;border-radius:12px;background:#fff;box-shadow:0 1px 2px rgba(16,24,40,.04)}
         #admin-urun-ekle .pick-label{font-weight:600;color:#111827;display:flex;align-items:center;gap:8px}
         #admin-urun-ekle .pick-chip{font-size:.75rem;padding:2px 8px;border-radius:999px;background:#eef2ff;color:#3730a3}

--- a/templates/product_add.html
+++ b/templates/product_add.html
@@ -90,8 +90,8 @@
 <style>
   /* Kart ızgarası */
   #urun-ekle .actions-grid{display:grid;gap:16px 24px;grid-template-columns:repeat(3,minmax(220px,1fr))}
-  @media (max-width:1200px){#urun-ekle .actions-grid{grid-template-columns:repeat(2,minmax(220px,1fr))}}
-  @media (max-width:640px){#urun-ekle .actions-grid{grid-template-columns:1fr}}
+  @media (max-width:1200px){ #urun-ekle .actions-grid{grid-template-columns:repeat(2,minmax(220px,1fr))}}
+  @media (max-width:640px){ #urun-ekle .actions-grid{grid-template-columns:1fr}}
   #urun-ekle .pick-item{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border:1px solid #e5e7eb;border-radius:12px;background:#fff;box-shadow:0 1px 2px rgba(16,24,40,.04)}
   #urun-ekle .pick-label{font-weight:600;color:#111827;display:flex;align-items:center;gap:8px}
   #urun-ekle .pick-chip{font-size:.75rem;padding:2px 8px;border-radius:999px;background:#eef2ff;color:#3730a3}


### PR DESCRIPTION
## Summary
- fix missing end-of-comment issue in admin page styles
- avoid Jinja comment parsing in product add page styles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aec73eb49c832b95327dab2a5af3dd