### PR TITLE
Register humanize_log filter for inventory templates

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -25,8 +25,10 @@ from models import (
     License,
 )
 from security import current_user
+from utils.i18n import humanize_log
 
 templates = Jinja2Templates(directory="templates")
+templates.env.filters["humanize_log"] = humanize_log
 
 router = APIRouter(prefix="/inventory", tags=["inventory"])
 


### PR DESCRIPTION
## Summary
- register `humanize_log` filter in inventory router to support log rendering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b00e429220832b9089391c490b29f9