### PR TITLE
Show tables for all request statuses

### DIFF
--- a/models.py
+++ b/models.py
@@ -383,6 +383,7 @@ class StockTotal(Base):
 class TalepDurum(str, enum.Enum):
     AKTIF = "aktif"
     TAMAMLANDI = "tamamlandi"
+    IPTAL = "iptal"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/routers/requests.py
+++ b/routers/requests.py
@@ -82,13 +82,31 @@ async def import_requests(file: UploadFile = File(...)):
 
 @router.get("/", response_class=HTMLResponse)
 async def list_requests(request: Request, db: Session = Depends(get_db)):
-    aktif = db.query(Talep).filter(Talep.durum == TalepDurum.AKTIF).all()
-    gruplu = {}
-    for t in aktif:
-        key = t.ifs_no or f"NO-IFS-{t.id}"
-        gruplu.setdefault(key, []).append(t)
+    def group(rows: list[Talep]) -> dict[str, list[Talep]]:
+        gruplu: dict[str, list[Talep]] = {}
+        for t in rows:
+            key = t.ifs_no or f"NO-IFS-{t.id}"
+            gruplu.setdefault(key, []).append(t)
+        return gruplu
+
+    aktif = group(
+        db.query(Talep).filter(Talep.durum == TalepDurum.AKTIF).all()
+    )
+    kapali = group(
+        db.query(Talep).filter(Talep.durum == TalepDurum.TAMAMLANDI).all()
+    )
+    iptal = group(
+        db.query(Talep).filter(Talep.durum == TalepDurum.IPTAL).all()
+    )
+
     return templates.TemplateResponse(
-        "requests/list.html", {"request": request, "gruplu": gruplu}
+        "requests/list.html",
+        {
+            "request": request,
+            "gruplu_aktif": aktif,
+            "gruplu_kapali": kapali,
+            "gruplu_iptal": iptal,
+        },
     )
 
 

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -3,22 +3,23 @@
 {% block content %}
 <div class="container-fluid p-3">
   <div class="d-flex justify-content-between align-items-center mb-3">
-    <h5 class="mb-0">Aktif Talepler</h5>
+    <h5 class="mb-0">Talepler</h5>
     <div class="d-flex gap-2">
       <a href="/requests/export" class="btn btn-outline-secondary btn-sm">Excel</a>
       <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#talepModal">Talep Aç</button>
     </div>
   </div>
 
-  <div class="accordion" id="accTalep">
+  {% macro render_section(gruplu, empty_msg, acc_id) %}
+  <div class="accordion" id="{{ acc_id }}">
     {% for ifs, talepler in gruplu.items() %}
       <div class="accordion-item mb-2">
         <h2 class="accordion-header">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#c{{ loop.index }}">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{ acc_id }}{{ loop.index }}">
             IFS No: {{ 'Yok' if ifs.startswith('NO-IFS') else ifs }} — ({{ talepler|length }} talep)
           </button>
         </h2>
-        <div id="c{{ loop.index }}" class="accordion-collapse collapse" data-bs-parent="#accTalep">
+        <div id="{{ acc_id }}{{ loop.index }}" class="accordion-collapse collapse" data-bs-parent="#{{ acc_id }}">
           <div class="accordion-body p-0">
             <div class="table-responsive">
               <table class="table table-sm align-middle mb-0">
@@ -51,9 +52,19 @@
         </div>
       </div>
     {% else %}
-      <div class="alert alert-secondary">Aktif talep bulunamadı.</div>
+      <div class="alert alert-secondary">{{ empty_msg }}</div>
     {% endfor %}
   </div>
+  {% endmacro %}
+
+  <h6>Aktif Talepler</h6>
+  {{ render_section(gruplu_aktif, "Aktif talep bulunamadı.", "accAktif") }}
+
+  <h6 class="mt-4">Kapalı Talepler</h6>
+  {{ render_section(gruplu_kapali, "Kapalı talep bulunamadı.", "accKapali") }}
+
+  <h6 class="mt-4">İptal Talepler</h6>
+  {{ render_section(gruplu_iptal, "İptal talep bulunamadı.", "accIptal") }}
 </div>
 
 <!-- Talep Aç Modal -->

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -3,22 +3,23 @@
 {% block content %}
 <div class="container-fluid p-3">
   <div class="d-flex justify-content-between align-items-center mb-3">
-    <h5 class="mb-0">Aktif Talepler</h5>
+    <h5 class="mb-0">Talepler</h5>
     <div class="d-flex gap-2">
       <a href="/talepler/export.xlsx" class="btn btn-outline-secondary btn-sm">Excel</a>
       <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#talepModal">Talep Aç</button>
     </div>
   </div>
 
-  <div class="accordion" id="accTalep">
+  {% macro render_section(gruplu, empty_msg, acc_id) %}
+  <div class="accordion" id="{{ acc_id }}">
     {% for ifs, talepler in gruplu.items() %}
       <div class="accordion-item mb-2">
         <h2 class="accordion-header">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#c{{ loop.index }}">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{ acc_id }}{{ loop.index }}">
             IFS No: {{ 'Yok' if ifs.startswith('NO-IFS') else ifs }} — ({{ talepler|length }} talep)
           </button>
         </h2>
-        <div id="c{{ loop.index }}" class="accordion-collapse collapse" data-bs-parent="#accTalep">
+        <div id="{{ acc_id }}{{ loop.index }}" class="accordion-collapse collapse" data-bs-parent="#{{ acc_id }}">
           <div class="accordion-body p-0">
             <div class="table-responsive">
               <table class="table table-sm align-middle mb-0">
@@ -51,9 +52,19 @@
         </div>
       </div>
     {% else %}
-      <div class="alert alert-secondary">Aktif talep bulunamadı.</div>
+      <div class="alert alert-secondary">{{ empty_msg }}</div>
     {% endfor %}
   </div>
+  {% endmacro %}
+
+  <h6>Aktif Talepler</h6>
+  {{ render_section(gruplu_aktif, "Aktif talep bulunamadı.", "accAktif") }}
+
+  <h6 class="mt-4">Kapalı Talepler</h6>
+  {{ render_section(gruplu_kapali, "Kapalı talep bulunamadı.", "accKapali") }}
+
+  <h6 class="mt-4">İptal Talepler</h6>
+  {{ render_section(gruplu_iptal, "İptal talep bulunamadı.", "accIptal") }}
 </div>
 
 <!-- Talep Aç Modal -->


### PR DESCRIPTION
## Summary
- display active, closed, and cancelled requests in separate tables
- track cancelled requests with a new status value

## Testing
- `python -m py_compile models.py routes/talepler.py routers/requests.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b18d5e58a4832b8fdb1d5d042dde9a