### PR TITLE
Fix missing format_json filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import os, secrets, json
+import os, secrets
 from typing import Optional
 
 from dotenv import load_dotenv
@@ -41,24 +41,8 @@ from routers.api import router as api_router
 from routes.admin import router as admin_router
 from routes.stock import router as stock_extra_router
 from routes.scrap import router as scrap_router
-from utils.i18n import humanize_log
+from utils.template_filters import register_filters
 from security import current_user, require_roles
-
-
-def format_json(value):
-    """Pretty-print JSON for templates.
-
-    Accepts either a JSON string or a Python object and returns a nicely
-    indented JSON representation. Falls back to ``str(value)`` if parsing
-    fails so templates can render whatever was provided without breaking.
-    """
-    if value in (None, ""):
-        return ""
-    try:
-        data = json.loads(value) if isinstance(value, str) else value
-        return json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)
-    except Exception:
-        return str(value)
 
 load_dotenv()
 bootstrap_schema()
@@ -108,10 +92,8 @@ app.add_middleware(
 
 # Statik dosyalar ve şablonlar
 app.mount("/static", StaticFiles(directory="static"), name="static")
-templates = Jinja2Templates(directory="templates")
+templates = register_filters(Jinja2Templates(directory="templates"))
 app.state.templates = templates
-templates.env.filters["humanize_log"] = humanize_log
-templates.env.filters["format_json"] = format_json
 
 # --- Routers (korumalı) -------------------------------------------------------
 app.include_router(home.router, prefix="", dependencies=[Depends(current_user)])

--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, Request, Depends, Form, HTTPException, UploadFile, File
-from fastapi import APIRouter, Request, Depends, Form, HTTPException, UploadFile, File
 from fastapi.responses import (
     JSONResponse,
     RedirectResponse,
@@ -11,6 +10,7 @@ from sqlalchemy.orm import Session, selectinload
 from datetime import datetime
 from fastapi.templating import Jinja2Templates
 from io import BytesIO
+from utils.template_filters import register_filters
 
 from database import get_db
 from models import (
@@ -27,7 +27,7 @@ from models import (
     ScrapPrinter,
 )
 from security import current_user
-templates = Jinja2Templates(directory="templates")
+templates = register_filters(Jinja2Templates(directory="templates"))
 
 
 router = APIRouter(prefix="/inventory", tags=["inventory"])

--- a/utils/template_filters.py
+++ b/utils/template_filters.py
@@ -1,0 +1,25 @@
+import json
+from utils.i18n import humanize_log
+
+
+def format_json(value):
+    """Pretty-print JSON for templates.
+
+    Accepts either a JSON string or a Python object and returns a nicely
+    indented JSON representation. Falls back to ``str(value)`` if parsing
+    fails so templates can render whatever was provided without breaking.
+    """
+    if value in (None, ""):
+        return ""
+    try:
+        data = json.loads(value) if isinstance(value, str) else value
+        return json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)
+    except Exception:
+        return str(value)
+
+
+def register_filters(templates):
+    """Register commonly used template filters on a Jinja2 environment."""
+    templates.env.filters["humanize_log"] = humanize_log
+    templates.env.filters["format_json"] = format_json
+    return templates


### PR DESCRIPTION
## Summary
- centralize Jinja2 filters and add format_json helper
- register common filters on app templates
- register filters for inventory routes to render JSON logs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b04efcc7dc832b9284e66720e6ba39