### PR TITLE
Add printer and license listing APIs

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -52,6 +52,47 @@ def printer_models(brand: str = Query(..., min_length=1), db: Session = Depends(
     return [r[0] for r in rows if r[0]]
 
 
+@router.get("/licenses/list")
+def licenses_list(db: Session = Depends(get_db)):
+    rows = (
+        db.query(models.License)
+        .filter(models.License.durum != "hurda")
+        .order_by(models.License.id.asc())
+        .all()
+    )
+    return {
+        "items": [
+            {
+                "id": r.id,
+                "lisans_adi": r.lisans_adi,
+                "lisans_anahtari": r.lisans_anahtari,
+            }
+            for r in rows
+        ]
+    }
+
+
+@router.get("/printers/list")
+def printers_list(db: Session = Depends(get_db)):
+    rows = (
+        db.query(models.Printer)
+        .filter(models.Printer.durum != "hurda")
+        .order_by(models.Printer.id.asc())
+        .all()
+    )
+    return {
+        "items": [
+            {
+                "id": r.id,
+                "marka": r.marka,
+                "model": r.model,
+                "seri_no": r.seri_no,
+            }
+            for r in rows
+        ]
+    }
+
+
 # === STOCK API ===
 @router.get("/stock/status")
 def stock_status(db: Session = Depends(get_db)):

--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -229,7 +229,36 @@ def detail_short(request: Request, item_id: int, db: Session = Depends(get_db), 
   return detail(request, item_id, db, user)
 
 @router.get("/assign/sources", name="inventory.assign_sources")
-def assign_sources(type: str, exclude_id: int | None = None, db: Session = Depends(get_db)):
+def assign_sources(
+    type: str | None = None,
+    exclude_id: int | None = None,
+    db: Session = Depends(get_db),
+):
+    if not type:
+        users = db.query(User).order_by(User.full_name.asc()).all()
+        inv_q = db.query(Inventory)
+        if exclude_id:
+            inv_q = inv_q.filter(Inventory.id != exclude_id)
+        inventories = inv_q.order_by(Inventory.id.desc()).all()
+        return {
+            "users": [
+                {
+                    "id": u.full_name or u.username,
+                    "text": u.full_name or u.username,
+                }
+                for u in users
+                if (u.full_name or u.username or "").strip()
+            ],
+            "inventories": [
+                {
+                    "id": r.id,
+                    "envanter_no": r.no,
+                    "marka": r.marka,
+                    "model": r.model,
+                }
+                for r in inventories
+            ],
+        }
     if type == "users":
         users = db.query(User).order_by(User.full_name.asc()).all()
         return [


### PR DESCRIPTION
## Summary
- add `/api/licenses/list` and `/api/printers/list` endpoints
- allow `/inventory/assign/sources` to return both inventories and users when no type is specified

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afff95aa8c832b8c402bc3285251aa