### PR TITLE
Show modal details for scrapped printers

### DIFF
--- a/routers/printers.py
+++ b/routers/printers.py
@@ -253,7 +253,7 @@ def create_printer_simple(
 @router.get("/{printer_id}", response_class=HTMLResponse)
 def printer_detail(printer_id: int, request: Request, db: Session = Depends(get_db)):
     p = db.get(Printer, printer_id)
-    if not p:
+    if not p or p.durum == "hurda":
         raise HTTPException(404, "Yazıcı bulunamadı")
     logs = (
         db.query(PrinterHistory)

--- a/routes/scrap.py
+++ b/routes/scrap.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, HTTPException
 from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 from database import get_db
-from models import StockLog
+from models import StockLog, ScrapPrinter, PrinterHistory
 
 router = APIRouter()
 
@@ -14,3 +14,21 @@ def scrap_detail(id: int, request: Request, db: Session = Depends(get_db)):
     row = db.query(StockLog).get(id)
     templates = get_templates(request)
     return templates.TemplateResponse("partials/scrap_detail.html", {"request": request, "row": row})
+
+
+@router.get("/scrap/printer/{printer_id}", response_class=HTMLResponse)
+def scrap_printer_detail(printer_id: int, request: Request, db: Session = Depends(get_db)):
+    row = db.query(ScrapPrinter).filter(ScrapPrinter.printer_id == printer_id).first()
+    if not row:
+        raise HTTPException(404, "Kayıt bulunamadı")
+    logs = (
+        db.query(PrinterHistory)
+        .filter(PrinterHistory.printer_id == printer_id)
+        .order_by(PrinterHistory.created_at.desc())
+        .all()
+    )
+    templates = get_templates(request)
+    return templates.TemplateResponse(
+        "partials/scrap_printer_detail.html",
+        {"request": request, "row": row, "logs": logs},
+    )

--- a/templates/hurdalar.html
+++ b/templates/hurdalar.html
@@ -86,6 +86,7 @@
               <th>Bağlı Env.</th>
               <th>Not</th>
               <th>Tarih</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -100,6 +101,11 @@
               <td>{{ r.snapshot.bagli_envanter_no or '-' }}</td>
               <td>{{ r.reason or '-' }}</td>
               <td>{{ r.created_at.strftime("%d.%m.%Y %H:%M") }}</td>
+              <td>
+                <button class="btn btn-outline-secondary btn-sm view-btn" data-id="{{ r.printer_id }}" title="Detayı Göster">
+                  <i class="bi bi-eye"></i>
+                </button>
+              </td>
             </tr>
             {% else %}
             <tr><td colspan="9" class="text-muted">Kayıt yok.</td></tr>
@@ -110,4 +116,28 @@
     </div>
   </div>
 </div>
+
+<div class="modal fade" id="hurdaDetayModal" tabindex="-1">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header"><h5 class="modal-title">Hurda Detayı</h5>
+        <button class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body" id="hurdaDetayBody">Yükleniyor...</div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.querySelectorAll('#yazici .view-btn').forEach(b=>{
+  b.addEventListener('click', async ()=>{
+    const id = b.dataset.id;
+    const r = await fetch('/scrap/printer/'+id);
+    const h = await r.text();
+    document.getElementById('hurdaDetayBody').innerHTML = h;
+    new bootstrap.Modal(document.getElementById('hurdaDetayModal')).show();
+  });
+});
+</script>
+
 {% endblock %}

--- a/templates/partials/scrap_printer_detail.html
+++ b/templates/partials/scrap_printer_detail.html
@@ -1,0 +1,21 @@
+<div class="row g-3">
+  <div class="col-md-6"><strong>Marka:</strong> {{ row.snapshot.marka }}</div>
+  <div class="col-md-6"><strong>Model:</strong> {{ row.snapshot.model }}</div>
+  <div class="col-md-6"><strong>Seri No:</strong> {{ row.snapshot.seri_no }}</div>
+  <div class="col-md-6"><strong>Fabrika:</strong> {{ row.snapshot.fabrika or '-' }}</div>
+  <div class="col-md-6"><strong>Kullanım Alanı:</strong> {{ row.snapshot.kullanim_alani or '-' }}</div>
+  <div class="col-md-6"><strong>Sorumlu:</strong> {{ row.snapshot.sorumlu_personel or '-' }}</div>
+  <div class="col-md-6"><strong>Bağlı Env.:</strong> {{ row.snapshot.bagli_envanter_no or '-' }}</div>
+  <div class="col-md-6"><strong>Not:</strong> {{ row.reason or '-' }}</div>
+  <div class="col-md-6"><strong>Tarih:</strong> {{ row.created_at.strftime('%d.%m.%Y %H:%M') }}</div>
+</div>
+<hr>
+<h6>Geçmiş İşlemler</h6>
+<ul class="list-group">
+  {% for log in logs %}
+    <li class="list-group-item">{{ log|humanize_log }}</li>
+  {% else %}
+    <li class="list-group-item text-muted">Kayıt yok.</li>
+  {% endfor %}
+</ul>
+

--- a/templates/printers_scrap.html
+++ b/templates/printers_scrap.html
@@ -16,6 +16,7 @@
           <th>Bağlı Env.</th>
           <th>Not</th>
           <th>Tarih</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -31,6 +32,11 @@
           <td>{{ r.snapshot.bagli_envanter_no or '-' }}</td>
           <td>{{ r.reason or '-' }}</td>
           <td>{{ r.created_at.strftime("%d.%m.%Y %H:%M") }}</td>
+          <td>
+            <button class="btn btn-outline-secondary btn-sm view-btn" data-id="{{ r.printer_id }}" title="Detayı Göster">
+              <i class="bi bi-eye"></i>
+            </button>
+          </td>
         </tr>
         {% endfor %}
       {% else %}
@@ -45,6 +51,11 @@
           <td>{{ p.bagli_envanter_no or '-' }}</td>
           <td>-</td>
           <td>-</td>
+          <td>
+            <button class="btn btn-outline-secondary btn-sm view-btn" data-id="{{ p.id }}" title="Detayı Göster">
+              <i class="bi bi-eye"></i>
+            </button>
+          </td>
         </tr>
         {% endfor %}
       {% endif %}
@@ -52,5 +63,29 @@
     </table>
   </div>
 </div>
-{% endblock %}
 
+<div class="modal fade" id="hurdaDetayModal" tabindex="-1">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Hurda Detayı</h5>
+        <button class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body" id="hurdaDetayBody">Yükleniyor...</div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.querySelectorAll('.view-btn').forEach(b=>{
+  b.addEventListener('click', async ()=>{
+    const id = b.dataset.id;
+    const r = await fetch('/scrap/printer/'+id);
+    const h = await r.text();
+    document.getElementById('hurdaDetayBody').innerHTML = h;
+    new bootstrap.Modal(document.getElementById('hurdaDetayModal')).show();
+  });
+});
+</script>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- Block access to printer detail pages for scrapped devices
- Add `/scrap/printer/{id}` endpoint and template to display full scrap details with history
- Add eye icons in scrap lists that open a modal showing details and log history

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b032428e0c832b9fca05b9ad3e3e2a