### PR TITLE
Enable searchable responsible personnel selector

### DIFF
--- a/static/js/selects.js
+++ b/static/js/selects.js
@@ -18,7 +18,7 @@ function makeSearchableSelect(el, placeholder="Seçiniz…") {
   return inst;
 }
 
-async function fillChoices({ endpoint, selectId, params={}, placeholder="Seçiniz…", keepValue=false }) {
+async function fillChoices({ endpoint, selectId, params={}, placeholder="Seçiniz…", keepValue=false, mapFn }) {
   const el = document.getElementById(selectId);
   if (!el) return;
   let inst = selects[selectId];
@@ -28,7 +28,8 @@ async function fillChoices({ endpoint, selectId, params={}, placeholder="Seçini
   const data = res.ok ? await res.json() : [];
   const current = keepValue ? el.value : null;
   inst.clearStore();
-  inst.setChoices(data.map(r => ({ value: r.id, label: r.text ?? r.ad ?? r.name })), 'value', 'label', true);
+  const map = mapFn || (r => ({ value: r.id, label: r.text ?? r.ad ?? r.name }));
+  inst.setChoices(data.map(map), 'value', 'label', true);
   if (keepValue && current) inst.setChoiceByValue(current);
 }
 
@@ -50,12 +51,12 @@ async function bindMarkaModel(markaSelectId, modelSelectId) {
 }
 
 function debounce(fn, d=300){ let t; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a), d); }; }
-function enableRemoteSearch(selectId, endpoint, extraParamsFn=()=>({})) {
+function enableRemoteSearch(selectId, endpoint, extraParamsFn=()=>({}), mapFn) {
   const inst = selects[selectId]; if (!inst) return;
   const input = inst.input?.element; if (!input) return;
   input.addEventListener("input", debounce(async ()=>{
     const q = input.value.trim();
-    await fillChoices({ endpoint, selectId, params: { q, ...extraParamsFn() }, keepValue: false });
+    await fillChoices({ endpoint, selectId, params: { q, ...extraParamsFn() }, keepValue: false, mapFn });
   }, 300));
 }
 

--- a/templates/inventory_add.html
+++ b/templates/inventory_add.html
@@ -91,7 +91,16 @@
   await loadOptions(fabrikaSel, '/api/picker/fabrika');
   await loadOptions(departmanSel, '/api/picker/kullanim_alani');
   await loadOptions(donanimSel, '/api/picker/donanim_tipi');
-  await loadOptions(personelSel, '/api/picker/kullanici');
+  if (window._selects) {
+    await _selects.fillChoices({
+      endpoint: '/api/picker/kullanici',
+      selectId: 'sorumlu_personel',
+      mapFn: r => ({ value: r.text, label: r.text })
+    });
+    _selects.enableRemoteSearch('sorumlu_personel', '/api/picker/kullanici', () => ({}), r => ({ value: r.text, label: r.text }));
+  } else {
+    await loadOptions(personelSel, '/api/picker/kullanici');
+  }
 
   const brandRes = await fetch('/api/picker/marka');
   const brands = await brandRes.json();

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -291,7 +291,12 @@ document.addEventListener('DOMContentLoaded', () => {
     await loadOptions(fabrikaSel, '/api/picker/fabrika');
     await loadOptions(departmanSel, '/api/picker/kullanim_alani');
     await loadOptions(donanimSel, '/api/picker/donanim_tipi');
-    await loadOptions(personelSel, '/api/picker/kullanici');
+    await _selects.fillChoices({
+      endpoint: '/api/picker/kullanici',
+      selectId: 'sorumlu_personel',
+      mapFn: r => ({ value: r.text, label: r.text })
+    });
+    _selects.enableRemoteSearch('sorumlu_personel', '/api/picker/kullanici', () => ({}), r => ({ value: r.text, label: r.text }));
 
     const brandRes = await fetch('/api/picker/marka');
     const brands = await brandRes.json();


### PR DESCRIPTION
## Summary
- allow selectable fields to map values flexibly in `fillChoices`
- enable remote search for the "Sorumlu Personel" dropdown on inventory forms

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b00bd78850832babd0e6502b0d9cb5