### PR TITLE
Expose mini-picker API and disable legacy prompt when available

### DIFF
--- a/templates/inventory_add.html
+++ b/templates/inventory_add.html
@@ -176,6 +176,9 @@
     $search.focus();
   }
 
+  // Dışarıdan çağırılabilsin
+  window.__openPickerModal = openModal;
+
   function updateAddState(){ $add.disabled = !current.allowAdd || ($search.value.trim().length===0); }
 
   async function load(q){

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -184,23 +184,25 @@
 <script>
   // Kutulara tıklayınca seçim aç; sonucu hidden'a yaz.
   (function(){
-    function openPicker(entity, current){
-      // TODO: kendi modal/offsayfa seçicini çağır.
-      const v = prompt(entity.toUpperCase()+" seçin:", current || "");
-      return (v && v.trim()) ? { id:v.trim(), text:v.trim() } : null;
-    }
-    const ids = ["fabrika","departman","donanim_tipi","sorumlu_personel","marka","model"];
-    ids.forEach(id=>{
-      const dsp = document.getElementById(id+"_display");
-      const hid = document.getElementById(id);
-      dsp.addEventListener('click', ()=>{
-        const pick = openPicker(id, hid.value);
-        if(!pick) return;
-        hid.value = pick.id;
-        dsp.value = pick.text;
-        dsp.classList.remove('is-invalid');
+    if(!window.__openPickerModal){
+      function openPicker(entity, current){
+        // TODO: kendi modal/offsayfa seçicini çağır.
+        const v = prompt(entity.toUpperCase()+" seçin:", current || "");
+        return (v && v.trim()) ? { id:v.trim(), text:v.trim() } : null;
+      }
+      const ids = ["fabrika","departman","donanim_tipi","sorumlu_personel","marka","model"];
+      ids.forEach(id=>{
+        const dsp = document.getElementById(id+"_display");
+        const hid = document.getElementById(id);
+        dsp.addEventListener('click', ()=>{
+          const pick = openPicker(id, hid.value);
+          if(!pick) return;
+          hid.value = pick.id;
+          dsp.value = pick.text;
+          dsp.classList.remove('is-invalid');
+        });
       });
-    });
+    }
 
     // Submit’te required hidden kontrolü
     document.getElementById('envanter-form').addEventListener('submit', (e)=>{


### PR DESCRIPTION
## Summary
- export mini-picker's `openModal` as global `__openPickerModal` for reuse
- skip legacy prompt bindings on inventory list when new picker modal is present

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aee0ee78d4832b8436e1c452268ae4