### PR TITLE
Display live inventory statistics on dashboard

### DIFF
--- a/routers/home.py
+++ b/routers/home.py
@@ -1,12 +1,78 @@
 # routers/home.py
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Depends
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from sqlalchemy import func, text
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import Inventory, InventoryLog, License, Printer
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
 
+
 @router.get("/", response_class=HTMLResponse)
-async def dashboard(request: Request):
-    stats = {"envanter_sayisi": 0, "lisans_sayisi": 0, "bekleyen_talep": 0, "son_islemler": []}
-    return templates.TemplateResponse("dashboard.html", {"request": request, "stats": stats})
+def dashboard(request: Request, db: Session = Depends(get_db)):
+    """Render dashboard with live statistics."""
+
+    total_inventory = (
+        db.query(func.count(Inventory.id)).filter(Inventory.durum != "hurda").scalar()
+    )
+    total_printers = (
+        db.query(func.count(Printer.id)).filter(Printer.durum != "hurda").scalar()
+    )
+    toplam_cihaz = (total_inventory or 0) + (total_printers or 0)
+
+    lisans_sayisi = (
+        db.query(func.count(License.id)).filter(License.durum != "hurda").scalar() or 0
+    )
+    bos_lisans_sayisi = (
+        db.query(func.count(License.id))
+        .filter(License.inventory_id.is_(None), License.durum != "hurda")
+        .scalar()
+        or 0
+    )
+
+    arizali_cihaz_sayisi = (
+        db.query(func.count(Inventory.id)).filter(Inventory.durum == "arızalı").scalar()
+        or 0
+    )
+    arizali_cihaz_sayisi += (
+        db.query(func.count(Printer.id)).filter(Printer.durum == "arızalı").scalar() or 0
+    )
+
+    try:
+        bekleyen_talep = db.execute(
+            text("SELECT COUNT(*) FROM requests WHERE durum='aktif'")
+        ).scalar()
+    except Exception:
+        bekleyen_talep = 0
+
+    son_islemler = (
+        db.query(
+            InventoryLog.created_at,
+            InventoryLog.actor,
+            InventoryLog.action,
+            Inventory.no.label("no"),
+        )
+        .join(Inventory, Inventory.id == InventoryLog.inventory_id)
+        .order_by(InventoryLog.created_at.desc())
+        .limit(5)
+        .all()
+    )
+
+    stats = {
+        "toplam_cihaz": toplam_cihaz,
+        "envanter_sayisi": total_inventory or 0,
+        "yazici_sayisi": total_printers or 0,
+        "lisans_sayisi": lisans_sayisi,
+        "bos_lisans_sayisi": bos_lisans_sayisi,
+        "arizali_cihaz_sayisi": arizali_cihaz_sayisi,
+        "bekleyen_talep": bekleyen_talep,
+        "son_islemler": son_islemler,
+    }
+
+    return templates.TemplateResponse(
+        "dashboard.html", {"request": request, "stats": stats}
+    )

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -12,33 +12,33 @@
   </form>
 </div>
 
-<div class="row g-3 mb-3">
+  <div class="row g-3 mb-3">
   <div class="col-12 col-md-6 col-xl-3">
     <div class="soft-card p-3 stat-card">
       <div class="stat-title">Toplam Cihaz</div>
-      <div class="stat-value">1.284</div>
-      <div class="stat-sub">Aktif: 1.102 / Arızalı: 44</div>
+      <div class="stat-value">{{ stats.toplam_cihaz }}</div>
+      <div class="stat-sub">Envanter: {{ stats.envanter_sayisi }} / Yazıcı: {{ stats.yazici_sayisi }}</div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-xl-3">
     <div class="soft-card p-3 stat-card">
       <div class="stat-title">Lisans (aktif)</div>
-      <div class="stat-value">362</div>
-      <div class="stat-sub">30 gün içinde bitecek: 12</div>
+      <div class="stat-value">{{ stats.lisans_sayisi }}</div>
+      <div class="stat-sub">Boş Lisans: {{ stats.bos_lisans_sayisi }}</div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-xl-3">
     <div class="soft-card p-3 stat-card">
-      <div class="stat-title">Aksesuar Stok</div>
-      <div class="stat-value">3.412</div>
-      <div class="stat-sub">Eşik altı: 5</div>
+      <div class="stat-title">Arızalı Cihaz</div>
+      <div class="stat-value">{{ stats.arizali_cihaz_sayisi }}</div>
+      <div class="stat-sub"></div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-xl-3">
     <div class="soft-card p-3 stat-card">
       <div class="stat-title">Açık Talep</div>
-      <div class="stat-value">19</div>
-      <div class="stat-sub">Ortalama SLA: 2.1 gün</div>
+      <div class="stat-value">{{ stats.bekleyen_talep }}</div>
+      <div class="stat-sub"></div>
     </div>
   </div>
 </div>
@@ -57,13 +57,17 @@
         </tr>
       </thead>
       <tbody>
-        {% for i in range(6) %}
+        {% for row in stats.son_islemler %}
         <tr>
-          <td>2025-08-20 10:2{{ i }}</td>
-          <td>kadir.can</td>
-          <td>Atama</td>
-          <td>Cihaz #12{{ i }}0</td>
+          <td>{{ row.created_at.strftime('%Y-%m-%d %H:%M') }}</td>
+          <td>{{ row.actor or '-' }}</td>
+          <td>{{ row.action }}</td>
+          <td>{{ row.no }}</td>
           <td><span class="badge badge-soft-success">Başarılı</span></td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="5" class="text-center">Kayıt bulunamadı.</td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- compute device, license, faulty device and request counts for dashboard
- show unassigned license count and last five operations on homepage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b065afb3fc832b85b50926b67f9091