### PR TITLE
Add dynamic row-based request creation

### DIFF
--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -72,7 +72,7 @@
 
 <!-- Talep Aç Modal -->
 <div class="modal fade" id="talepModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <form id="frmTalep" class="modal-content" onsubmit="return talepGonder(event)">
       <div class="modal-header">
         <h5 class="modal-title">Talep Aç</h5>
@@ -80,74 +80,63 @@
       </div>
 
       <div class="modal-body">
-        <!-- Tür seçimi -->
-        <div class="mb-3">
-          <label class="form-label">Talep Türü</label>
-          <select class="form-select" name="tur" id="tur" required>
-            <option value="envanter">Envanter</option>
-            <option value="lisans">Lisans</option>
-            <option value="aksesuar">Aksesuar</option>
-          </select>
-        </div>
-
-        <!-- Aksesuar alanları (opsiyonel) -->
-        <div id="grpAksesuar" class="row g-2 d-none">
-          <div class="col-12">
-            <label class="form-label">Donanım Tipi (opsiyonel)</label>
-            <select id="donanim_tipi" name="donanim_tipi" class="form-select">
-              <option value="">Seçiniz...</option>
-            </select>
-          </div>
-          <div class="col-6">
-            <label class="form-label">IFS No (opsiyonel)</label>
-            <input name="ifs_no" class="form-control" placeholder="IFS No">
-          </div>
-          <div class="col-6">
-            <label class="form-label">Miktar (opsiyonel)</label>
-            <input name="miktar" type="number" min="1" class="form-control" placeholder="Miktar">
-          </div>
-          <div class="col-6">
-            <label class="form-label">Marka (opsiyonel)</label>
-            <input name="marka" class="form-control" placeholder="Marka">
-          </div>
-          <div class="col-6">
-            <label class="form-label">Model (opsiyonel)</label>
-            <input name="model" class="form-control" placeholder="Model">
-          </div>
-        </div>
-
-        <!-- Envanter alanları (opsiyonel) -->
-        <div id="grpEnvanter" class="mt-3">
-          <div class="row g-2">
-            <div class="col-6">
-              <label class="form-label">Envanter No (opsiyonel)</label>
+        <div id="talepRows">
+          <div class="talep-row row g-2 align-items-end mb-2">
+            <div class="col-md-2">
+              <label class="form-label">Talep Türü</label>
+              <select class="form-select tur" name="tur">
+                <option value="envanter">Envanter</option>
+                <option value="lisans">Lisans</option>
+                <option value="aksesuar">Aksesuar</option>
+              </select>
+            </div>
+            <div class="col-md-2 envanter-field">
+              <label class="form-label">Envanter No</label>
               <input name="envanter_no" class="form-control" placeholder="Envanter No">
             </div>
-            <div class="col-6">
-              <label class="form-label">Sorumlu Personel (opsiyonel)</label>
+            <div class="col-md-2 envanter-field">
+              <label class="form-label">Sorumlu</label>
               <input name="sorumlu_personel" class="form-control" placeholder="Ad Soyad">
             </div>
-            <div class="col-12">
-              <label class="form-label">Bağlı Envanter No (opsiyonel)</label>
+            <div class="col-md-2 envanter-field">
+              <label class="form-label">Bağlı Envanter</label>
               <input name="bagli_envanter_no" class="form-control" placeholder="Bağlı Envanter No">
             </div>
-          </div>
-        </div>
-
-        <!-- Lisans alanları (opsiyonel) -->
-        <div id="grpLisans" class="mt-3 d-none">
-          <div class="row g-2">
-            <div class="col-12">
-              <label class="form-label">Lisans Adı (opsiyonel)</label>
+            <div class="col-md-2 lisans-field d-none">
+              <label class="form-label">Lisans Adı</label>
               <input name="lisans_adi" class="form-control" placeholder="Lisans Adı">
             </div>
+            <div class="col-md-2 aksesuar-field d-none">
+              <label class="form-label">Donanım Tipi</label>
+              <select name="donanim_tipi" class="form-select">
+                <option value="">Seçiniz...</option>
+              </select>
+            </div>
+            <div class="col-md-2 aksesuar-field d-none">
+              <label class="form-label">IFS No</label>
+              <input name="ifs_no" class="form-control" placeholder="IFS No">
+            </div>
+            <div class="col-md-1 aksesuar-field d-none">
+              <label class="form-label">Miktar</label>
+              <input name="miktar" type="number" min="1" class="form-control" placeholder="Miktar">
+            </div>
+            <div class="col-md-2 aksesuar-field d-none">
+              <label class="form-label">Marka</label>
+              <input name="marka" class="form-control" placeholder="Marka">
+            </div>
+            <div class="col-md-2 aksesuar-field d-none">
+              <label class="form-label">Model</label>
+              <input name="model" class="form-control" placeholder="Model">
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Açıklama</label>
+              <input name="aciklama" class="form-control" placeholder="Açıklama">
+            </div>
+            <div class="col-auto">
+              <button type="button" class="btn btn-success btn-sm add-row">+</button>
+              <button type="button" class="btn btn-danger btn-sm remove-row">-</button>
+            </div>
           </div>
-        </div>
-
-        <!-- İsteğe bağlı açıklama -->
-        <div class="mt-3">
-          <label class="form-label">Açıklama (opsiyonel)</label>
-          <textarea name="aciklama" class="form-control" rows="2" placeholder="Not"></textarea>
         </div>
       </div>
 
@@ -160,34 +149,53 @@
 </div>
 
 <script>
-  const turSel = document.getElementById('tur');
-  const grpEnvanter = document.getElementById('grpEnvanter');
-  const grpLisans = document.getElementById('grpLisans');
-  const grpAksesuar = document.getElementById('grpAksesuar');
+  const rowContainer = document.getElementById('talepRows');
 
-  function toggleGroups() {
-    const val = turSel.value;
-    grpEnvanter.classList.toggle('d-none', val !== 'envanter');
-    grpLisans.classList.toggle('d-none', val !== 'lisans');
-    grpAksesuar.classList.toggle('d-none', val !== 'aksesuar');
+  function bindRow(row) {
+    const tur = row.querySelector('.tur');
+    function toggle() {
+      const val = tur.value;
+      row.querySelectorAll('.envanter-field').forEach(e => e.classList.toggle('d-none', val !== 'envanter'));
+      row.querySelectorAll('.lisans-field').forEach(e => e.classList.toggle('d-none', val !== 'lisans'));
+      row.querySelectorAll('.aksesuar-field').forEach(e => e.classList.toggle('d-none', val !== 'aksesuar'));
+    }
+    tur.addEventListener('change', toggle);
+    toggle();
+
+    row.querySelector('.add-row').addEventListener('click', () => {
+      const clone = row.cloneNode(true);
+      clone.querySelectorAll('input').forEach(i => i.value = '');
+      clone.querySelectorAll('select').forEach(s => { if(!s.classList.contains('tur')) s.selectedIndex = 0; });
+      rowContainer.appendChild(clone);
+      bindRow(clone);
+    });
+
+    row.querySelector('.remove-row').addEventListener('click', () => {
+      if (rowContainer.children.length > 1) row.remove();
+    });
   }
-  turSel.addEventListener('change', toggleGroups);
-  toggleGroups();
+
+  bindRow(rowContainer.firstElementChild);
 
   // donanım tipleri
   fetch('/api/lookup/donanim_tipi').then(r=>r.json()).then(list=>{
-    const sel=document.getElementById('donanim_tipi');
-    list.forEach(n=>{ const o=document.createElement('option'); o.value=o.textContent=n; sel.appendChild(o); });
+    const opts = list.map(n=>`<option value="${n}">${n}</option>`).join('');
+    document.querySelectorAll('select[name="donanim_tipi"]').forEach(sel=>sel.insertAdjacentHTML('beforeend', opts));
   });
 
   async function talepGonder(e) {
     e.preventDefault();
-    const form = document.getElementById('frmTalep');
-    const fd = new FormData(form);
-    const res = await fetch('/requests', { method: 'POST', body: fd });
-    const data = await res.json();
-    if (data.ok) location.reload();
-    else alert('Kayıt hatası');
+    const rows = rowContainer.querySelectorAll('.talep-row');
+    for (const row of rows) {
+      const fd = new FormData();
+      row.querySelectorAll('input, select').forEach(el => {
+        if (el.name && el.value) fd.append(el.name, el.value);
+      });
+      const res = await fetch('/requests', { method: 'POST', body: fd });
+      const data = await res.json();
+      if (!data.ok) { alert('Kayıt hatası'); return false; }
+    }
+    location.reload();
     return false;
   }
 </script>


### PR DESCRIPTION
## Summary
- Rework "Talep Aç" modal to support multiple request rows with type first and in-row fields
- Introduce green add and red remove buttons for dynamically adding/removing request lines
- Submit each row individually and load hardware type options dynamically

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b191e01450832baf0a4d6b04a2b54d