### PR TITLE
Show request tables by status

### DIFF
--- a/routers/requests.py
+++ b/routers/requests.py
@@ -82,30 +82,19 @@ async def import_requests(file: UploadFile = File(...)):
 
 @router.get("/", response_class=HTMLResponse)
 async def list_requests(request: Request, db: Session = Depends(get_db)):
-    def group(rows: list[Talep]) -> dict[str, list[Talep]]:
-        gruplu: dict[str, list[Talep]] = {}
-        for t in rows:
-            key = t.ifs_no or f"NO-IFS-{t.id}"
-            gruplu.setdefault(key, []).append(t)
-        return gruplu
+    """Display requests grouped by status."""
 
-    aktif = group(
-        db.query(Talep).filter(Talep.durum == TalepDurum.AKTIF).all()
-    )
-    kapali = group(
-        db.query(Talep).filter(Talep.durum == TalepDurum.TAMAMLANDI).all()
-    )
-    iptal = group(
-        db.query(Talep).filter(Talep.durum == TalepDurum.IPTAL).all()
-    )
+    aktif = db.query(Talep).filter(Talep.durum == TalepDurum.AKTIF).all()
+    kapali = db.query(Talep).filter(Talep.durum == TalepDurum.TAMAMLANDI).all()
+    iptal = db.query(Talep).filter(Talep.durum == TalepDurum.IPTAL).all()
 
     return templates.TemplateResponse(
         "requests/list.html",
         {
             "request": request,
-            "gruplu_aktif": aktif,
-            "gruplu_kapali": kapali,
-            "gruplu_iptal": iptal,
+            "aktif": aktif,
+            "kapali": kapali,
+            "iptal": iptal,
         },
     )
 

--- a/routes/talepler.py
+++ b/routes/talepler.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Form
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from sqlalchemy.orm import Session
-from typing import Optional, Dict, List
+from typing import Optional
 from io import BytesIO
 from openpyxl import Workbook
 
@@ -15,29 +15,19 @@ router = APIRouter(prefix="/talepler", tags=["Talepler"])
 
 @router.get("", response_class=HTMLResponse)
 def liste(request: Request, db: Session = Depends(get_db)):
-    def gruplandir(rows: List[Talep]) -> Dict[str, List[Talep]]:
-        gruplu: Dict[str, List[Talep]] = {}
-        for t in rows:
-            key = t.ifs_no or f"NO-IFS-{t.id}"
-            gruplu.setdefault(key, []).append(t)
-        return gruplu
+    """Talep kayıtlarını duruma göre tablo halinde göster."""
 
-    aktif = gruplandir(
-        db.query(Talep).filter(Talep.durum == TalepDurum.AKTIF).all()
-    )
-    kapali = gruplandir(
-        db.query(Talep).filter(Talep.durum == TalepDurum.TAMAMLANDI).all()
-    )
-    iptal = gruplandir(
-        db.query(Talep).filter(Talep.durum == TalepDurum.IPTAL).all()
-    )
+    aktif = db.query(Talep).filter(Talep.durum == TalepDurum.AKTIF).all()
+    kapali = db.query(Talep).filter(Talep.durum == TalepDurum.TAMAMLANDI).all()
+    iptal = db.query(Talep).filter(Talep.durum == TalepDurum.IPTAL).all()
+
     return templates.TemplateResponse(
         "talepler.html",
         {
             "request": request,
-            "gruplu_aktif": aktif,
-            "gruplu_kapali": kapali,
-            "gruplu_iptal": iptal,
+            "aktif": aktif,
+            "kapali": kapali,
+            "iptal": iptal,
         },
     )
 

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -10,61 +10,49 @@
     </div>
   </div>
 
-  {% macro render_section(gruplu, empty_msg, acc_id) %}
-  <div class="accordion" id="{{ acc_id }}">
-    {% for ifs, talepler in gruplu.items() %}
-      <div class="accordion-item mb-2">
-        <h2 class="accordion-header">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{ acc_id }}{{ loop.index }}">
-            IFS No: {{ 'Yok' if ifs.startswith('NO-IFS') else ifs }} — ({{ talepler|length }} talep)
-          </button>
-        </h2>
-        <div id="{{ acc_id }}{{ loop.index }}" class="accordion-collapse collapse" data-bs-parent="#{{ acc_id }}">
-          <div class="accordion-body p-0">
-            <div class="table-responsive">
-              <table class="table table-sm align-middle mb-0">
-                <thead>
-                  <tr>
-                    <th>#</th><th>Tür</th><th>Donanım Tipi</th><th>Marka</th><th>Model</th><th>Miktar</th>
-                    <th>Envanter No</th><th>Lisans Adı</th><th>Sorumlu</th><th>Açıklama</th><th>Tarih</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for t in talepler %}
-                  <tr>
-                    <td>{{ t.id }}</td>
-                    <td>{{ t.tur }}</td>
-                    <td>{{ t.donanim_tipi or '-' }}</td>
-                    <td>{{ t.marka or '-' }}</td>
-                    <td>{{ t.model or '-' }}</td>
-                    <td>{{ t.miktar or '-' }}</td>
-                    <td>{{ t.envanter_no or t.bagli_envanter_no or '-' }}</td>
-                    <td>{{ t.lisans_adi or '-' }}</td>
-                    <td>{{ t.sorumlu_personel or '-' }}</td>
-                    <td>{{ t.aciklama or '-' }}</td>
-                    <td>{{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}</td>
-                  </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    {% else %}
-      <div class="alert alert-secondary">{{ empty_msg }}</div>
-    {% endfor %}
+  {% macro render_table(rows, empty_msg) %}
+  <div class="table-responsive">
+    <table class="table table-striped table-sm align-middle">
+      <thead>
+        <tr>
+          <th>#</th><th>Tür</th><th>Donanım Tipi</th><th>Marka</th><th>Model</th><th>Miktar</th>
+          <th>IFS No</th><th>Envanter No</th><th>Lisans Adı</th><th>Sorumlu</th><th>Açıklama</th><th>Tarih</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for t in rows %}
+        <tr>
+          <td>{{ t.id }}</td>
+          <td>{{ t.tur }}</td>
+          <td>{{ t.donanim_tipi or '-' }}</td>
+          <td>{{ t.marka or '-' }}</td>
+          <td>{{ t.model or '-' }}</td>
+          <td>{{ t.miktar or '-' }}</td>
+          <td>{{ t.ifs_no or '-' }}</td>
+          <td>{{ t.envanter_no or t.bagli_envanter_no or '-' }}</td>
+          <td>{{ t.lisans_adi or '-' }}</td>
+          <td>{{ t.sorumlu_personel or '-' }}</td>
+          <td>{{ t.aciklama or '-' }}</td>
+          <td>{{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}</td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="12" class="text-center text-muted">{{ empty_msg }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
   {% endmacro %}
 
   <h6>Aktif Talepler</h6>
-  {{ render_section(gruplu_aktif, "Aktif talep bulunamadı.", "accAktif") }}
+  {{ render_table(aktif, "Aktif talep bulunamadı.") }}
 
   <h6 class="mt-4">Kapalı Talepler</h6>
-  {{ render_section(gruplu_kapali, "Kapalı talep bulunamadı.", "accKapali") }}
+  {{ render_table(kapali, "Kapalı talep bulunamadı.") }}
 
   <h6 class="mt-4">İptal Talepler</h6>
-  {{ render_section(gruplu_iptal, "İptal talep bulunamadı.", "accIptal") }}
+  {{ render_table(iptal, "İptal talep bulunamadı.") }}
 </div>
 
 <!-- Talep Aç Modal -->

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -10,61 +10,49 @@
     </div>
   </div>
 
-  {% macro render_section(gruplu, empty_msg, acc_id) %}
-  <div class="accordion" id="{{ acc_id }}">
-    {% for ifs, talepler in gruplu.items() %}
-      <div class="accordion-item mb-2">
-        <h2 class="accordion-header">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{ acc_id }}{{ loop.index }}">
-            IFS No: {{ 'Yok' if ifs.startswith('NO-IFS') else ifs }} — ({{ talepler|length }} talep)
-          </button>
-        </h2>
-        <div id="{{ acc_id }}{{ loop.index }}" class="accordion-collapse collapse" data-bs-parent="#{{ acc_id }}">
-          <div class="accordion-body p-0">
-            <div class="table-responsive">
-              <table class="table table-sm align-middle mb-0">
-                <thead>
-                  <tr>
-                    <th>#</th><th>Tür</th><th>Donanım Tipi</th><th>Marka</th><th>Model</th><th>Miktar</th>
-                    <th>Envanter No</th><th>Lisans Adı</th><th>Sorumlu</th><th>Açıklama</th><th>Tarih</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for t in talepler %}
-                  <tr>
-                    <td>{{ t.id }}</td>
-                    <td>{{ t.tur }}</td>
-                    <td>{{ t.donanim_tipi or '-' }}</td>
-                    <td>{{ t.marka or '-' }}</td>
-                    <td>{{ t.model or '-' }}</td>
-                    <td>{{ t.miktar or '-' }}</td>
-                    <td>{{ t.envanter_no or t.bagli_envanter_no or '-' }}</td>
-                    <td>{{ t.lisans_adi or '-' }}</td>
-                    <td>{{ t.sorumlu_personel or '-' }}</td>
-                    <td>{{ t.aciklama or '-' }}</td>
-                    <td>{{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}</td>
-                  </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    {% else %}
-      <div class="alert alert-secondary">{{ empty_msg }}</div>
-    {% endfor %}
+  {% macro render_table(rows, empty_msg) %}
+  <div class="table-responsive">
+    <table class="table table-striped table-sm align-middle">
+      <thead>
+        <tr>
+          <th>#</th><th>Tür</th><th>Donanım Tipi</th><th>Marka</th><th>Model</th><th>Miktar</th>
+          <th>IFS No</th><th>Envanter No</th><th>Lisans Adı</th><th>Sorumlu</th><th>Açıklama</th><th>Tarih</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for t in rows %}
+        <tr>
+          <td>{{ t.id }}</td>
+          <td>{{ t.tur }}</td>
+          <td>{{ t.donanim_tipi or '-' }}</td>
+          <td>{{ t.marka or '-' }}</td>
+          <td>{{ t.model or '-' }}</td>
+          <td>{{ t.miktar or '-' }}</td>
+          <td>{{ t.ifs_no or '-' }}</td>
+          <td>{{ t.envanter_no or t.bagli_envanter_no or '-' }}</td>
+          <td>{{ t.lisans_adi or '-' }}</td>
+          <td>{{ t.sorumlu_personel or '-' }}</td>
+          <td>{{ t.aciklama or '-' }}</td>
+          <td>{{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}</td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="12" class="text-center text-muted">{{ empty_msg }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
   {% endmacro %}
 
   <h6>Aktif Talepler</h6>
-  {{ render_section(gruplu_aktif, "Aktif talep bulunamadı.", "accAktif") }}
+  {{ render_table(aktif, "Aktif talep bulunamadı.") }}
 
   <h6 class="mt-4">Kapalı Talepler</h6>
-  {{ render_section(gruplu_kapali, "Kapalı talep bulunamadı.", "accKapali") }}
+  {{ render_table(kapali, "Kapalı talep bulunamadı.") }}
 
   <h6 class="mt-4">İptal Talepler</h6>
-  {{ render_section(gruplu_iptal, "İptal talep bulunamadı.", "accIptal") }}
+  {{ render_table(iptal, "İptal talep bulunamadı.") }}
 </div>
 
 <!-- Talep Aç Modal -->


### PR DESCRIPTION
## Summary
- Replace accordion request display with Bootstrap tables grouped by status
- Query active, closed, and cancelled requests separately for templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b18f97fbac832b8476277c4c366b76