### PR TITLE
Handle action menu operations client-side

### DIFF
--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -295,19 +295,18 @@
     const assignModal = new bootstrap.Modal(document.getElementById('assignModal'));
     const assignForm  = document.getElementById('assignForm');
 
-    document.querySelectorAll('.dropdown-menu [data-action]').forEach(item => {
-      item.addEventListener('click', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        if (item.classList.contains('disabled')) return;
+    document.querySelectorAll('#licensesTable .action-select').forEach(sel => {
+      sel.addEventListener('change', (e) => {
+        const id = e.target.dataset.id;
+        const val = e.target.value;
+        if (!val) return;
 
-        const id = item.dataset.id;
-        const action = item.dataset.action;
-
-        if (action === 'assign') {
+        if (val === 'assign') {
           assignForm.action = `/lisans/${id}/assign`;
           assignModal.show();
-        } else if (action === 'scrap') {
+        } else if (val === 'edit') {
+          window.location.href = `/licenses/${id}/edit`;
+        } else if (val === 'scrap') {
           const f = document.createElement('form');
           f.method = 'post';
           f.action = `/lisans/${id}/scrap`;
@@ -318,6 +317,8 @@
           document.body.appendChild(f);
           f.submit();
         }
+
+        e.target.value = '';
       });
     });
 

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -360,33 +360,29 @@ document.addEventListener('DOMContentLoaded', () => {
   const assignModal = new bootstrap.Modal(assignModalEl);
   const assignForm = document.getElementById('assignForm');
 
-  document.querySelectorAll('.action-go').forEach(btn => {
-    btn.addEventListener('click', function(){
-      const tr = this.closest('tr');
+  document.querySelectorAll('.action-select').forEach(sel => {
+    sel.addEventListener('change', (e) => {
+      const tr = e.target.closest('tr');
       const printerId = tr.dataset.id;
-      const sel = tr.querySelector('.action-select');
-      const val = sel.value;
-
-      if(!val){ sel.classList.add('is-invalid'); setTimeout(()=>sel.classList.remove('is-invalid'), 1200); return; }
+      const val = e.target.value;
+      if(!val) return;
 
       if(val === 'edit'){
         window.location.href = `/printers/edit/${printerId}`;
-        return;
-      }
-      if(val === 'assign'){
+      } else if(val === 'assign'){
         document.getElementById('assignPrinterId').value = printerId;
         document.getElementById('assignPrinterLabel').innerText = `#${printerId}`;
         assignModal.show();
-        return;
-      }
-      if(val === 'scrap'){
-        if(!confirm('Bu yazıcıyı hurdaya ayırmak istiyor musunuz?')) return;
+      } else if(val === 'scrap'){
+        if(!confirm('Bu yazıcıyı hurdaya ayırmak istiyor musunuz?')) { e.target.value=''; return; }
         const formData = new FormData();
         formData.append('reason','İşlemler menüsünden hurdaya ayrıldı');
         fetch(`/printers/scrap/${printerId}`, { method: 'POST', body: formData })
           .then(r => r.json()).then(j => { if(j.ok){ location.reload(); } else { alert('İşlem başarısız'); } })
           .catch(() => alert('Sunucu hatası'));
       }
+
+      e.target.value = '';
     });
   });
 


### PR DESCRIPTION
## Summary
- Process license action selections in-page to submit assignments or scraps without hitting invalid GET endpoints
- Drive printer action selections via change events, enabling edit, assign, and scrap flows directly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aff18941c4832ba3b274cce40f3fa0