### PR TITLE
Add Talep request tracking module

### DIFF
--- a/alembic/versions/c8b2f8041a88_add_talepler.py
+++ b/alembic/versions/c8b2f8041a88_add_talepler.py
@@ -1,0 +1,58 @@
+"""add talepler table
+
+Revision ID: c8b2f8041a88
+Revises: 9f3d8fa40c3b
+Create Date: 2024-10-23
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c8b2f8041a88"
+down_revision = "9f3d8fa40c3b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "talepler",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "tur",
+            sa.Enum("envanter", "lisans", "aksesuar", name="talepturu"),
+            nullable=False,
+        ),
+        sa.Column("ifs_no", sa.String(100), nullable=True),
+        sa.Column("miktar", sa.Integer(), nullable=True),
+        sa.Column("marka", sa.String(150), nullable=True),
+        sa.Column("model", sa.String(150), nullable=True),
+        sa.Column("envanter_no", sa.String(100), nullable=True),
+        sa.Column("sorumlu_personel", sa.String(150), nullable=True),
+        sa.Column("bagli_envanter_no", sa.String(100), nullable=True),
+        sa.Column("lisans_adi", sa.String(200), nullable=True),
+        sa.Column("aciklama", sa.Text(), nullable=True),
+        sa.Column(
+            "durum",
+            sa.Enum("aktif", "tamamlandi", name="talepdurum"),
+            nullable=False,
+            server_default="aktif",
+        ),
+        sa.Column(
+            "olusturma_tarihi",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_talepler_ifs_no", "talepler", ["ifs_no"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_talepler_ifs_no", table_name="talepler")
+    op.drop_table("talepler")
+    op.execute("DROP TYPE IF EXISTS talepturu")
+    op.execute("DROP TYPE IF EXISTS talepdurum")
+

--- a/models.py
+++ b/models.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 from datetime import datetime, date
 from typing import Optional
+import enum
 from sqlalchemy import (
     create_engine,
     Integer,
@@ -350,6 +351,44 @@ class StockTotal(Base):
     __tablename__ = "stock_totals"
     donanim_tipi = Column(String(150), primary_key=True)
     toplam = Column(Integer, nullable=False, default=0)
+
+
+class TalepDurum(str, enum.Enum):
+    AKTIF = "aktif"
+    TAMAMLANDI = "tamamlandi"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class TalepTuru(str, enum.Enum):
+    ENVANTER = "envanter"
+    LISANS = "lisans"
+    AKSESUAR = "aksesuar"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class Talep(Base):
+    __tablename__ = "talepler"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tur = Column(Enum(TalepTuru), nullable=False)
+
+    ifs_no = Column(String(100), index=True, nullable=True)
+    miktar = Column(Integer, nullable=True)
+    marka = Column(String(150), nullable=True)
+    model = Column(String(150), nullable=True)
+
+    envanter_no = Column(String(100), nullable=True)
+    sorumlu_personel = Column(String(150), nullable=True)
+    bagli_envanter_no = Column(String(100), nullable=True)
+    lisans_adi = Column(String(200), nullable=True)
+
+    aciklama = Column(Text, nullable=True)
+    durum = Column(Enum(TalepDurum), default=TalepDurum.AKTIF, nullable=False)
+    olusturma_tarihi = Column(DateTime, default=datetime.utcnow, nullable=False)
 
 
 class Lookup(Base):

--- a/routers/requests.py
+++ b/routers/requests.py
@@ -1,9 +1,16 @@
 # routers/requests.py
-from fastapi import APIRouter, Request, UploadFile, File, Depends
-from fastapi.responses import HTMLResponse, PlainTextResponse, StreamingResponse
+from fastapi import APIRouter, Request, UploadFile, File, Depends, Form
+from fastapi.responses import (
+    HTMLResponse,
+    PlainTextResponse,
+    StreamingResponse,
+    JSONResponse,
+)
 from sqlalchemy.orm import Session
+from typing import Optional
 from database import get_db
 from fastapi.templating import Jinja2Templates
+from models import Talep, TalepTuru, TalepDurum
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
@@ -17,15 +24,48 @@ async def export_requests(db: Session = Depends(get_db)):
 
     wb = Workbook()
     ws = wb.active
-    ws.append(["ID", "Açıklama", "Durum", "Tarih"])
+    ws.append(
+        [
+            "ID",
+            "Tür",
+            "IFS No",
+            "Marka",
+            "Model",
+            "Miktar",
+            "Envanter No",
+            "Bağlı Envanter",
+            "Lisans Adı",
+            "Sorumlu",
+            "Açıklama",
+            "Durum",
+            "Tarih",
+        ]
+    )
 
-    # No Request model is defined yet, so this export will return only headers.
+    for t in db.query(Talep).all():
+        ws.append(
+            [
+                t.id,
+                t.tur.value,
+                t.ifs_no or "",
+                t.marka or "",
+                t.model or "",
+                t.miktar or "",
+                t.envanter_no or "",
+                t.bagli_envanter_no or "",
+                t.lisans_adi or "",
+                t.sorumlu_personel or "",
+                t.aciklama or "",
+                t.durum.value,
+                t.olusturma_tarihi.strftime("%Y-%m-%d %H:%M"),
+            ]
+        )
 
     stream = BytesIO()
     wb.save(stream)
     stream.seek(0)
 
-    headers = {"Content-Disposition": "attachment; filename=requests.xlsx"}
+    headers = {"Content-Disposition": "attachment; filename=talepler.xlsx"}
     return StreamingResponse(
         stream,
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -37,14 +77,58 @@ async def export_requests(db: Session = Depends(get_db)):
 async def import_requests(file: UploadFile = File(...)):
     return f"Received {file.filename}, but import is not implemented."
 
+
 @router.get("/", response_class=HTMLResponse)
-async def list_requests(request: Request):
-    return templates.TemplateResponse("requests/list.html", {"request": request})
+async def list_requests(request: Request, db: Session = Depends(get_db)):
+    aktif = db.query(Talep).filter(Talep.durum == TalepDurum.AKTIF).all()
+    gruplu = {}
+    for t in aktif:
+        key = t.ifs_no or f"NO-IFS-{t.id}"
+        gruplu.setdefault(key, []).append(t)
+    return templates.TemplateResponse(
+        "requests/list.html", {"request": request, "gruplu": gruplu}
+    )
+
+
+@router.post("/", response_class=JSONResponse)
+async def create_request(
+    tur: TalepTuru = Form(...),
+    ifs_no: Optional[str] = Form(None),
+    miktar: Optional[int] = Form(None),
+    marka: Optional[str] = Form(None),
+    model: Optional[str] = Form(None),
+    envanter_no: Optional[str] = Form(None),
+    sorumlu_personel: Optional[str] = Form(None),
+    bagli_envanter_no: Optional[str] = Form(None),
+    lisans_adi: Optional[str] = Form(None),
+    aciklama: Optional[str] = Form(None),
+    db: Session = Depends(get_db),
+):
+    talep = Talep(
+        tur=tur,
+        ifs_no=ifs_no,
+        miktar=miktar,
+        marka=marka,
+        model=model,
+        envanter_no=envanter_no,
+        sorumlu_personel=sorumlu_personel,
+        bagli_envanter_no=bagli_envanter_no,
+        lisans_adi=lisans_adi,
+        aciklama=aciklama,
+    )
+    db.add(talep)
+    db.commit()
+    db.refresh(talep)
+    return {"ok": True, "id": talep.id}
+
 
 @router.get("/create", response_class=HTMLResponse)
-async def create_request(request: Request):
+async def create_request_form(request: Request):
     return templates.TemplateResponse("requests/create.html", {"request": request})
+
 
 @router.get("/convert/{request_id}", response_class=HTMLResponse)
 async def convert_request(request_id: int, request: Request):
-    return templates.TemplateResponse("requests/convert.html", {"request": request, "request_id": request_id})
+    return templates.TemplateResponse(
+        "requests/convert.html", {"request": request, "request_id": request_id}
+    )

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -1,42 +1,165 @@
-{% extends "base.html" %}{% block title %}Talepler – Liste{% endblock %}
+{% extends "base.html" %}
+{% block title %}Talep Takip{% endblock %}
 {% block content %}
-<h2 class="h5 mb-3">Talepler</h2>
-<div class="mb-3">
-  <div class="dropdown d-inline">
-    <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-      Excel
-    </button>
-    <ul class="dropdown-menu">
-      <li><a class="dropdown-item" href="/requests/export">Dışa Aktar</a></li>
-      <li>
-        <form action="/requests/import" method="post" enctype="multipart/form-data">
-          <input type="file" name="file" id="reqExcel" class="d-none" onchange="this.form.submit()">
-          <label for="reqExcel" class="dropdown-item mb-0">İçe Aktar</label>
-        </form>
-      </li>
-    </ul>
+<div class="container-fluid p-3">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h5 class="mb-0">Aktif Talepler</h5>
+    <div class="d-flex gap-2">
+      <a href="/requests/export" class="btn btn-outline-secondary btn-sm">Excel</a>
+      <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#talepModal">Talep Aç</button>
+    </div>
+  </div>
+
+  <div class="accordion" id="accTalep">
+    {% for ifs, talepler in gruplu.items() %}
+      <div class="accordion-item mb-2">
+        <h2 class="accordion-header">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#c{{ loop.index }}">
+            IFS No: {{ 'Yok' if ifs.startswith('NO-IFS') else ifs }} — ({{ talepler|length }} talep)
+          </button>
+        </h2>
+        <div id="c{{ loop.index }}" class="accordion-collapse collapse" data-bs-parent="#accTalep">
+          <div class="accordion-body p-0">
+            <div class="table-responsive">
+              <table class="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th>#</th><th>Tür</th><th>Marka</th><th>Model</th><th>Miktar</th>
+                    <th>Envanter No</th><th>Lisans Adı</th><th>Sorumlu</th><th>Açıklama</th><th>Tarih</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for t in talepler %}
+                  <tr>
+                    <td>{{ t.id }}</td>
+                    <td>{{ t.tur }}</td>
+                    <td>{{ t.marka or '-' }}</td>
+                    <td>{{ t.model or '-' }}</td>
+                    <td>{{ t.miktar or '-' }}</td>
+                    <td>{{ t.envanter_no or t.bagli_envanter_no or '-' }}</td>
+                    <td>{{ t.lisans_adi or '-' }}</td>
+                    <td>{{ t.sorumlu_personel or '-' }}</td>
+                    <td>{{ t.aciklama or '-' }}</td>
+                    <td>{{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% else %}
+      <div class="alert alert-secondary">Aktif talep bulunamadı.</div>
+    {% endfor %}
   </div>
 </div>
-<ul class="nav nav-tabs" id="requestTab" role="tablist">
-  <li class="nav-item" role="presentation">
-    <button class="nav-link active" id="aktif-tab" data-bs-toggle="tab" data-bs-target="#aktif" type="button" role="tab">Aktif Talepler</button>
-  </li>
-  <li class="nav-item" role="presentation">
-    <button class="nav-link" id="kapali-tab" data-bs-toggle="tab" data-bs-target="#kapali" type="button" role="tab">Kapalı Talepler</button>
-  </li>
-  <li class="nav-item" role="presentation">
-    <button class="nav-link" id="iptal-tab" data-bs-toggle="tab" data-bs-target="#iptal" type="button" role="tab">İptal Talepler</button>
-  </li>
-</ul>
-<div class="tab-content pt-3">
-  <div class="tab-pane fade show active" id="aktif" role="tabpanel" aria-labelledby="aktif-tab">
-    <div class="card p-3"><a class="btn btn-primary btn-sm" href="/requests/create">Talep Oluştur</a></div>
-  </div>
-  <div class="tab-pane fade" id="kapali" role="tabpanel" aria-labelledby="kapali-tab">
-    <div class="card p-3">Kapalı talepler listesi...</div>
-  </div>
-  <div class="tab-pane fade" id="iptal" role="tabpanel" aria-labelledby="iptal-tab">
-    <div class="card p-3">İptal talepler listesi...</div>
+
+<!-- Talep Aç Modal -->
+<div class="modal fade" id="talepModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <form id="frmTalep" class="modal-content" onsubmit="return talepGonder(event)">
+      <div class="modal-header">
+        <h5 class="modal-title">Talep Aç</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+
+      <div class="modal-body">
+        <!-- Tür seçimi -->
+        <div class="mb-3">
+          <label class="form-label">Talep Türü</label>
+          <select class="form-select" name="tur" id="tur" required>
+            <option value="envanter">Envanter</option>
+            <option value="lisans">Lisans</option>
+            <option value="aksesuar">Aksesuar</option>
+          </select>
+        </div>
+
+        <!-- Ortak alanlar (Aksesuar isteğiyle uyumlu: Marka/Model/Miktar/IFS) -->
+        <div class="row g-2">
+          <div class="col-6">
+            <label class="form-label">IFS No (opsiyonel)</label>
+            <input name="ifs_no" class="form-control" placeholder="IFS No">
+          </div>
+          <div class="col-6">
+            <label class="form-label">Miktar (opsiyonel)</label>
+            <input name="miktar" type="number" min="1" class="form-control" placeholder="Miktar">
+          </div>
+          <div class="col-6">
+            <label class="form-label">Marka (opsiyonel)</label>
+            <input name="marka" class="form-control" placeholder="Marka">
+          </div>
+          <div class="col-6">
+            <label class="form-label">Model (opsiyonel)</label>
+            <input name="model" class="form-control" placeholder="Model">
+          </div>
+        </div>
+
+        <!-- Envanter alanları (opsiyonel) -->
+        <div id="grpEnvanter" class="mt-3">
+          <div class="row g-2">
+            <div class="col-6">
+              <label class="form-label">Envanter No (opsiyonel)</label>
+              <input name="envanter_no" class="form-control" placeholder="Envanter No">
+            </div>
+            <div class="col-6">
+              <label class="form-label">Sorumlu Personel (opsiyonel)</label>
+              <input name="sorumlu_personel" class="form-control" placeholder="Ad Soyad">
+            </div>
+            <div class="col-12">
+              <label class="form-label">Bağlı Envanter No (opsiyonel)</label>
+              <input name="bagli_envanter_no" class="form-control" placeholder="Bağlı Envanter No">
+            </div>
+          </div>
+        </div>
+
+        <!-- Lisans alanları (opsiyonel) -->
+        <div id="grpLisans" class="mt-3 d-none">
+          <div class="row g-2">
+            <div class="col-12">
+              <label class="form-label">Lisans Adı (opsiyonel)</label>
+              <input name="lisans_adi" class="form-control" placeholder="Lisans Adı">
+            </div>
+          </div>
+        </div>
+
+        <!-- İsteğe bağlı açıklama -->
+        <div class="mt-3">
+          <label class="form-label">Açıklama (opsiyonel)</label>
+          <textarea name="aciklama" class="form-control" rows="2" placeholder="Not"></textarea>
+        </div>
+      </div>
+
+      <div class="modal-footer">
+        <button class="btn btn-secondary" type="button" data-bs-dismiss="modal">Kapat</button>
+        <button class="btn btn-primary" type="submit">Kaydet</button>
+      </div>
+    </form>
   </div>
 </div>
+
+<script>
+  const turSel = document.getElementById('tur');
+  const grpEnvanter = document.getElementById('grpEnvanter');
+  const grpLisans = document.getElementById('grpLisans');
+
+  function toggleGroups() {
+    const val = turSel.value;
+    grpEnvanter.classList.toggle('d-none', val !== 'envanter');
+    grpLisans.classList.toggle('d-none', val !== 'lisans');
+  }
+  turSel.addEventListener('change', toggleGroups);
+  toggleGroups();
+
+  async function talepGonder(e) {
+    e.preventDefault();
+    const form = document.getElementById('frmTalep');
+    const fd = new FormData(form);
+    const res = await fetch('/requests', { method: 'POST', body: fd });
+    const data = await res.json();
+    if (data.ok) location.reload();
+    else alert('Kayıt hatası');
+    return false;
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- integrate Talep listing and creation into existing `/requests` router
- replace requests list page with grouped IFS view and modal form
- drop redundant `talepler` router and update navigation link

## Testing
- `python -m py_compile models.py routers/requests.py app.py && echo PYCOMPILE_OK`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b167b65a10832b80b91d6c787ac5ca