### PR TITLE
Fix lookup fields not opening selection modal

### DIFF
--- a/static/js/mini-picker.js
+++ b/static/js/mini-picker.js
@@ -168,6 +168,17 @@
     });
   });
 
+  // Sayfaya sonradan eklenen lookup-display inputları için tıklama delegasyonu
+  document.addEventListener('click', (e)=>{
+    const input = e.target.closest('input.lookup-display');
+    if(!input) return;
+    const entity = input.id ? input.id.replace('_display','') : null;
+    if(!entity) return;
+    const hidden = document.getElementById(entity);
+    const chip   = document.querySelector(`.pick-chip[data-for="${entity}"]`);
+    openModal(entity, hidden, input, chip);
+  });
+
   // Dışarıdan çağrılabilsin
   window.__openPickerModal = openModal;
 


### PR DESCRIPTION
## Summary
- ensure dynamically inserted `lookup-display` inputs trigger the picker modal via delegated click handler

## Testing
- `python -m pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aff59bf798832ba5d416b8f6e27039