### PR TITLE
Fix stock totals update for add and assign operations

### DIFF
--- a/routes/stock.py
+++ b/routes/stock.py
@@ -2,26 +2,46 @@ from fastapi import APIRouter, Depends, Body, Request
 from sqlalchemy.orm import Session
 from datetime import datetime
 from database import get_db
-from models import StockLog, StockAssignment, License, Inventory, Printer
+from models import (
+    StockLog,
+    StockAssignment,
+    StockTotal,
+    License,
+    Inventory,
+    Printer,
+)
 
 router = APIRouter(prefix="/stock", tags=["Stock"])
 
 @router.post("/add")
 def stock_add(payload: dict = Body(...), db: Session = Depends(get_db)):
     is_license = payload.get("is_license")
+    donanim_tipi = payload.get("donanim_tipi")
+    miktar = 1 if is_license else int(payload.get("miktar") or 0)
+    islem = payload.get("islem") or "girdi"
+
+    total = db.get(StockTotal, donanim_tipi) or StockTotal(
+        donanim_tipi=donanim_tipi, toplam=0
+    )
+    if islem in ("cikti", "hurda") and total.toplam < miktar:
+        return {"ok": False, "error": "Yetersiz stok"}
+
     log = StockLog(
-        donanim_tipi   = payload.get("donanim_tipi"),
-        marka          = None if is_license else payload.get("marka"),
-        model          = None if is_license else payload.get("model"),
-        lisans_anahtari= payload.get("lisans_anahtari") if is_license else None,
-        mail_adresi    = payload.get("mail_adresi") if is_license else None,
-        miktar         = 1 if is_license else int(payload.get("miktar") or 0),
-        ifs_no         = payload.get("ifs_no") or None,
-        islem          = payload.get("islem") or "girdi",
-        tarih          = datetime.utcnow(),
-        actor          = payload.get("islem_yapan") or "Sistem",
+        donanim_tipi=donanim_tipi,
+        marka=None if is_license else payload.get("marka"),
+        model=None if is_license else payload.get("model"),
+        lisans_anahtari=payload.get("lisans_anahtari") if is_license else None,
+        mail_adresi=payload.get("mail_adresi") if is_license else None,
+        miktar=miktar,
+        ifs_no=payload.get("ifs_no") or None,
+        islem=islem,
+        tarih=datetime.utcnow(),
+        actor=payload.get("islem_yapan") or "Sistem",
     )
     db.add(log)
+
+    total.toplam = total.toplam + miktar if islem == "girdi" else total.toplam - miktar
+    db.merge(total)
     db.commit()
     return {"ok": True, "id": log.id}
 
@@ -59,14 +79,22 @@ def stock_assign(payload: dict = Body(...), db: Session = Depends(get_db)):
         actor = payload.get("islem_yapan") or "Sistem",
         tarih = now,
     )
+    total = db.get(StockTotal, assign.donanim_tipi)
+    if not total or total.toplam < assign.miktar:
+        return {"ok": False, "error": "Yetersiz stok"}
+
     db.add(assign)
-    db.add(StockLog(
-        donanim_tipi=assign.donanim_tipi,
-        miktar=assign.miktar,
-        ifs_no=assign.ifs_no,
-        islem="atama",
-        actor=assign.actor,
-        tarih=now,
-    ))
+    db.add(
+        StockLog(
+            donanim_tipi=assign.donanim_tipi,
+            miktar=assign.miktar,
+            ifs_no=assign.ifs_no,
+            islem="atama",
+            actor=assign.actor,
+            tarih=now,
+        )
+    )
+    total.toplam -= assign.miktar
+    db.merge(total)
     db.commit()
     return {"ok": True, "desc": desc}


### PR DESCRIPTION
## Summary
- update `/stock/add` endpoint to maintain StockTotal counts
- ensure `/stock/assign` validates and subtracts from totals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b06315e5d4832b998f4b3c65353acf