### PR TITLE
Align license and printer action menus with inventory

### DIFF
--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -73,6 +73,8 @@
   </div>
 </div>
 
+<script>window.SKIP_SELECT_ENHANCE = true;</script>
+
 <!-- Yeni Ekle Modal -->
 <div class="modal fade" id="addModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-lg">
@@ -329,35 +331,12 @@
     });
 
     if (window.Choices) {
-      new Choices('#selPersonel', { searchEnabled: true, shouldSort: false });
-      new Choices('#selBagli', { searchEnabled: true, shouldSort: false });
+      new Choices('#selLisansAdi',   { searchEnabled: true, shouldSort: false });
+      new Choices('#selPersonelAdd', { searchEnabled: true, shouldSort: false });
+      new Choices('#selPersonel',    { searchEnabled: true, shouldSort: false });
+      new Choices('#selBagli',       { searchEnabled: true, shouldSort: false });
     }
   });
-
-  // Sadece lisans tablosundaki işlem select'lerini enhance et
-  (function () {
-    const selects = document.querySelectorAll('#licensesTable .action-select');
-    if (!selects.length || !window.Choices) return;
-
-    selects.forEach(function (el) {
-      const ch = new Choices(el, {
-        searchEnabled: true,
-        shouldSort: false,
-        itemSelectText: '',
-        removeItemButton: false,
-        allowHTML: true,
-        placeholderValue: 'Seçiniz...'
-      });
-
-      // Seçim yapıldıktan sonra global handler'ın çalışmasına izin verip UI'yı sıfırla
-      el.addEventListener('change', function () {
-        setTimeout(() => {
-          ch.setChoiceByValue('');
-          ch.clearInput();
-        });
-      });
-    });
-  })();
 </script>
 
 <style>

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -157,6 +157,8 @@
   </div>
 </div>
 
+<script>window.SKIP_SELECT_ENHANCE = true;</script>
+
 <!-- Filtre Modal -->
 <div class="modal fade" id="filterModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
@@ -249,6 +251,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const markaSel = document.getElementById('selYaziciMarka');
     const modelSel = document.getElementById('selYaziciModel');
     if (markaSel && modelSel) {
+      if (window.Choices) {
+        new Choices(markaSel, { searchEnabled: true, shouldSort: false });
+        new Choices(modelSel, { searchEnabled: true, shouldSort: false });
+      }
       const loadModels = async () => {
         const marka = markaSel.value;
         modelSel.innerHTML = '<option value="">Seçiniz...</option>';


### PR DESCRIPTION
## Summary
- Disable global Choices.js enhancement on license and printer pages so per-row action menus remain plain
- Manually initialize Choices.js only on specific form selects for licenses and printers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b020aad0c4832bb78560887d97da53