### PR TITLE
Remove navigation clutter from edit modals

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -107,7 +107,9 @@ document.addEventListener("DOMContentLoaded", () => {
   if (window.self !== window.top) {
     const aside = document.querySelector("aside");
     const main = document.querySelector("main");
+    const nav = document.querySelector("nav.navbar");
     if (aside) aside.remove();
+    if (nav) nav.remove();
     if (main) main.classList.remove("col-lg-10");
   }
 

--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -43,7 +43,9 @@
     </div>
     <div class="mt-3">
       <button class="btn btn-primary btn-sm">Kaydet</button>
+      {% if not modal %}
       <a href="{{ url_for('inventory.list') }}" class="btn btn-outline-secondary btn-sm">İptal</a>
+      {% endif %}
     </div>
   </form>
 </div>

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -5,7 +5,9 @@
 <div class="container-fluid p-3 content">
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h4 class="mb-0">Lisans {{ 'Düzenle' if license else 'Ekle' }}</h4>
+    {% if not modal %}
     <a class="btn btn-light" href="{{ url_for('license_list') }}">← Listeye Dön</a>
+    {% endif %}
   </div>
 
   <div class="card shadow-sm">
@@ -63,7 +65,9 @@
 
         <div class="d-flex gap-2 mt-4">
           <button class="btn btn-primary" type="submit">Kaydet</button>
+          {% if not modal %}
           <a class="btn btn-secondary" href="{{ url_for('license_list') }}">İptal</a>
+          {% endif %}
         </div>
       </form>
     </div>

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -21,7 +21,9 @@
       <textarea name="notlar" class="form-control" rows="3">{{ p.notlar or '' }}</textarea>
     </div>
     <button class="btn btn-primary btn-sm">Kaydet</button>
+    {% if not modal %}
     <a href="/printers/{{ p.id }}" class="btn btn-outline-secondary btn-sm">İptal</a>
+    {% endif %}
   </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Hide navbar when a page is opened inside a modal/iframe
- Hide back and cancel links on license, inventory and printer edit forms when used as modal dialogs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b14a614314832b8440bde73fd456ad