### PR TITLE
Display stock status within current page

### DIFF
--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -81,3 +81,15 @@ document.getElementById('frmStockAssign')?.addEventListener('submit', async (e)=
   const j = await res.json();
   if(j.ok){ location.reload(); } else { alert(j.error || 'Atama başarısız'); }
 });
+
+// Stok durumu modalı
+const stockStatusModal = document.getElementById('stockStatusModal');
+stockStatusModal?.addEventListener('show.bs.modal', ()=>{
+  fetch('/stock/durum/json')
+    .then(r=>r.json())
+    .then(d=>{
+      const tbody = document.querySelector('#tblStockStatus tbody');
+      if(!tbody) return;
+      tbody.innerHTML = (d.rows||[]).map(r=>`<tr><td>${r.donanim_tipi}</td><td>${r.ifs_no||'-'}</td><td>${r.stok}</td></tr>`).join('');
+    });
+});

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -7,7 +7,7 @@
     <h5 class="mb-0">Stok Logları (En Güncel)</h5>
     <div class="d-flex gap-2">
       <button class="btn btn-outline-info btn-sm" type="button"
-              onclick="window.open('/stock/durum','stokDurumu','width=600,height=400')">
+              data-bs-toggle="modal" data-bs-target="#stockStatusModal">
         Stok Durumu
       </button>
       <div class="dropdown">
@@ -63,6 +63,32 @@
         {% endfor %}
       </tbody>
     </table>
+  </div>
+</div>
+
+<!-- STOK DURUMU MODALI -->
+<div class="modal fade" id="stockStatusModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Stok Durumu</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <div class="table-responsive">
+          <table class="table table-sm" id="tblStockStatus">
+            <thead class="table-light">
+              <tr>
+                <th>Donanım Tipi</th>
+                <th>IFS No</th>
+                <th>Stok</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Replace separate stock status window with Bootstrap modal on stock list
- Load stock status data dynamically from JSON endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b067067324832b97d13b057f2fa493