### PR TITLE
feat: add mini-picker flag and conditional prompt binding

### DIFF
--- a/templates/inventory_add.html
+++ b/templates/inventory_add.html
@@ -1,3 +1,7 @@
+<script>
+  // Bu sayfada mini-picker kullanılacak; liste sayfasındaki prompt bağlayıcısını kapat.
+  window.USE_MINI_PICKER = true;
+</script>
 <form method="post" action="/inventory/create" class="needs-validation" novalidate>
   <div class="row g-3" id="envanter-ekle">
 
@@ -318,5 +322,67 @@
       openNewPicker(entity);
     };
   }
+})();
+</script>
+
+<script>
+(function(){
+  const ENTITIES = ['fabrika','departman','donanim_tipi','sorumlu_personel','marka','model'];
+
+  function openNew(entity){
+    // inventory_add.html içinde tanımlı openModal’ı çağırıyoruz
+    if (window.openModal) { window.openModal(entity); return; }
+    console.error('openModal bulunamadı (mini picker yüklenmemiş).');
+  }
+
+  // 1) Eski global fonksiyon varsa ez
+  try {
+    Object.defineProperty(window,'openPicker',{ value:(ent)=>{ openNew(ent); return false; }, writable:false });
+  } catch(e){ window.openPicker = (ent)=>{ openNew(ent); return false; }; }
+
+  // 2) prompt çağrılırsa yakala ve modale çevir
+  (function(){
+    const orig = window.prompt;
+    window.prompt = function(msg, deflt){
+      const m = String(msg||'').toLowerCase();
+      if (/(fabrika|departman|donanım|donanim|sorumlu|marka|model).*seçin/.test(m)) {
+        const ent = m.includes('donan') ? 'donanim_tipi'
+                  : m.includes('fabrika') ? 'fabrika'
+                  : m.includes('departman') ? 'departman'
+                  : m.includes('sorumlu') ? 'sorumlu_personel'
+                  : m.includes('marka') ? 'marka' : 'model';
+        openNew(ent);
+        return null; // iptal dön
+      }
+      return orig.call(window, msg, deflt);
+    };
+  })();
+
+  // 3) _display inputlarında eski click handler’ını capture fazında iptal et
+  ENTITIES.forEach(id=>{
+    const dsp = document.getElementById(id + '_display');
+    if (!dsp) return;
+    dsp.addEventListener('click', (ev)=>{
+      ev.preventDefault();
+      ev.stopImmediatePropagation();
+      openNew(id);
+    }, { capture:true });
+  });
+
+  // 4) Marka değişirse modeli temizle
+  const markaH = document.getElementById('marka');
+  const markaD = document.getElementById('marka_display');
+  const clearModel = ()=>{
+    const mH = document.getElementById('model');
+    const mD = document.getElementById('model_display');
+    if (mH) mH.value = '';
+    if (mD) mD.value = '';
+    const chip = document.querySelector('.pick-chip[data-for="model"]');
+    if (chip){ chip.classList.add('d-none'); chip.textContent=''; }
+  };
+  ['change','input'].forEach(e=>{
+    if (markaH) markaH.addEventListener(e, clearModel);
+    if (markaD) markaD.addEventListener(e, clearModel);
+  });
 })();
 </script>

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Envanter Listesi{% endblock %}
 {% block content %}
-<div class="container-fluid p-2">
+  <div id="inventory-list-root" class="container-fluid p-2">
   <div class="d-flex align-items-center justify-content-between mb-3">
     <div class="d-flex align-items-center gap-2">
       <a href="#" id="addBtn" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle">
@@ -182,39 +182,41 @@
 
 <script>window.SKIP_SELECT_ENHANCE = true;</script>
 <script>
-  // Kutulara tıklayınca seçim aç; sonucu hidden'a yaz.
-  (function(){
-    if(!window.__openPickerModal){
-      function openPicker(entity, current){
-        // TODO: kendi modal/offsayfa seçicini çağır.
-        const v = prompt(entity.toUpperCase()+" seçin:", current || "");
-        return (v && v.trim()) ? { id:v.trim(), text:v.trim() } : null;
-      }
-      const ids = ["fabrika","departman","donanim_tipi","sorumlu_personel","marka","model"];
-      ids.forEach(id=>{
-        const dsp = document.getElementById(id+"_display");
-        const hid = document.getElementById(id);
-        dsp.addEventListener('click', ()=>{
-          const pick = openPicker(id, hid.value);
-          if(!pick) return;
-          hid.value = pick.id;
-          dsp.value = pick.text;
-          dsp.classList.remove('is-invalid');
-        });
-      });
-    }
+// Mini picker modu açıksa (envanter ekleme modali) bu bağlayıcıyı hiç kurma
+if (!window.USE_MINI_PICKER) {
+  function oldOpenPicker(entity, current){
+    const v = prompt(entity.toUpperCase()+" seçin:", current || "");
+    return (v && v.trim()) ? { id:v.trim(), text:v.trim() } : null;
+  }
 
-    // Submit’te required hidden kontrolü
-    document.getElementById('envanter-form').addEventListener('submit', (e)=>{
-      let ok = true;
-      ["fabrika","departman","donanim_tipi","sorumlu_personel","marka","model"].forEach(id=>{
-        const hid = document.getElementById(id);
-        const dsp = document.getElementById(id+"_display");
-        if(!hid.value){ ok = false; dsp.classList.add('is-invalid'); }
-      });
-      if(!ok){ e.preventDefault(); e.stopPropagation(); }
+  const ids = ["fabrika","departman","donanim_tipi","sorumlu_personel","marka","model"];
+  ids.forEach(id=>{
+    // Sadece liste sayfasındaki alanlara bağlan (modalı etkilemesin diye kök kapsamı daralt)
+    const root = document.getElementById('inventory-list-root') || document;
+    const dsp  = root.querySelector('#'+id+'_display');
+    const hid  = root.querySelector('#'+id);
+    if (!dsp || !hid) return;
+
+    dsp.addEventListener('click', ()=>{
+      const pick = oldOpenPicker(id, hid.value);
+      if(!pick) return;
+      hid.value = pick.id;
+      dsp.value = pick.text;
+      dsp.classList.remove('is-invalid');
     });
-  })();
+  });
+}
+
+// Submit’te required hidden kontrolü
+document.getElementById('envanter-form').addEventListener('submit', (e)=>{
+  let ok = true;
+  ["fabrika","departman","donanim_tipi","sorumlu_personel","marka","model"].forEach(id=>{
+    const hid = document.getElementById(id);
+    const dsp = document.getElementById(id+"_display");
+    if(!hid.value){ ok = false; dsp.classList.add('is-invalid'); }
+  });
+  if(!ok){ e.preventDefault(); e.stopPropagation(); }
+});
 </script>
 
 <!-- Filtre Modal -->


### PR DESCRIPTION
## Summary
- enable mini-picker mode and intercept legacy prompt pickers
- conditionally bind prompt picker on inventory list page when mini picker inactive

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aee482c5f4832bb971cd8b26170613