### PR TITLE
feat: add picker add support

### DIFF
--- a/routers/picker.py
+++ b/routers/picker.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from typing import List, Dict, Any, Optional
 
@@ -7,46 +8,92 @@ from models import UsageArea, LicenseName, Factory, HardwareType, Brand, Model
 
 router = APIRouter(prefix="/api/picker", tags=["Picker"])
 
+# --- MODEL eşleme ---
+# label: görünen metnin alanı
+# parent_field: (opsiyonel) bağlı fk alanı (ör. model.brand_id)
 ENTITY_MAP = {
-    "kullanim_alani": {"model": UsageArea, "label": "name"},
-    "lisans_adi": {"model": LicenseName, "label": "name"},
-    "fabrika": {"model": Factory, "label": "name"},
-    "donanim_tipi": {"model": HardwareType, "label": "name"},
-    "marka": {"model": Brand, "label": "name"},
-    "model": {"model": Model, "label": "name"},
+    "kullanim_alani": {"model": UsageArea, "label": "name", "parent_field": None},
+    "lisans_adi":     {"model": LicenseName, "label": "name", "parent_field": None},
+    "fabrika":        {"model": Factory, "label": "name", "parent_field": None},
+    "donanim_tipi":   {"model": HardwareType, "label": "name", "parent_field": None},
+    "marka":          {"model": Brand, "label": "name", "parent_field": None},
+    "model":          {"model": Model, "label": "name", "parent_field": "brand_id"},  # 🔴 bağlı
 }
-
 
 def resolve_entity(entity: str):
     meta = ENTITY_MAP.get(entity)
     if not meta or meta["model"] is None:
-        raise HTTPException(status_code=404, detail="Entity bulunamadı / modellenmedi.")
+        raise HTTPException(404, "Entity bulunamadı / modellenmedi.")
     return meta
 
+class CreatePayload(BaseModel):
+    text: str
+    parent_id: Optional[int] = None  # (örn. model eklerken marka_id)
 
 @router.get("/{entity}", response_model=List[Dict[str, Any]])
 def picker_list(
     entity: str,
     q: Optional[str] = Query(None),
+    request: Request = None,
     db: Session = Depends(get_db),
 ):
     meta = resolve_entity(entity)
-    ModelCls = meta["model"]
+    Model = meta["model"]
     label = meta["label"]
-    query = db.query(ModelCls)
+    parent_field = meta.get("parent_field")
+
+    query = db.query(Model)
+
+    # parent filter: ?marka_id=.. veya ?parent_id=..
+    params = dict(request.query_params)
+    raw_parent = params.get("parent_id") or params.get("marka_id")
+    if parent_field and not raw_parent:
+        raw_parent = params.get(parent_field)
+    if parent_field and raw_parent:
+        query = query.filter(getattr(Model, parent_field) == int(raw_parent))
+
     if q:
-        query = query.filter(getattr(ModelCls, label).ilike(f"%{q}%"))
-    rows = query.order_by(getattr(ModelCls, label).asc()).limit(200).all()
+        query = query.filter(getattr(Model, label).ilike(f"%{q}%"))
+
+    rows = query.order_by(getattr(Model, label).asc()).limit(200).all()
     return [{"id": getattr(r, "id"), "text": getattr(r, label)} for r in rows]
 
+@router.post("/{entity}", response_model=Dict[str, Any])
+def picker_create(entity: str, body: CreatePayload, db: Session = Depends(get_db)):
+    meta = resolve_entity(entity)
+    Model = meta["model"]
+    label = meta["label"]
+    parent_field = meta.get("parent_field")
+
+    # Boş/çok kısa kontrolü
+    name = (body.text or "").strip()
+    if not name:
+        raise HTTPException(400, "Metin gerekli.")
+
+    # Duplicate basit kontrol (case-insensitive)
+    exists_q = db.query(Model).filter(getattr(Model, label).ilike(name))
+    if parent_field and body.parent_id:
+        exists_q = exists_q.filter(getattr(Model, parent_field) == body.parent_id)
+    if db.query(exists_q.exists()).scalar():
+        raise HTTPException(409, "Kayıt zaten var.")
+
+    kwargs = {label: name}
+    if parent_field and body.parent_id:
+        kwargs[parent_field] = body.parent_id
+
+    obj = Model(**kwargs)
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return {"id": getattr(obj, "id"), "text": getattr(obj, label)}
 
 @router.delete("/{entity}/{row_id}")
 def picker_delete(entity: str, row_id: int, db: Session = Depends(get_db)):
     meta = resolve_entity(entity)
-    ModelCls = meta["model"]
-    obj = db.get(ModelCls, row_id)
+    Model = meta["model"]
+    obj = db.query(Model).get(row_id)
     if not obj:
-        raise HTTPException(status_code=404, detail="Kayıt bulunamadı.")
+        raise HTTPException(404, "Kayıt bulunamadı.")
     db.delete(obj)
     db.commit()
     return {"ok": True}

--- a/static/js/mini-picker.js
+++ b/static/js/mini-picker.js
@@ -1,10 +1,14 @@
 (function(){
+
+  // ENTITY eşlemesi: endpoint + opsiyonel bağımlılık (dependsOn)
   const MAP = {
     kullanim_alani: { title: "KULLANIM ALANI", endpoint: "/api/picker/kullanim_alani" },
     lisans_adi:     { title: "LİSANS ADI",     endpoint: "/api/picker/lisans_adi"     },
     fabrika:        { title: "FABRİKA",        endpoint: "/api/picker/fabrika"        },
     donanim_tipi:   { title: "DONANIM TİPİ",   endpoint: "/api/picker/donanim_tipi"   },
     marka:          { title: "MARKA",          endpoint: "/api/picker/marka"          },
+
+    // MODEL marka'ya bağlı: GET'te ?marka_id=.. gönder, POST'ta parent_id olarak geç
     model:          { title: "MODEL",          endpoint: "/api/picker/model",
                       dependsOn: { hiddenId: "marka", param: "marka_id" } },
   };
@@ -12,6 +16,7 @@
   const $m      = document.getElementById('picker-modal');
   const $title  = document.getElementById('picker-title');
   const $search = document.getElementById('picker-search');
+  const $add    = document.getElementById('picker-add');
   const $list   = document.getElementById('picker-list');
   const $close  = document.querySelector('.picker-close');
   const $cancel = document.getElementById('picker-cancel');
@@ -20,35 +25,49 @@
 
   function getDependencyParams(entity){
     const meta = MAP[entity];
-    if(!meta || !meta.dependsOn) return {};
+    if(!meta || !meta.dependsOn) return { extra: {}, parentId: null };
     const dep = meta.dependsOn;
     const depHidden = document.getElementById(dep.hiddenId);
-    if(!depHidden || !depHidden.value) return null;
-    return { [dep.param]: depHidden.value };
+    if(!depHidden || !depHidden.value) return { extra: null, parentId: null }; // bağımlı ama seçilmemiş
+    return { extra: { [dep.param]: depHidden.value }, parentId: depHidden.value };
   }
 
   function openModal(entity, hiddenEl, chipEl){
     const meta = MAP[entity] || { title: entity.toUpperCase(), endpoint: `/api/picker/${entity}` };
-    const extraParams = getDependencyParams(entity);
-    if(extraParams === null){
-      alert("Önce MARKA seçin.");
+
+    const dep = getDependencyParams(entity);
+    if(dep.extra === null){
+      alert("Önce bağlı alanı seçin (örn. önce MARKA seçin).");
       return;
     }
-    current = { entity, endpoint: meta.endpoint, hidden: hiddenEl, chip: chipEl || null, extra: extraParams || {} };
+
+    current = {
+      entity,
+      endpoint: meta.endpoint,
+      hidden: hiddenEl,
+      chip: chipEl || null,
+      extra: dep.extra || {},
+      parentId: dep.parentId || null,
+    };
 
     $title.textContent = `${meta.title} seçin`;
     $search.value = ''; $list.innerHTML = '';
     $m.hidden = false; $m.style.display = 'flex';
+
+    updateAddState();
     load('');
     $search.focus();
+  }
+
+  function updateAddState(){
+    $add.disabled = ($search.value.trim().length === 0);
   }
 
   async function load(q){
     const url = new URL(current.endpoint, location.origin);
     if(q) url.searchParams.set('q', q);
     Object.entries(current.extra || {}).forEach(([k,v]) => url.searchParams.set(k, v));
-
-    const res = await fetch(url, { headers:{Accept:'application/json'} });
+    const res = await fetch(url, { headers:{ Accept:'application/json' } });
     const data = (await res.json()) || [];
     render(data);
   }
@@ -62,47 +81,80 @@
           <button type="button" class="picker-select">Seç</button>
           <button type="button" class="picker-del" title="Sil">–</button>
         </div>
-      </div>
-    `).join('');
+      </div>`).join('');
   }
 
   function closeModal(){
-    $m.style.display='none'; $m.hidden=true; $list.innerHTML=''; $search.value='';
+    $m.style.display='none'; $m.hidden=true;
+    $list.innerHTML=''; $search.value='';
     current = { entity:null, endpoint:null, hidden:null, chip:null, extra:{} };
   }
 
-  $search.oninput = e => load(e.target.value.trim());
-  $list.onclick = async e => {
+  // Arama + Ekle
+  $search.addEventListener('input', (e)=>{ updateAddState(); load(e.target.value.trim()); });
+  $search.addEventListener('keydown', (e)=>{ if(e.key === 'Enter' && !$add.disabled) { e.preventDefault(); addItem(); } });
+
+  $add.addEventListener('click', addItem);
+
+  async function addItem(){
+    const text = $search.value.trim();
+    if(!text) return;
+
+    // POST body: { text, parent_id? }
+    const body = { text };
+    if(current.parentId) body.parent_id = current.parentId;
+
+    const res = await fetch(current.endpoint, {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json', 'Accept':'application/json' },
+      body: JSON.stringify(body)
+    });
+
+    if(res.ok){
+      const created = await res.json(); // {id, text}
+      // otomatik seç
+      if(current.hidden) current.hidden.value = created.id;
+      if(current.chip){ current.chip.textContent = created.text; current.chip.classList.remove('d-none'); }
+      closeModal();
+    }else if(res.status === 409){
+      alert('Bu kayıt zaten var.');
+    }else{
+      alert('Ekleme başarısız!');
+    }
+  }
+
+  // Liste seçim/silme
+  $list.addEventListener('click', async (e)=>{
     const row = e.target.closest('.picker-row'); if(!row) return;
+
     if(e.target.classList.contains('picker-select')){
       if(current.hidden) current.hidden.value = row.dataset.id;
       if(current.chip){ current.chip.textContent = row.dataset.text; current.chip.classList.remove('d-none'); }
       closeModal();
     }else if(e.target.classList.contains('picker-del')){
       if(!confirm('Silinsin mi?')) return;
-      const del = await fetch(`${current.endpoint}/${encodeURIComponent(row.dataset.id)}`, {method:'DELETE'});
-      if(del.ok){
+      const url = `${current.endpoint}/${encodeURIComponent(row.dataset.id)}`;
+      const delRes = await fetch(url, { method:'DELETE' });
+      if(delRes.ok){
         row.remove();
         if(!$list.children.length) $list.innerHTML = `<div class="picker-empty">Kayıt bulunamadı.</div>`;
-      }else{ alert('Silme başarısız!'); }
+      }else{
+        alert('Silme başarısız!');
+      }
     }
-  };
+  });
+
   $close.onclick = $cancel.onclick = closeModal;
-  $m.addEventListener('click', e => { if(e.target === $m) closeModal(); });
+  $m.addEventListener('click', e=>{ if(e.target === $m) closeModal(); });
 
-  function bindPickButtons(root){
-    const container = typeof root === 'string' ? document.querySelector(root) : root;
-    if(!container) return;
-    container.querySelectorAll('.pick-btn').forEach(btn => {
-      btn.addEventListener('click', () => {
-        const entity = btn.dataset.entity;
-        const hidden = document.getElementById(entity);
-        const chip   = container.querySelector(`.pick-chip[data-for="${entity}"]`);
-        openModal(entity, hidden, chip);
-      });
+  // ≡ butonlarını bağla (admin/kullanıcı fark etmez; kapsayıcı id’ni değiştir)
+  document.querySelectorAll('#admin-urun-ekle .pick-btn, #urun-ekle .pick-btn').forEach(btn=>{
+    btn.addEventListener('click', ()=>{
+      const entity = btn.dataset.entity;
+      const hidden = document.getElementById(entity);
+      const chip   = document.querySelector(`.pick-chip[data-for="${entity}"]`);
+      openModal(entity, hidden, chip);
     });
-  }
+  });
 
-  window.bindPickButtons = bindPickButtons;
-  window.openModal = openModal;
 })();

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -128,8 +128,10 @@
         .picker-card{width:420px;max-width:92vw;background:#fff;border-radius:14px;box-shadow:0 10px 30px rgba(0,0,0,.18);overflow:hidden}
         .picker-head{display:flex;align-items:center;justify-content:space-between;padding:10px 14px;border-bottom:1px solid #eef2f7}
         .picker-close{border:0;background:transparent;font-size:22px;line-height:1;cursor:pointer;padding:2px 6px}
-        .picker-search{padding:10px 14px;border-bottom:1px solid #eef2f7}
-        .picker-search input{width:100%;padding:10px 12px;border:1px solid #dbe2ea;border-radius:10px}
+        .picker-search{display:flex;gap:8px;align-items:center;padding:10px 14px;border-bottom:1px solid #eef2f7}
+        .picker-search input{flex:1 1 auto;padding:10px 12px;border:1px solid #dbe2ea;border-radius:10px}
+        .picker-add{flex:0 0 auto;padding:9px 14px;border:1px solid #16a34a;background:#16a34a;color:#fff;border-radius:10px;cursor:pointer}
+        .picker-add:disabled{opacity:.5;cursor:not-allowed}
         .picker-list{max-height:320px;overflow:auto}
         .picker-row{display:flex;align-items:center;justify-content:space-between;padding:10px 14px;border-bottom:1px dashed #eef2f7}
         .picker-row:nth-child(even){background:#fafbff}
@@ -149,7 +151,10 @@
             <strong id="picker-title">Seçim</strong>
             <button type="button" class="picker-close" aria-label="Kapat">×</button>
           </div>
-          <div class="picker-search"><input id="picker-search" type="text" placeholder="Ara..."></div>
+          <div class="picker-search">
+            <input id="picker-search" type="text" placeholder="Ara / yeni değer yaz..." />
+            <button type="button" class="picker-add" id="picker-add">Ekle</button>
+          </div>
           <div id="picker-list" class="picker-list"></div>
           <div class="picker-foot"><button type="button" class="btn btn-light" id="picker-cancel">Kapat</button></div>
         </div>
@@ -157,9 +162,6 @@
 
       <!-- ===== Mini Picker Script ===== -->
       <script src="{{ url_for('static', path='js/mini-picker.js') }}"></script>
-      <script>
-        bindPickButtons('#admin-urun-ekle');
-      </script>
 
     <div class="tab-pane fade" id="pane-connections" role="tabpanel" aria-labelledby="tab-connections">
       <h5 class="mb-3">LDAP Bağlantıları</h5>

--- a/templates/product_add.html
+++ b/templates/product_add.html
@@ -76,7 +76,8 @@
     </div>
 
     <div class="picker-search">
-      <input id="picker-search" type="text" placeholder="Ara..." />
+      <input id="picker-search" type="text" placeholder="Ara / yeni değer yaz..." />
+      <button type="button" class="picker-add" id="picker-add">Ekle</button>
     </div>
 
     <div id="picker-list" class="picker-list"><!-- JS doldurur --></div>
@@ -104,8 +105,10 @@
   .picker-card{width:420px;max-width:92vw;background:#fff;border-radius:14px;box-shadow:0 10px 30px rgba(0,0,0,.18);overflow:hidden}
   .picker-head{display:flex;align-items:center;justify-content:space-between;padding:10px 14px;border-bottom:1px solid #eef2f7}
   .picker-close{border:0;background:transparent;font-size:22px;line-height:1;cursor:pointer;padding:2px 6px}
-  .picker-search{padding:10px 14px;border-bottom:1px solid #eef2f7}
-  .picker-search input{width:100%;padding:10px 12px;border:1px solid #dbe2ea;border-radius:10px}
+  .picker-search{display:flex;gap:8px;align-items:center;padding:10px 14px;border-bottom:1px solid #eef2f7}
+  .picker-search input{flex:1 1 auto;padding:10px 12px;border:1px solid #dbe2ea;border-radius:10px}
+  .picker-add{flex:0 0 auto;padding:9px 14px;border:1px solid #16a34a;background:#16a34a;color:#fff;border-radius:10px;cursor:pointer}
+  .picker-add:disabled{opacity:.5;cursor:not-allowed}
   .picker-list{max-height:320px;overflow:auto}
   .picker-row{display:flex;align-items:center;justify-content:space-between;padding:10px 14px;border-bottom:1px dashed #eef2f7}
   .picker-row:nth-child(even){background:#fafbff}
@@ -119,7 +122,4 @@
 </style>
 
 <script src="{{ url_for('static', path='js/mini-picker.js') }}"></script>
-<script>
-  bindPickButtons('#urun-ekle');
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add add button and styles to picker modal
- support dependent picker adds via POST
- backend API accepts parent filter and creation

## Testing
- `python -m py_compile routers/picker.py`
- `node --check static/js/mini-picker.js`


------
https://chatgpt.com/codex/tasks/task_e_68aecb69213c832ba91180d42c4f3b37