### PR TITLE
Simplify inventory change log display

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import os, secrets
+import os, secrets, json
 from typing import Optional
 
 from dotenv import load_dotenv
@@ -43,6 +43,22 @@ from routes.stock import router as stock_extra_router
 from routes.scrap import router as scrap_router
 from utils.i18n import humanize_log
 from security import current_user, require_roles
+
+
+def format_json(value):
+    """Pretty-print JSON for templates.
+
+    Accepts either a JSON string or a Python object and returns a nicely
+    indented JSON representation. Falls back to ``str(value)`` if parsing
+    fails so templates can render whatever was provided without breaking.
+    """
+    if value in (None, ""):
+        return ""
+    try:
+        data = json.loads(value) if isinstance(value, str) else value
+        return json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)
+    except Exception:
+        return str(value)
 
 load_dotenv()
 bootstrap_schema()
@@ -95,6 +111,7 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 templates = Jinja2Templates(directory="templates")
 app.state.templates = templates
 templates.env.filters["humanize_log"] = humanize_log
+templates.env.filters["format_json"] = format_json
 
 # --- Routers (korumalı) -------------------------------------------------------
 app.include_router(home.router, prefix="", dependencies=[Depends(current_user)])

--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Request, Depends, Form, HTTPException, UploadFile, File
+from fastapi import APIRouter, Request, Depends, Form, HTTPException, UploadFile, File
 from fastapi.responses import (
     JSONResponse,
     RedirectResponse,
@@ -26,10 +27,8 @@ from models import (
     ScrapPrinter,
 )
 from security import current_user
-from utils.i18n import humanize_log
-
 templates = Jinja2Templates(directory="templates")
-templates.env.filters["humanize_log"] = humanize_log
+
 
 router = APIRouter(prefix="/inventory", tags=["inventory"])
 
@@ -223,7 +222,6 @@ def detail(request: Request, item_id: int, db: Session = Depends(get_db), user=D
             "inv": item,
             "logs": logs,
             "lisanslar": lisanslar,
-            "loglar": logs,
         },
     )
 

--- a/templates/inventory_detail.html
+++ b/templates/inventory_detail.html
@@ -51,8 +51,8 @@
                 {% for log in logs %}
                 <tr>
                   <td>{{ log.action }}</td>
-                  <td class="text-muted"><pre class="mb-0">{{ log.before_json }}</pre></td>
-                  <td><pre class="mb-0">{{ log.after_json }}</pre></td>
+                  <td class="text-muted"><pre class="mb-0">{{ log.before_json | format_json }}</pre></td>
+                  <td><pre class="mb-0">{{ log.after_json | format_json }}</pre></td>
                   <td>{{ log.note }}</td>
                   <td>{{ log.actor }}</td>
                   <td>{{ log.created_at }}</td>
@@ -111,14 +111,6 @@
   });
   </script>
 
-  <h6 class="mt-4">Geçmiş Kayıtlar</h6>
-  <ul class="list-group">
-    {% for log in loglar %}
-      <li class="list-group-item">{{ log|humanize_log }}</li>
-    {% else %}
-      <li class="list-group-item text-muted">Kayıt yok.</li>
-    {% endfor %}
-  </ul>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- remove duplicate change log list from inventory detail view
- pretty-print log snapshots using new `format_json` filter
- register Jinja filters centrally in `app.py`

## Testing
- `python -m py_compile routers/inventory.py app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0444ca0fc832b97c3faf8f6221b6b