### PR TITLE
refactor: centralize get_db

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,8 +14,8 @@ from sqlalchemy.orm import Session
 
 from models import init_db
 from db_bootstrap import bootstrap_schema
+from database import get_db
 from auth import (
-    get_db,
     get_user_by_username,
     get_user_by_id,
     verify_password,

--- a/auth.py
+++ b/auth.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
-from models import SessionLocal, User
+from models import User
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -12,14 +12,6 @@ def hash_password(password: str) -> str:
 
 def verify_password(plain_password: str, password_hash: str) -> bool:
     return pwd_context.verify(plain_password, password_hash)
-
-
-def get_db() -> Session:
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 def get_user_by_username(db: Session, username: str) -> User | None:

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -4,7 +4,8 @@ from sqlalchemy.orm import Session
 from fastapi.templating import Jinja2Templates
 
 from models import User, Connection
-from auth import get_db, hash_password
+from auth import hash_password
+from database import get_db
 
 router = APIRouter(prefix="/admin", tags=["Admin"])
 templates = Jinja2Templates(directory="templates")

--- a/routers/api.py
+++ b/routers/api.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
-from auth import get_db
+from database import get_db
 import models
 from sqlalchemy import func, case, and_
 

--- a/routers/catalog.py
+++ b/routers/catalog.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from auth import get_db
+from database import get_db
 from models import Brand, Model, UsageArea, Factory, LicenseName, HardwareType
 
 router = APIRouter(prefix="/catalog", tags=["Katalog"])

--- a/routers/printers.py
+++ b/routers/printers.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from typing import Optional, Dict, Any
 from datetime import datetime
 
-from auth import get_db
+from database import get_db
 from security import current_user
 from models import Printer, PrinterHistory, ScrapPrinter, Brand, Model, UsageArea
 from sqlalchemy import text

--- a/routers/printers_scrap_list.py
+++ b/routers/printers_scrap_list.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
-from auth import get_db
+from database import get_db
 from models import Printer, ScrapPrinter
 
 templates = Jinja2Templates(directory="templates")

--- a/routers/stock.py
+++ b/routers/stock.py
@@ -12,7 +12,7 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, text
 from sqlalchemy.orm import Session
 
-from auth import get_db
+from database import get_db
 from security import SessionUser, current_user
 from models import StockAssignment, StockLog, HardwareType, UsageArea
 

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Request, Depends, Form
 from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 from models import User, Lookup
-from auth import get_db
+from database import get_db
 from fastapi.templating import Jinja2Templates
 
 router = APIRouter(prefix="/admin", tags=["Admin"])

--- a/routes/lookup.py
+++ b/routes/lookup.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 from models import Lookup
-from auth import get_db
+from database import get_db
 
 router = APIRouter(prefix="/api/lookup", tags=["Lookup"])
 

--- a/security.py
+++ b/security.py
@@ -1,7 +1,8 @@
 # security.py
 from fastapi import Request, HTTPException, status, Depends
 from sqlalchemy.orm import Session
-from auth import get_db, get_user_by_id
+from database import get_db
+from auth import get_user_by_id
 
 class SessionUser:
     def __init__(


### PR DESCRIPTION
## Summary
- centralize `get_db` helper in `database.py`
- remove duplicate `get_db` from `auth.py`
- update imports to use `database.get_db`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1296e7f8832b9cec1f069dc26093