### PR TITLE
Unassign licenses when inventory scrapped

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -25,6 +25,7 @@ from models import (
     UsageArea,
     HardwareType,
     License,
+    LicenseLog,
     ScrapPrinter,
     StockLog,
 )
@@ -413,6 +414,17 @@ def scrap(item_id: int = Form(...), aciklama: str = Form(""), db: Session = Depe
 
   item.durum = "hurda"
   db.add(item)
+
+  for lic in list(item.licenses):
+    lic.sorumlu_personel = None
+    lic.bagli_envanter_no = None
+    lic.inventory_id = None
+    db.add(LicenseLog(
+      license_id=lic.id,
+      islem="ATAMA",
+      detay="Envanter hurdaya ayrıldığı için lisans bağlantısı kaldırıldı",
+      islem_yapan=user.username
+    ))
 
   db.add(InventoryLog(
     inventory_id=item.id,


### PR DESCRIPTION
## Summary
- Clear license assignments when moving an inventory item to scrap
- Log license unlink events with `LicenseLog`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b14b702758832b8df234186258dcb6