### PR TITLE
Show email in license pages and add detail page exit

### DIFF
--- a/templates/license_detail.html
+++ b/templates/license_detail.html
@@ -2,6 +2,10 @@
 {% block title %}Lisans Detayı{% endblock %}
 {% block content %}
 <div class="container-fluid p-2 content">
+  <div class="d-flex align-items-center justify-content-between mb-2">
+    <h5>Lisans: {{ item.lisans_adi }}</h5>
+    <a href="/lisans" class="btn btn-sm btn-outline-secondary">← Listeye dön</a>
+  </div>
   <div class="table-responsive">
     <table class="table table-sm">
       <tbody>
@@ -10,6 +14,7 @@
         <tr><th>Key</th><td class="text-truncate" style="max-width:220px;">{{ item.lisans_key }}</td></tr>
         <tr><th>Sorumlu</th><td>{{ item.sorumlu_personel or '-' }}</td></tr>
         <tr><th>Bağlı Envanter</th><td>{{ item.bagli_envanter_no or '-' }}</td></tr>
+        <tr><th>E-posta</th><td>{{ item.mail_adresi or '-' }}</td></tr>
         <tr><th>Durum</th><td>{{ item.durum }}</td></tr>
       </tbody>
     </table>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -45,6 +45,7 @@
           <th data-field="lisans_anahtari">Key</th>
           <th data-field="sorumlu_personel">Sorumlu</th>
           <th data-field="bagli_envanter_no">Bağlı Envanter</th>
+          <th data-field="mail_adresi">E-posta</th>
           <th data-field="durum">Durum</th>
           <th class="actions text-start">İşlemler</th>
         </tr>
@@ -57,6 +58,7 @@
           <td class="text-truncate" style="max-width:180px;">{{ row.lisans_key }}</td>
           <td>{{ row.sorumlu_personel or '-' }}</td>
           <td>{{ row.bagli_envanter_no or '-' }}</td>
+          <td>{{ row.mail_adresi or '-' }}</td>
           <td>
             {% if row.durum == 'hurda' %}<span class="badge bg-secondary">Hurda</span>
             {% else %}<span class="badge bg-success">Aktif</span>{% endif %}

--- a/templates/license_scrap_list.html
+++ b/templates/license_scrap_list.html
@@ -6,7 +6,7 @@
   <div class="table-responsive">
     <table class="table table-sm align-middle">
       <thead>
-        <tr><th>No</th><th>Lisans Adı</th><th>Key</th><th>Sorumlu</th><th>Bağlı Envanter</th><th>Not</th><th>Durum</th><th></th></tr>
+        <tr><th>No</th><th>Lisans Adı</th><th>Key</th><th>Sorumlu</th><th>Bağlı Envanter</th><th>E-posta</th><th>Not</th><th>Durum</th><th></th></tr>
       </thead>
       <tbody>
         {% for row in items %}
@@ -16,6 +16,7 @@
           <td class="text-truncate" style="max-width:220px;">{{ row.lisans_key }}</td>
           <td>{{ row.sorumlu_personel or '-' }}</td>
           <td>{{ row.bagli_envanter_no or '-' }}</td>
+          <td>{{ row.mail_adresi or '-' }}</td>
           <td>{{ row.notlar or '-' }}</td>
           <td><span class="badge bg-secondary">Hurda</span></td>
           <td class="text-nowrap">

--- a/templates/partials/license_detail.html
+++ b/templates/partials/license_detail.html
@@ -6,6 +6,7 @@
       <tr><th>Key</th><td class="text-truncate" style="max-width:220px;">{{ item.lisans_key }}</td></tr>
       <tr><th>Sorumlu</th><td>{{ item.sorumlu_personel or '-' }}</td></tr>
       <tr><th>Bağlı Envanter</th><td>{{ item.bagli_envanter_no or '-' }}</td></tr>
+      <tr><th>E-posta</th><td>{{ item.mail_adresi or '-' }}</td></tr>
       <tr><th>Durum</th><td>{{ item.durum }}</td></tr>
       {% if item.notlar %}
       <tr><th>Notlar</th><td>{{ item.notlar }}</td></tr>


### PR DESCRIPTION
## Summary
- display email in license listings
- show email on license details and modal
- add back-to-list button on license detail page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b052fe59b0832b99db7cde2cb3c307