### PR TITLE
Implement license edit and assign pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,6 +118,16 @@ def licenses_list_alias(request: Request, db: Session = Depends(get_db), user=De
 def licenses_detail_alias(lic_id: int, request: Request, db: Session = Depends(get_db), user=Depends(current_user)):
     return license_router.license_detail(lic_id, request, db)
 
+
+@app.get("/licenses/{lic_id}/edit", include_in_schema=False)
+def licenses_edit_alias(lic_id: int, request: Request, db: Session = Depends(get_db), user=Depends(current_user)):
+    return license_router.edit_license_form(lic_id, request, db)
+
+
+@app.get("/licenses/{lic_id}/assign", include_in_schema=False)
+def licenses_assign_alias(lic_id: int, request: Request, db: Session = Depends(get_db), user=Depends(current_user)):
+    return license_router.assign_license_form(lic_id, request, db, user)
+
 # Sadece admin
 app.include_router(logs.router, prefix="/logs", tags=["Logs"], dependencies=[Depends(require_roles("admin"))])
 app.include_router(admin_router, dependencies=[Depends(require_roles("admin"))])

--- a/templates/license_assign.html
+++ b/templates/license_assign.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block title %}Lisans Atama{% endblock %}
+{% block content %}
+<div class="container-fluid p-3 content">
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <h4 class="mb-0">Lisans Atama</h4>
+    <a class="btn btn-light" href="{{ url_for('license_list') }}">← Listeye Dön</a>
+  </div>
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <form method="post" action="/lisans/{{ license.id }}/assign">
+        <input type="hidden" name="islem_yapan" value="{{ current_user.full_name if current_user else 'system' }}">
+        <div class="mb-3">
+          <label class="form-label">Sorumlu Personel</label>
+          <select name="sorumlu_personel" class="form-select">
+            <option value="">Seçiniz</option>
+            {% for u in users %}
+              <option value="{{ u }}" {% if license.sorumlu_personel == u %}selected{% endif %}>{{ u }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Bağlı Olduğu Envanter No</label>
+          <select name="bagli_envanter_no" class="form-select">
+            <option value="">Seçiniz</option>
+            {% for inv in envanterler %}
+              <option value="{{ inv.no }}" {% if license.bagli_envanter_no == inv.no %}selected{% endif %}>{{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="d-flex gap-2 mt-4">
+          <button class="btn btn-primary" type="submit">Kaydet</button>
+          <a class="btn btn-secondary" href="{{ url_for('license_list') }}">İptal</a>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add form and POST handler for editing licenses
- Add dedicated license assignment form and route
- Wire alias routes so `/licenses/{id}/edit` and `/licenses/{id}/assign` resolve

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af0f41ade0832ba602ce0d9b3d792e