### PR TITLE
Show license and printer scraps with notes

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -23,6 +23,7 @@ from models import (
     UsageArea,
     HardwareType,
     License,
+    ScrapPrinter,
 )
 from security import current_user
 from utils.i18n import humanize_log
@@ -407,6 +408,17 @@ def hurdalar_listesi(request: Request, db: Session = Depends(get_db), user=Depen
     )
     for item in hurdalar
   }
+
+  license_scraps = db.query(License).filter(License.durum == "hurda").all()
+  printer_scraps = db.query(ScrapPrinter).order_by(ScrapPrinter.created_at.desc()).all()
+
   return templates.TemplateResponse(
-    "hurdalar.html", {"request": request, "hurdalar": hurdalar, "logs_map": logs_map}
+    "hurdalar.html",
+    {
+      "request": request,
+      "hurdalar": hurdalar,
+      "logs_map": logs_map,
+      "license_scraps": license_scraps,
+      "printer_scraps": printer_scraps,
+    },
   )

--- a/routers/license.py
+++ b/routers/license.py
@@ -263,6 +263,7 @@ def assign_license(
 @router.post("/{lic_id}/scrap")
 def scrap_license(
     lic_id: int,
+    aciklama: str = Form(""),
     islem_yapan: str = Form("system"),
     request: Request = None,
     db: Session = Depends(get_db),
@@ -271,7 +272,10 @@ def scrap_license(
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
     lic.durum = "hurda"
-    _logla(db, lic, "HURDA", "Lisans hurdaya ayrıldı.", islem_yapan)
+    if aciklama:
+        lic.notlar = (lic.notlar + "\n" if lic.notlar else "") + aciklama
+    detay = "Lisans hurdaya ayrıldı." + (f" Not: {aciklama}" if aciklama else "")
+    _logla(db, lic, "HURDA", detay, islem_yapan)
     db.commit()
     return RedirectResponse(url=request.url_for("license_scrap_list"), status_code=status.HTTP_303_SEE_OTHER)
 

--- a/templates/hurdalar.html
+++ b/templates/hurdalar.html
@@ -10,6 +10,9 @@
     <li class="nav-item" role="presentation">
       <button class="nav-link" id="lisans-tab" data-bs-toggle="tab" data-bs-target="#lisans" type="button" role="tab">Lisans</button>
     </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="yazici-tab" data-bs-toggle="tab" data-bs-target="#yazici" type="button" role="tab">Yazıcı</button>
+    </li>
   </ul>
   <div class="tab-content pt-3">
     <div class="tab-pane fade show active" id="envanter" role="tabpanel" aria-labelledby="envanter-tab">
@@ -49,7 +52,61 @@
       </table>
     </div>
     <div class="tab-pane fade" id="lisans" role="tabpanel" aria-labelledby="lisans-tab">
-      <div class="card p-3">Lisans hurdaları listesi...</div>
+      <table class="table table-sm align-middle">
+        <thead>
+          <tr><th>No</th><th>Lisans Adı</th><th>Key</th><th>Sorumlu</th><th>Bağlı Envanter</th><th>Not</th></tr>
+        </thead>
+        <tbody>
+          {% for row in license_scraps %}
+          <tr>
+            <td>{{ row.id }}</td>
+            <td>{{ row.lisans_adi }}</td>
+            <td class="text-truncate" style="max-width:220px;">{{ row.lisans_key }}</td>
+            <td>{{ row.sorumlu_personel or '-' }}</td>
+            <td>{{ row.bagli_envanter_no or '-' }}</td>
+            <td>{{ row.notlar or '-' }}</td>
+          </tr>
+          {% else %}
+          <tr><td colspan="6" class="text-muted">Kayıt yok.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div class="tab-pane fade" id="yazici" role="tabpanel" aria-labelledby="yazici-tab">
+      <div class="table-responsive">
+        <table class="table table-sm align-middle">
+          <thead class="table-light">
+            <tr>
+              <th>ID</th>
+              <th>Marka/Model</th>
+              <th>Seri</th>
+              <th>Fabrika</th>
+              <th>Kullanım Alanı</th>
+              <th>Sorumlu</th>
+              <th>Bağlı Env.</th>
+              <th>Not</th>
+              <th>Tarih</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for r in printer_scraps %}
+            <tr>
+              <td>#{{ r.printer_id }}</td>
+              <td>{{ r.snapshot.marka }} {{ r.snapshot.model }}</td>
+              <td>{{ r.snapshot.seri_no }}</td>
+              <td>{{ r.snapshot.fabrika or '-' }}</td>
+              <td>{{ r.snapshot.kullanim_alani or '-' }}</td>
+              <td>{{ r.snapshot.sorumlu_personel or '-' }}</td>
+              <td>{{ r.snapshot.bagli_envanter_no or '-' }}</td>
+              <td>{{ r.reason or '-' }}</td>
+              <td>{{ r.created_at.strftime("%d.%m.%Y %H:%M") }}</td>
+            </tr>
+            {% else %}
+            <tr><td colspan="9" class="text-muted">Kayıt yok.</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -315,6 +315,9 @@
         } else if (val === 'edit') {
           window.location.href = `/licenses/${id}/edit`;
         } else if (val === 'scrap') {
+          if(!confirm('Bu lisansı hurdaya ayırmak istiyor musunuz?')) { e.target.value=''; return; }
+          const reason = prompt('Hurda sebebi / not (opsiyonel):','');
+          if(reason === null){ e.target.value=''; return; }
           const f = document.createElement('form');
           f.method = 'post';
           f.action = `/lisans/${id}/scrap`;
@@ -322,6 +325,7 @@
           who.name = 'islem_yapan';
           who.value = "{{ current_user.full_name if current_user else 'system' }}";
           f.appendChild(who);
+          if(reason){ const r = document.createElement('input'); r.name = 'aciklama'; r.value = reason; f.appendChild(r); }
           document.body.appendChild(f);
           f.submit();
         }

--- a/templates/license_scrap_list.html
+++ b/templates/license_scrap_list.html
@@ -6,7 +6,7 @@
   <div class="table-responsive">
     <table class="table table-sm align-middle">
       <thead>
-        <tr><th>No</th><th>Lisans Adı</th><th>Key</th><th>Sorumlu</th><th>Bağlı Envanter</th><th>Durum</th></tr>
+        <tr><th>No</th><th>Lisans Adı</th><th>Key</th><th>Sorumlu</th><th>Bağlı Envanter</th><th>Not</th><th>Durum</th></tr>
       </thead>
       <tbody>
         {% for row in items %}
@@ -16,10 +16,11 @@
           <td class="text-truncate" style="max-width:220px;">{{ row.lisans_key }}</td>
           <td>{{ row.sorumlu_personel or '-' }}</td>
           <td>{{ row.bagli_envanter_no or '-' }}</td>
+          <td>{{ row.notlar or '-' }}</td>
           <td><span class="badge bg-secondary">Hurda</span></td>
         </tr>
         {% else %}
-        <tr><td colspan="6" class="text-muted">Kayıt yok.</td></tr>
+        <tr><td colspan="7" class="text-muted">Kayıt yok.</td></tr>
         {% endfor %}
       </tbody>
     </table>

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -388,8 +388,10 @@ document.addEventListener('DOMContentLoaded', () => {
         assignModal.show();
       } else if(val === 'scrap'){
         if(!confirm('Bu yazıcıyı hurdaya ayırmak istiyor musunuz?')) { e.target.value=''; return; }
+        const reason = prompt('Hurda sebebi / not (opsiyonel):','');
+        if(reason === null){ e.target.value=''; return; }
         const formData = new FormData();
-        formData.append('reason','İşlemler menüsünden hurdaya ayrıldı');
+        if(reason) formData.append('reason', reason);
         fetch(`/printers/scrap/${printerId}`, { method: 'POST', body: formData })
           .then(r => r.json()).then(j => { if(j.ok){ location.reload(); } else { alert('İşlem başarısız'); } })
           .catch(() => alert('Sunucu hatası'));

--- a/templates/printers_scrap.html
+++ b/templates/printers_scrap.html
@@ -14,6 +14,7 @@
           <th>Kullanım Alanı</th>
           <th>Sorumlu</th>
           <th>Bağlı Env.</th>
+          <th>Not</th>
           <th>Tarih</th>
         </tr>
       </thead>
@@ -28,6 +29,7 @@
           <td>{{ r.snapshot.kullanim_alani or '-' }}</td>
           <td>{{ r.snapshot.sorumlu_personel or '-' }}</td>
           <td>{{ r.snapshot.bagli_envanter_no or '-' }}</td>
+          <td>{{ r.reason or '-' }}</td>
           <td>{{ r.created_at.strftime("%d.%m.%Y %H:%M") }}</td>
         </tr>
         {% endfor %}
@@ -41,6 +43,7 @@
           <td>{{ p.kullanim_alani or '-' }}</td>
           <td>{{ p.sorumlu_personel or '-' }}</td>
           <td>{{ p.bagli_envanter_no or '-' }}</td>
+          <td>-</td>
           <td>-</td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- add license and printer tabs to the main scrap page
- allow entering a note when scrapping licenses or printers and display it in scrap lists
- include notes in dedicated scrap list pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b02df187f0832bb74100cbd6b30df7