### PR TITLE
Ensure users table has first and last name columns

### DIFF
--- a/models.py
+++ b/models.py
@@ -378,6 +378,14 @@ def init_db():
     insp = inspect(engine)
     cols = {col["name"] for col in insp.get_columns("users")}
     with engine.begin() as conn:
+        if "first_name" not in cols:
+            conn.execute(
+                text("ALTER TABLE users ADD COLUMN first_name VARCHAR(60) DEFAULT ''")
+            )
+        if "last_name" not in cols:
+            conn.execute(
+                text("ALTER TABLE users ADD COLUMN last_name VARCHAR(60) DEFAULT ''")
+            )
         if "full_name" not in cols:
             conn.execute(
                 text("ALTER TABLE users ADD COLUMN full_name VARCHAR(120) DEFAULT ''")


### PR DESCRIPTION
## Summary
- add lightweight migration to create `first_name` and `last_name` columns for existing `users` tables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0143243e4832bbbd3e2a5c8b97ddf