### PR TITLE
Reorder add buttons and enhance stock status details

### DIFF
--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -45,15 +45,3 @@
   });
 })();
 
-// Arama kapalı sadece seçmeli (Choices kullanıyorsan searchEnabled:false)
-(function(){
-  const initNoSearch = (selId) => {
-    const el = document.getElementById(selId);
-    if(!el) return;
-    if (window.Choices) {
-      new Choices(el, { searchEnabled:false, shouldSort:false, itemSelectText:'' });
-    }
-  };
-  initNoSearch('licIslemSelect');
-  initNoSearch('prnIslemSelect');
-})();

--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -84,12 +84,19 @@ document.getElementById('frmStockAssign')?.addEventListener('submit', async (e)=
 
 // Stok durumu modalı
 const stockStatusModal = document.getElementById('stockStatusModal');
-stockStatusModal?.addEventListener('show.bs.modal', ()=>{
-  fetch('/stock/durum/json')
-    .then(r=>r.json())
-    .then(d=>{
+stockStatusModal?.addEventListener('show.bs.modal', () => {
+  fetch('/api/stock/status')
+    .then(r => r.json())
+    .then(d => {
       const tbody = document.querySelector('#tblStockStatus tbody');
-      if(!tbody) return;
-      tbody.innerHTML = (d.rows||[]).map(r=>`<tr><td>${r.donanim_tipi}</td><td>${r.ifs_no||'-'}</td><td>${r.stok}</td></tr>`).join('');
+      if (!tbody) return;
+      const detail = d.detail || {};
+      tbody.innerHTML = Object.entries(d.totals || {}).map(([dt, qty]) => {
+        const det = detail[dt];
+        const id = 'det' + dt.replace(/[^a-zA-Z0-9]/g, '');
+        const btn = det ? `<button class="btn btn-sm btn-outline-secondary" data-bs-toggle="collapse" data-bs-target="#${id}"><i class="bi bi-list"></i></button>` : '';
+        const detailRows = det ? `<tr id="${id}" class="collapse"><td colspan="3"><table class="table table-sm mb-0">${Object.entries(det).map(([ifs, q]) => `<tr><td>${ifs}</td><td>${q}</td></tr>`).join('')}</table></td></tr>` : '';
+        return `<tr><td>${dt}</td><td>${qty}</td><td>${btn}</td></tr>${detailRows}`;
+      }).join('');
     });
 });

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -3,14 +3,12 @@
 {% block content %}
   <div id="inventory-list-root" class="container-fluid p-2">
   <div class="d-flex align-items-center justify-content-between mb-3">
+    <h5 class="mb-0">Envanter</h5>
     <div class="d-flex align-items-center gap-2">
       <a href="#" id="addBtn" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle">
         <i class="bi bi-plus-lg"></i>
         <span>Ekle</span>
       </a>
-      <h5 class="mb-0">Envanter</h5>
-    </div>
-    <div class="d-flex align-items-center gap-2">
       <div class="dropdown">
         <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
           Excel

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -3,14 +3,12 @@
 {% block content %}
 <div id="licenses-list" class="container-fluid p-2 content">
   <div class="d-flex align-items-center justify-content-between mb-3">
+    <h5 class="mb-0">Lisans</h5>
     <div class="d-flex align-items-center gap-2">
-        <a href="#" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#addModal">
-          <i class="bi bi-plus-lg"></i>
-          <span>Ekle</span>
-        </a>
-      <h5 class="mb-0">Lisans</h5>
-    </div>
-    <div class="d-flex align-items-center gap-2">
+      <a href="#" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#addModal">
+        <i class="bi bi-plus-lg"></i>
+        <span>Ekle</span>
+      </a>
       <div class="dropdown">
         <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
           Excel
@@ -28,12 +26,6 @@
       <button class="btn btn-outline-secondary btn-sm" id="filterBtn">Filtre</button>
       <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">Temizle</button>
       <input type="text" id="searchInput" class="form-control form-control-sm" placeholder="Ara...">
-      <select id="licIslemSelect" class="form-select form-select-sm ms-2">
-        <option value="">Seçiniz</option>
-        <option value="assign">Atama Yap</option>
-        <option value="edit">Düzenle</option>
-        <option value="scrap">Hurdaya Ayır</option>
-      </select>
     </div>
   </div>
   <div class="table-responsive">

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -4,14 +4,12 @@
 {% block content %}
 <div class="container-fluid p-3">
   <div class="d-flex align-items-center justify-content-between mb-3">
+    <h5 class="mb-0">Yazıcılar</h5>
     <div class="d-flex align-items-center gap-2">
-        <a href="#" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#addModal">
-          <i class="bi bi-plus-lg"></i>
-          <span>Ekle</span>
-        </a>
-      <h5 class="mb-0">Yazıcılar</h5>
-    </div>
-    <div class="d-flex align-items-center gap-2">
+      <a href="#" class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#addModal">
+        <i class="bi bi-plus-lg"></i>
+        <span>Ekle</span>
+      </a>
       <div class="dropdown">
         <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
           Excel
@@ -29,12 +27,6 @@
       <button class="btn btn-outline-secondary btn-sm" id="filterBtn">Filtre</button>
       <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">Temizle</button>
       <input type="text" id="searchInput" class="form-control form-control-sm" placeholder="Ara...">
-      <select id="prnIslemSelect" class="form-select form-select-sm ms-2">
-        <option value="">Seçiniz</option>
-        <option value="assign">Atama Yap</option>
-        <option value="edit">Düzenle</option>
-        <option value="scrap">Hurdaya Ayır</option>
-      </select>
     </div>
   </div>
 

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -10,6 +10,10 @@
               data-bs-toggle="modal" data-bs-target="#stockStatusModal">
         Stok Durumu
       </button>
+      <button class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#stockAddModal">
+        <i class="bi bi-plus-lg"></i>
+        <span>Ekle</span>
+      </button>
       <div class="dropdown">
         <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
           Excel
@@ -24,10 +28,6 @@
           </li>
         </ul>
       </div>
-      <button class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#stockAddModal">
-        <i class="bi bi-plus-lg"></i>
-        <span>Ekle</span>
-      </button>
       <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#stockAssignModal">Atama</button>
     </div>
   </div>
@@ -80,8 +80,8 @@
             <thead class="table-light">
               <tr>
                 <th>Donanım Tipi</th>
-                <th>IFS No</th>
                 <th>Stok</th>
+                <th></th>
               </tr>
             </thead>
             <tbody></tbody>


### PR DESCRIPTION
## Summary
- Move green **Ekle** buttons to the left of Excel actions on inventory, printer, license, and stock pages
- Remove unused global action selects from printer and license listings
- Fetch up-to-date stock status with optional IFS breakdown and toggleable detail rows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b06ba27964832b81067eaa984daca5