### PR TITLE
Enable modal editing for records and refine printer history

### DIFF
--- a/routers/license.py
+++ b/routers/license.py
@@ -167,7 +167,7 @@ def create_license(
 
 
 @router.get("/{lic_id}/edit", response_class=HTMLResponse, name="license.edit_form")
-def edit_license_form(lic_id: int, request: Request, db: Session = Depends(get_db)):
+def edit_license_form(lic_id: int, request: Request, modal: bool = False, db: Session = Depends(get_db)):
     lic = db.query(License).get(lic_id)
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
@@ -183,6 +183,7 @@ def edit_license_form(lic_id: int, request: Request, db: Session = Depends(get_d
             "users": users,
             "license_names": license_names,
             "form_action": f"/lisans/{lic_id}/edit",
+            "modal": modal,
         },
     )
 
@@ -197,6 +198,7 @@ def edit_license_post(
     inventory_id: int = Form(None),
     ifs_no: str = Form(""),
     mail_adresi: str = Form(""),
+    modal: bool = False,
     db: Session = Depends(get_db),
     user = Depends(current_user),
 ):
@@ -213,6 +215,8 @@ def edit_license_post(
     lic.mail_adresi = mail_adresi or None
     _logla(db, lic, "DUZENLE", "Lisans düzenlendi", getattr(user, "full_name", None) or "system")
     db.commit()
+    if modal:
+        return HTMLResponse("<script>window.parent.postMessage('modal-close','*');</script>")
     return RedirectResponse(url=request.url_for("license_list"), status_code=status.HTTP_303_SEE_OTHER)
 
 

--- a/routers/printers.py
+++ b/routers/printers.py
@@ -304,11 +304,11 @@ def assign_printer(
 
 
 @router.get("/edit/{printer_id}", response_class=HTMLResponse)
-def edit_printer(printer_id: int, request: Request, db: Session = Depends(get_db)):
+def edit_printer(printer_id: int, request: Request, modal: bool = False, db: Session = Depends(get_db)):
     p = db.get(Printer, printer_id)
     if not p:
         raise HTTPException(404, "Yazıcı bulunamadı")
-    return templates.TemplateResponse("printers_edit.html", {"request": request, "p": p})
+    return templates.TemplateResponse("printers_edit.html", {"request": request, "p": p, "modal": modal})
 
 
 @router.post("/edit/{printer_id}")
@@ -318,6 +318,7 @@ def edit_printer_post(
     model: str = Form(None),
     seri_no: str = Form(None),
     notlar: str = Form(None),
+    modal: bool = False,
     db: Session = Depends(get_db),
     user=Depends(current_user),
 ):
@@ -340,6 +341,8 @@ def edit_printer_post(
         )
     )
     db.commit()
+    if modal:
+        return HTMLResponse("<script>window.parent.postMessage('modal-close','*');</script>")
     return RedirectResponse(url=f"/printers/{printer_id}", status_code=303)
 
 

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -24,7 +24,14 @@
     // stock  -> /{entity}/{id}/stock
     // scrap  -> /{entity}/{id}/scrap
     const map = { assign: 'assign', edit: 'edit', stock: 'stock', scrap: 'scrap' };
-    if (map[val]) go(`/${entity}/${id}/${map[val]}`);
+    if (map[val]) {
+      const url = `/${entity}/${id}/${map[val]}`;
+      if (val === 'edit' && window.openModal) {
+        openModal(url + '?modal=1');
+      } else {
+        go(url);
+      }
+    }
     sel.value = '';
   });
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -81,6 +81,21 @@
       </div>
     </div>
 
+    <!-- iframe modal -->
+    <div class="modal fade" id="iframeModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="iframeModalTitle"></h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body p-0">
+            <iframe id="iframeModalFrame" style="width:100%;height:70vh;border:0;"></iframe>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
     <script src="{{ url_for('static', path='js/picker.js') }}"></script>
@@ -137,6 +152,31 @@ document.addEventListener("DOMContentLoaded", () => {
 
 // Use this for interactive elements inside rows
 function stopRowClick(e) { e.stopPropagation(); }
+
+function openModal(url, title="") {
+  const frame = document.getElementById("iframeModalFrame");
+  frame.src = url;
+  document.getElementById("iframeModalTitle").textContent = title;
+  const modal = new bootstrap.Modal(document.getElementById("iframeModal"));
+  modal.show();
+}
+window.openModal = openModal;
+
+document.addEventListener("click", (e) => {
+  const link = e.target.closest("[data-modal-url]");
+  if (!link) return;
+  e.preventDefault();
+  openModal(link.dataset.modalUrl, link.dataset.modalTitle || "");
+});
+
+window.addEventListener("message", (e) => {
+  if (e.data === "modal-close") {
+    const modalEl = document.getElementById("iframeModal");
+    const modal = bootstrap.Modal.getInstance(modalEl);
+    if (modal) modal.hide();
+    window.location.reload();
+  }
+});
     </script>
 
     <style>

--- a/templates/inventory/detail.html
+++ b/templates/inventory/detail.html
@@ -3,7 +3,7 @@
 <h2 class="h5 mb-3">Detay (ID: {{ item_id }})</h2>
 <div class="card p-3">Detay bilgileri...</div>
 <div class="mt-3 d-flex gap-2">
-  <a href="/inventory/{{ item_id }}/edit" class="btn btn-primary btn-sm">Düzenle</a>
+  <a href="#" data-modal-url="/inventory/{{ item_id }}/edit?modal=1" class="btn btn-primary btn-sm">Düzenle</a>
   <a href="/inventory/{{ item_id }}/maintenance" class="btn btn-outline-light btn-sm">Bakım/Onarım</a>
   <a href="/inventory/{{ item_id }}/history" class="btn btn-outline-light btn-sm">Hareket Geçmişi</a>
 </div>

--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container-fluid p-3">
   <h5 class="mb-3">Envanter Düzenle</h5>
-  <form method="post">
+  <form method="post" action="{{ '?modal=1' if modal else '' }}">
     <div class="row g-3">
       <div class="col-md-3">
         <label class="form-label">Fabrika</label>

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -418,7 +418,7 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('assign_item_id').value = id;
         assignModal.show();
       } else if (val === 'edit') {
-        window.location.href = "{{ url_for('inventory.edit', item_id=0)|replace('/0', '/__ID__') }}".replace('__ID__', id);
+        if(window.openModal){ openModal(`/inventory/${id}/edit?modal=1`); }
       } else if (val === 'scrap') {
         document.getElementById('scrap_item_id').value = id;
         scrapModal.show();

--- a/templates/license_detail.html
+++ b/templates/license_detail.html
@@ -4,7 +4,10 @@
 <div class="container-fluid p-2 content">
   <div class="d-flex align-items-center justify-content-between mb-2">
     <h5>Lisans: {{ item.lisans_adi }}</h5>
-    <a href="/lisans" class="btn btn-sm btn-outline-secondary">← Listeye dön</a>
+    <div class="d-flex gap-2">
+      <a href="#" class="btn btn-sm btn-primary" data-modal-url="/lisans/{{ item.id }}/edit?modal=1">Düzenle</a>
+      <a href="/lisans" class="btn btn-sm btn-outline-secondary">← Listeye dön</a>
+    </div>
   </div>
   <div class="table-responsive">
     <table class="table table-sm">

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -10,7 +10,7 @@
 
   <div class="card shadow-sm">
     <div class="card-body">
-      <form method="post" action="{{ form_action }}">
+      <form method="post" action="{{ form_action }}{{ '?modal=1' if modal else '' }}">
         <div class="row g-3">
           <div class="col-md-6">
             <label class="form-label">Lisans Adı</label>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -315,7 +315,7 @@
           assignForm.action = `/lisans/${id}/assign`;
           assignModal.show();
         } else if (val === 'edit') {
-          window.location.href = `/licenses/${id}/edit`;
+          if(window.openModal){ openModal(`/lisans/${id}/edit?modal=1`); }
         } else if (val === 'scrap') {
           if(!confirm('Bu lisansı hurdaya ayırmak istiyor musunuz?')) { e.target.value=''; return; }
           const reason = prompt('Hurda sebebi / not (opsiyonel):','');

--- a/templates/printers_detail.html
+++ b/templates/printers_detail.html
@@ -4,7 +4,10 @@
 <div class="container py-3">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h5 class="mb-0">Yazıcı #{{ p.id }} — {{ p.marka }} {{ p.model }}</h5>
-    <a class="btn btn-sm btn-outline-secondary" href="/printers">Geri</a>
+    <div class="d-flex gap-2">
+      <a class="btn btn-sm btn-primary" href="#" data-modal-url="/printers/edit/{{ p.id }}?modal=1">Düzenle</a>
+      <a class="btn btn-sm btn-outline-secondary" href="/printers">Geri</a>
+    </div>
   </div>
   <div class="row g-3">
     <div class="col-lg-6">
@@ -33,7 +36,11 @@
               <li class="list-group-item">
                 <div class="small text-muted">{{ h.created_at.strftime("%d.%m.%Y %H:%M") }} — {{ h.actor or '-' }} — {{ h.action }}</div>
                 {% if h.changes %}
-                <pre class="mt-2 mb-0 small">{{ h.changes | tojson(indent=2) }}</pre>
+                <ul class="mt-2 mb-0 small">
+                  {% for field, vals in h.changes.items() %}
+                  <li><code>{{ field }}</code>: {{ vals.old or '-' }} → {{ vals.new or '-' }}</li>
+                  {% endfor %}
+                </ul>
                 {% endif %}
               </li>
               {% endfor %}

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container-fluid p-3">
   <h5 class="mb-3">Yazıcı Düzenle</h5>
-  <form method="post">
+  <form method="post" action="{{ '?modal=1' if modal else '' }}">
     <div class="mb-2">
       <label class="form-label">Marka</label>
       <input type="text" name="marka" value="{{ p.marka or '' }}" class="form-control">

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -381,7 +381,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if(!val) return;
 
       if(val === 'edit'){
-        window.location.href = `/printers/edit/${printerId}`;
+        if(window.openModal){ openModal(`/printers/edit/${printerId}?modal=1`); }
       } else if(val === 'assign'){
         document.getElementById('assignPrinterId').value = printerId;
         document.getElementById('assignPrinterLabel').innerText = `#${printerId}`;


### PR DESCRIPTION
## Summary
- open inventory, license, and printer edit forms in a shared modal
- handle modal submissions server-side and refresh parent on save
- show printer change history as readable list instead of raw JSON

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b067d6f354832b87fc1c9d7521c55c