### PR TITLE
Use tabs for request status tables

### DIFF
--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -45,14 +45,29 @@
   </div>
   {% endmacro %}
 
-  <h6>Aktif Talepler</h6>
-  {{ render_table(aktif, "Aktif talep bulunamadı.") }}
+  <ul class="nav nav-tabs" id="talepTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="aktif-tab" data-bs-toggle="tab" data-bs-target="#aktif" type="button" role="tab">Aktif</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="kapali-tab" data-bs-toggle="tab" data-bs-target="#kapali" type="button" role="tab">Kapalı</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="iptal-tab" data-bs-toggle="tab" data-bs-target="#iptal" type="button" role="tab">İptal</button>
+    </li>
+  </ul>
 
-  <h6 class="mt-4">Kapalı Talepler</h6>
-  {{ render_table(kapali, "Kapalı talep bulunamadı.") }}
-
-  <h6 class="mt-4">İptal Talepler</h6>
-  {{ render_table(iptal, "İptal talep bulunamadı.") }}
+  <div class="tab-content mt-3" id="talepTabsContent">
+    <div class="tab-pane fade show active" id="aktif" role="tabpanel" aria-labelledby="aktif-tab">
+      {{ render_table(aktif, "Aktif talep bulunamadı.") }}
+    </div>
+    <div class="tab-pane fade" id="kapali" role="tabpanel" aria-labelledby="kapali-tab">
+      {{ render_table(kapali, "Kapalı talep bulunamadı.") }}
+    </div>
+    <div class="tab-pane fade" id="iptal" role="tabpanel" aria-labelledby="iptal-tab">
+      {{ render_table(iptal, "İptal talep bulunamadı.") }}
+    </div>
+  </div>
 </div>
 
 <!-- Talep Aç Modal -->

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -45,14 +45,29 @@
   </div>
   {% endmacro %}
 
-  <h6>Aktif Talepler</h6>
-  {{ render_table(aktif, "Aktif talep bulunamadı.") }}
+  <ul class="nav nav-tabs" id="talepTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="aktif-tab" data-bs-toggle="tab" data-bs-target="#aktif" type="button" role="tab">Aktif</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="kapali-tab" data-bs-toggle="tab" data-bs-target="#kapali" type="button" role="tab">Kapalı</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="iptal-tab" data-bs-toggle="tab" data-bs-target="#iptal" type="button" role="tab">İptal</button>
+    </li>
+  </ul>
 
-  <h6 class="mt-4">Kapalı Talepler</h6>
-  {{ render_table(kapali, "Kapalı talep bulunamadı.") }}
-
-  <h6 class="mt-4">İptal Talepler</h6>
-  {{ render_table(iptal, "İptal talep bulunamadı.") }}
+  <div class="tab-content mt-3" id="talepTabsContent">
+    <div class="tab-pane fade show active" id="aktif" role="tabpanel" aria-labelledby="aktif-tab">
+      {{ render_table(aktif, "Aktif talep bulunamadı.") }}
+    </div>
+    <div class="tab-pane fade" id="kapali" role="tabpanel" aria-labelledby="kapali-tab">
+      {{ render_table(kapali, "Kapalı talep bulunamadı.") }}
+    </div>
+    <div class="tab-pane fade" id="iptal" role="tabpanel" aria-labelledby="iptal-tab">
+      {{ render_table(iptal, "İptal talep bulunamadı.") }}
+    </div>
+  </div>
 </div>
 
 <!-- Talep Aç Modal -->


### PR DESCRIPTION
## Summary
- Present request lists in tabbed interface for Aktif, Kapalı and İptal states
- Apply tabbed layout to both `/requests` and legacy `/talepler` templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b190b7a6fc832bafdeaf805b9cdf8b