### PR TITLE
Add modal license detail view in inventory screen

### DIFF
--- a/routers/license.py
+++ b/routers/license.py
@@ -323,6 +323,14 @@ def license_scrap_list(request: Request, db: Session = Depends(get_db)):
     return templates.TemplateResponse("license_scrap_list.html", {"request": request, "items": items})
 
 
+@router.get("/detail/{lic_id}", response_class=HTMLResponse, name="license.detail_partial")
+def license_detail_partial(lic_id: int, request: Request, db: Session = Depends(get_db)):
+    lic = db.query(License).get(lic_id)
+    if not lic:
+        raise HTTPException(status_code=404, detail="Lisans bulunamadı")
+    return templates.TemplateResponse("partials/license_detail.html", {"request": request, "item": lic})
+
+
 @router.get("/{lic_id}", name="license_detail")
 def license_detail(lic_id: int, request: Request, db: Session = Depends(get_db)):
     lic = db.query(License).get(lic_id)

--- a/templates/inventory_detail.html
+++ b/templates/inventory_detail.html
@@ -74,13 +74,42 @@
       {% for l in lisanslar %}
       <li class="list-group-item d-flex justify-content-between align-items-center">
         <span>{{ l.lisans_adi }}{% if l.lisans_anahtari %} - {{ l.lisans_anahtari }}{% endif %}</span>
-        <span class="text-muted">{{ l.durum or 'Aktif' }}</span>
+        <div class="d-flex align-items-center gap-2">
+          <span class="text-muted">{{ l.durum or 'Aktif' }}</span>
+          <button class="btn btn-sm btn-outline-secondary license-detail-btn" data-id="{{ l.id }}" title="Detayları Göster">
+            <i class="bi bi-eye"></i>
+          </button>
+        </div>
       </li>
       {% endfor %}
     {% else %}
       <li class="list-group-item text-muted">Kayıtlı lisans yok.</li>
     {% endif %}
   </ul>
+
+  <div class="modal fade" id="licenseDetailModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Lisans Detayı</h5>
+          <button class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+        </div>
+        <div class="modal-body" id="licenseDetailBody">Yükleniyor...</div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  document.querySelectorAll('.license-detail-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const id = btn.dataset.id;
+      const r = await fetch('/lisans/detail/' + id);
+      const h = await r.text();
+      document.getElementById('licenseDetailBody').innerHTML = h;
+      new bootstrap.Modal(document.getElementById('licenseDetailModal')).show();
+    });
+  });
+  </script>
 
   <h6 class="mt-4">Geçmiş Kayıtlar</h6>
   <ul class="list-group">

--- a/templates/partials/license_detail.html
+++ b/templates/partials/license_detail.html
@@ -1,0 +1,26 @@
+<div class="table-responsive">
+  <table class="table table-sm mb-0">
+    <tbody>
+      <tr><th>No</th><td>{{ item.id }}</td></tr>
+      <tr><th>Lisans Adı</th><td>{{ item.lisans_adi }}</td></tr>
+      <tr><th>Key</th><td class="text-truncate" style="max-width:220px;">{{ item.lisans_key }}</td></tr>
+      <tr><th>Sorumlu</th><td>{{ item.sorumlu_personel or '-' }}</td></tr>
+      <tr><th>Bağlı Envanter</th><td>{{ item.bagli_envanter_no or '-' }}</td></tr>
+      <tr><th>Durum</th><td>{{ item.durum }}</td></tr>
+      {% if item.notlar %}
+      <tr><th>Notlar</th><td>{{ item.notlar }}</td></tr>
+      {% endif %}
+    </tbody>
+  </table>
+</div>
+<h6 class="mt-3">Geçmiş</h6>
+<ul class="list-group">
+  {% for log in item.logs|sort(attribute='tarih', reverse=True) %}
+  <li class="list-group-item small">
+    <strong>{{ log.islem }}</strong> — {{ log.detay }}
+    <span class="text-muted">({{ log.islem_yapan }}, {{ log.tarih }})</span>
+  </li>
+  {% else %}
+  <li class="list-group-item text-muted">Kayıt yok.</li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- show license detail button in inventory detail view
- load license info in a modal via new `/lisans/detail/{id}` endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b042cac6e8832b9d3c290c6544387a