### PR TITLE
Add stock status window and fix stock entry actions

### DIFF
--- a/routers/stock.py
+++ b/routers/stock.py
@@ -166,8 +166,16 @@ def add_log(
     return RedirectResponse(url="/stock", status_code=303)
 
 
-@router.get("/durum")
-def stock_status(db: Session = Depends(get_db)):
+@router.get("/durum", response_class=HTMLResponse)
+def stock_status_page(request: Request, db: Session = Depends(get_db)):
+    rows = current_stock(db)
+    return templates.TemplateResponse(
+        "stock_status.html", {"request": request, "rows": rows}
+    )
+
+
+@router.get("/durum/json")
+def stock_status_json(db: Session = Depends(get_db)):
     return JSONResponse({"ok": True, "rows": current_stock(db)})
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -85,7 +85,7 @@
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
     <script src="{{ url_for('static', path='js/picker.js') }}"></script>
     <script defer src="/static/js/selects.js"></script>
-    <script src="{{ url_for('static', path='/js/actions.js') }}"></script>
+    <script src="{{ url_for('static', path='js/actions.js') }}"></script>
   {% block scripts %}
   <script>
 document.addEventListener("DOMContentLoaded", () => {

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -6,6 +6,10 @@
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h5 class="mb-0">Stok Logları (En Güncel)</h5>
     <div class="d-flex gap-2">
+      <button class="btn btn-outline-info btn-sm" type="button"
+              onclick="window.open('/stock/durum','stokDurumu','width=600,height=400')">
+        Stok Durumu
+      </button>
       <div class="dropdown">
         <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
           Excel

--- a/templates/stock_status.html
+++ b/templates/stock_status.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="tr">
+<head>
+  <meta charset="utf-8">
+  <title>Stok Durumu</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-3">
+  <h5>Stok Durumu</h5>
+  <div class="table-responsive">
+    <table class="table table-sm">
+      <thead class="table-light">
+        <tr>
+          <th>Donanım Tipi</th>
+          <th>IFS No</th>
+          <th>Stok</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for r in rows %}
+        <tr>
+          <td>{{ r.donanim_tipi }}</td>
+          <td>{{ r.ifs_no or '-' }}</td>
+          <td>{{ r.stok }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Stock Durumu button with small popup showing current stock levels
- Serve stock status via new HTML route and template
- Fix missing actions.js include so stock entry actions trigger correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0647121a0832ba4de2e09c0c1cd7c