### PR TITLE
Fix printer edit path and add scrap modals

### DIFF
--- a/routers/printers.py
+++ b/routers/printers.py
@@ -303,7 +303,7 @@ def assign_printer(
     return JSONResponse({"ok": True})
 
 
-@router.get("/edit/{printer_id}", response_class=HTMLResponse)
+@router.get("/{printer_id}/edit", response_class=HTMLResponse)
 def edit_printer(printer_id: int, request: Request, modal: bool = False, db: Session = Depends(get_db)):
     p = db.get(Printer, printer_id)
     if not p:
@@ -311,7 +311,7 @@ def edit_printer(printer_id: int, request: Request, modal: bool = False, db: Ses
     return templates.TemplateResponse("printers_edit.html", {"request": request, "p": p, "modal": modal})
 
 
-@router.post("/edit/{printer_id}")
+@router.post("/{printer_id}/edit")
 def edit_printer_post(
     printer_id: int,
     marka: str = Form(None),
@@ -376,7 +376,7 @@ def stock_printer(printer_id: int, db: Session = Depends(get_db), user=Depends(c
     return RedirectResponse(url="/stock", status_code=303)
 
 
-@router.post("/scrap/{printer_id}")
+@router.post("/{printer_id}/scrap")
 def scrap_printer(
     printer_id: int,
     reason: str = Form(None),

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -189,6 +189,30 @@
         </div>
       </div>
     </form>
+</div>
+</div>
+
+<!-- HURDA MODALI -->
+<div class="modal fade" id="scrapModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="scrapForm" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Hurdaya Ayır</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <p>Bu lisans hurdaya ayrılacak. Onaylıyor musunuz?</p>
+        <div class="mb-2">
+          <label class="form-label">Açıklama (opsiyonel)</label>
+          <textarea name="aciklama" class="form-control" rows="3" placeholder="Hurda sebebi / not"></textarea>
+        </div>
+        <input type="hidden" name="islem_yapan" value="{{ current_user.full_name if current_user else 'system' }}">
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" data-bs-dismiss="modal" type="button">Vazgeç</button>
+        <button class="btn btn-danger" type="submit">Hurdaya Ayır</button>
+      </div>
+    </form>
   </div>
 </div>
 
@@ -296,9 +320,13 @@
     // Mevcut atama/hurda işlemleri
     const assignModal = new bootstrap.Modal(document.getElementById('assignModal'));
     const assignForm  = document.getElementById('assignForm');
+    const scrapModal  = new bootstrap.Modal(document.getElementById('scrapModal'));
+    const scrapForm   = document.getElementById('scrapForm');
+    let scrapId = null;
 
     document.querySelectorAll('#licensesTable .action-select').forEach(sel => {
       sel.addEventListener('change', (e) => {
+        e.stopImmediatePropagation();
         const id = e.target.dataset.id;
         const val = e.target.value;
         if (!val) return;
@@ -309,23 +337,20 @@
         } else if (val === 'edit') {
           if(window.openModal){ openModal(`/lisans/${id}/edit?modal=1`); }
         } else if (val === 'scrap') {
-          if(!confirm('Bu lisansı hurdaya ayırmak istiyor musunuz?')) { e.target.value=''; return; }
-          const reason = prompt('Hurda sebebi / not (opsiyonel):','');
-          if(reason === null){ e.target.value=''; return; }
-          const f = document.createElement('form');
-          f.method = 'post';
-          f.action = `/lisans/${id}/scrap`;
-          const who = document.createElement('input');
-          who.name = 'islem_yapan';
-          who.value = "{{ current_user.full_name if current_user else 'system' }}";
-          f.appendChild(who);
-          if(reason){ const r = document.createElement('input'); r.name = 'aciklama'; r.value = reason; f.appendChild(r); }
-          document.body.appendChild(f);
-          f.submit();
+          scrapId = id;
+          scrapModal.show();
         }
 
         e.target.value = '';
       });
+    });
+
+    scrapForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(scrapForm);
+      const res = await fetch(`/lisans/${scrapId}/scrap`, { method: 'POST', body: fd });
+      if(res.ok){ scrapModal.hide(); window.location.href = `{{ url_for('license_scrap_list') }}`; }
+      else { alert('Hurdaya ayırma başarısız'); }
     });
 
     if (window.Choices) {

--- a/templates/printers_detail.html
+++ b/templates/printers_detail.html
@@ -5,7 +5,7 @@
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h5 class="mb-0">Yazıcı #{{ p.id }} — {{ p.marka }} {{ p.model }}</h5>
     <div class="d-flex gap-2">
-      <a class="btn btn-sm btn-primary" href="#" data-modal-url="/printers/edit/{{ p.id }}?modal=1">Düzenle</a>
+      <a class="btn btn-sm btn-primary" href="#" data-modal-url="/printers/{{ p.id }}/edit?modal=1">Düzenle</a>
       <a class="btn btn-sm btn-outline-secondary" href="/printers">Geri</a>
     </div>
   </div>

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -221,6 +221,30 @@
     </form>
   </div>
 </div>
+
+<!-- HURDA MODAL -->
+<div class="modal fade" id="scrapModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="scrapForm" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Hurdaya Ayır</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" id="scrapPrinterId">
+        <p>Bu envanter hurdaya ayrılacak. Onaylıyor musunuz?</p>
+        <div class="mb-2">
+          <label class="form-label">Açıklama (opsiyonel)</label>
+          <textarea name="reason" class="form-control" rows="3" placeholder="Hurda sebebi / not"></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" data-bs-dismiss="modal" type="button">Vazgeç</button>
+        <button class="btn btn-danger" type="submit">Hurdaya Ayır</button>
+      </div>
+    </form>
+  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
@@ -364,33 +388,42 @@ document.addEventListener('DOMContentLoaded', () => {
   const assignModalEl = document.getElementById('assignModal');
   const assignModal = new bootstrap.Modal(assignModalEl);
   const assignForm = document.getElementById('assignForm');
+  const scrapModalEl = document.getElementById('scrapModal');
+  const scrapModal = new bootstrap.Modal(scrapModalEl);
+  const scrapForm = document.getElementById('scrapForm');
 
   document.querySelectorAll('.action-select').forEach(sel => {
     sel.addEventListener('change', (e) => {
+      e.stopImmediatePropagation();
       const tr = e.target.closest('tr');
       const printerId = tr.dataset.id;
       const val = e.target.value;
       if(!val) return;
 
       if(val === 'edit'){
-        if(window.openModal){ openModal(`/printers/edit/${printerId}?modal=1`); }
+        if(window.openModal){ openModal(`/printers/${printerId}/edit?modal=1`); }
       } else if(val === 'assign'){
         document.getElementById('assignPrinterId').value = printerId;
         document.getElementById('assignPrinterLabel').innerText = `#${printerId}`;
         assignModal.show();
       } else if(val === 'scrap'){
-        if(!confirm('Bu yazıcıyı hurdaya ayırmak istiyor musunuz?')) { e.target.value=''; return; }
-        const reason = prompt('Hurda sebebi / not (opsiyonel):','');
-        if(reason === null){ e.target.value=''; return; }
-        const formData = new FormData();
-        if(reason) formData.append('reason', reason);
-        fetch(`/printers/scrap/${printerId}`, { method: 'POST', body: formData })
-          .then(r => r.json()).then(j => { if(j.ok){ location.reload(); } else { alert('İşlem başarısız'); } })
-          .catch(() => alert('Sunucu hatası'));
+        document.getElementById('scrapPrinterId').value = printerId;
+        scrapModal.show();
       }
 
       e.target.value = '';
     });
+  });
+
+  scrapForm.addEventListener('submit', function(e){
+    e.preventDefault();
+    const pid = document.getElementById('scrapPrinterId').value;
+    const formData = new FormData(scrapForm);
+    fetch(`/printers/${pid}/scrap`, { method: 'POST', body: formData })
+      .then(r => r.json()).then(j => {
+        if(j.ok){ scrapModal.hide(); window.location.href = '/printers/scrap'; }
+        else { alert('Hurdaya ayırma başarısız'); }
+      }).catch(()=> alert('Sunucu hatası'));
   });
 
   assignForm.addEventListener('submit', function(e){


### PR DESCRIPTION
## Summary
- correct printer edit and scrap endpoint paths
- add Bootstrap scrap confirmation modals for printer and license lists
- update frontend to trigger new modals and editing routes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b15d8c9260832b947a142c3d32ee85