### PR TITLE
feat: enhance request handling with actions and grouping

### DIFF
--- a/routes/talepler.py
+++ b/routes/talepler.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Form
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from sqlalchemy.orm import Session
-from typing import Optional
+from typing import Optional, List
 from io import BytesIO
 from openpyxl import Workbook
 
@@ -36,10 +36,10 @@ def liste(request: Request, db: Session = Depends(get_db)):
 def olustur(
     tur: TalepTuru = Form(...),
     donanim_tipi: Optional[str] = Form(None),
-    ifs_no: Optional[str] = Form(None),
-    miktar: Optional[int] = Form(None),
-    marka: Optional[str] = Form(None),
-    model: Optional[str] = Form(None),
+    ifs_no: List[str] = Form([]),
+    miktar: List[int] = Form([]),
+    marka: List[str] = Form([]),
+    model: List[str] = Form([]),
     envanter_no: Optional[str] = Form(None),
     sorumlu_personel: Optional[str] = Form(None),
     bagli_envanter_no: Optional[str] = Form(None),
@@ -47,23 +47,61 @@ def olustur(
     aciklama: Optional[str] = Form(None),
     db: Session = Depends(get_db),
 ):
-    talep = Talep(
-        tur=tur,
-        donanim_tipi=donanim_tipi,
-        ifs_no=ifs_no,
-        miktar=miktar,
-        marka=marka,
-        model=model,
-        envanter_no=envanter_no,
-        sorumlu_personel=sorumlu_personel,
-        bagli_envanter_no=bagli_envanter_no,
-        lisans_adi=lisans_adi,
-        aciklama=aciklama,
-    )
-    db.add(talep)
+    created_ids: List[int] = []
+    if tur == TalepTuru.AKSESUAR and ifs_no:
+        for idx, no in enumerate(ifs_no):
+            talep = Talep(
+                tur=tur,
+                donanim_tipi=donanim_tipi,
+                ifs_no=no or None,
+                miktar=miktar[idx] if idx < len(miktar) else None,
+                marka=marka[idx] if idx < len(marka) else None,
+                model=model[idx] if idx < len(model) else None,
+                aciklama=aciklama,
+            )
+            db.add(talep)
+            db.flush()
+            created_ids.append(talep.id)
+    else:
+        talep = Talep(
+            tur=tur,
+            donanim_tipi=donanim_tipi,
+            ifs_no=ifs_no[0] if ifs_no else None,
+            miktar=miktar[0] if miktar else None,
+            marka=marka[0] if marka else None,
+            model=model[0] if model else None,
+            envanter_no=envanter_no,
+            sorumlu_personel=sorumlu_personel,
+            bagli_envanter_no=bagli_envanter_no,
+            lisans_adi=lisans_adi,
+            aciklama=aciklama,
+        )
+        db.add(talep)
+        db.flush()
+        created_ids.append(talep.id)
+
     db.commit()
-    db.refresh(talep)
-    return {"ok": True, "id": talep.id}
+    return {"ok": True, "ids": created_ids}
+
+
+@router.post("/{talep_id}/cancel", response_class=JSONResponse)
+def cancel_request(talep_id: int, db: Session = Depends(get_db)):
+    talep = db.get(Talep, talep_id)
+    if not talep:
+        return JSONResponse({"ok": False}, status_code=404)
+    talep.durum = TalepDurum.IPTAL
+    db.commit()
+    return {"ok": True}
+
+
+@router.post("/{talep_id}/close", response_class=JSONResponse)
+def close_request(talep_id: int, db: Session = Depends(get_db)):
+    talep = db.get(Talep, talep_id)
+    if not talep:
+        return JSONResponse({"ok": False}, status_code=404)
+    talep.durum = TalepDurum.TAMAMLANDI
+    db.commit()
+    return {"ok": True}
 
 
 @router.get("/export.xlsx")

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -16,30 +16,47 @@
       <thead>
         <tr>
           <th>#</th><th>Tür</th><th>Donanım Tipi</th><th>Marka</th><th>Model</th><th>Miktar</th>
-          <th>IFS No</th><th>Envanter No</th><th>Lisans Adı</th><th>Sorumlu</th><th>Açıklama</th><th>Tarih</th>
+          <th>IFS No</th><th>Envanter No</th><th>Lisans Adı</th><th>Sorumlu</th><th>Açıklama</th><th>Tarih</th><th>İşlem</th>
         </tr>
       </thead>
       <tbody>
-        {% for t in rows %}
-        <tr>
-          <td>{{ t.id }}</td>
-          <td>{{ t.tur }}</td>
-          <td>{{ t.donanim_tipi or '-' }}</td>
-          <td>{{ t.marka or '-' }}</td>
-          <td>{{ t.model or '-' }}</td>
-          <td>{{ t.miktar or '-' }}</td>
-          <td>{{ t.ifs_no or '-' }}</td>
-          <td>{{ t.envanter_no or t.bagli_envanter_no or '-' }}</td>
-          <td>{{ t.lisans_adi or '-' }}</td>
-          <td>{{ t.sorumlu_personel or '-' }}</td>
-          <td>{{ t.aciklama or '-' }}</td>
-          <td>{{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}</td>
+        {% set groups = rows|groupby('ifs_no') %}
+        {% for g in groups %}
+        <tr class="table-light">
+          <td colspan="13">IFS No: {{ g.grouper or '-' }}</td>
         </tr>
-        {% else %}
-        <tr>
-          <td colspan="12" class="text-center text-muted">{{ empty_msg }}</td>
-        </tr>
+          {% for t in g.list %}
+          <tr>
+            <td>{{ t.id }}</td>
+            <td>{{ t.tur }}</td>
+            <td>{{ t.donanim_tipi or '-' }}</td>
+            <td>{{ t.marka or '-' }}</td>
+            <td>{{ t.model or '-' }}</td>
+            <td>{{ t.miktar or '-' }}</td>
+            <td>{{ t.ifs_no or '-' }}</td>
+            <td>{{ t.envanter_no or t.bagli_envanter_no or '-' }}</td>
+            <td>{{ t.lisans_adi or '-' }}</td>
+            <td>{{ t.sorumlu_personel or '-' }}</td>
+            <td>{{ t.aciklama or '-' }}</td>
+            <td>{{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}</td>
+            <td>
+              <div class="btn-group">
+                <button class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">İşlem</button>
+                <ul class="dropdown-menu">
+                  <li><a class="dropdown-item" href="#" onclick="talepIptal({{ t.id }})">İptal Et</a></li>
+                  <li><a class="dropdown-item" href="#" onclick="talepKapat({{ t.id }})">Stok Gir</a></li>
+                  <li><a class="dropdown-item" href="/talepler/convert/{{ t.id }}">Direk Giriş</a></li>
+                </ul>
+              </div>
+            </td>
+          </tr>
+          {% endfor %}
         {% endfor %}
+        {% if rows|length == 0 %}
+        <tr>
+          <td colspan="13" class="text-center text-muted">{{ empty_msg }}</td>
+        </tr>
+        {% endif %}
       </tbody>
     </table>
   </div>
@@ -91,29 +108,17 @@
         </div>
 
         <!-- Aksesuar alanları (opsiyonel) -->
-        <div id="grpAksesuar" class="row g-2 d-none">
-          <div class="col-12">
-            <label class="form-label">Donanım Tipi (opsiyonel)</label>
-            <select id="donanim_tipi" name="donanim_tipi" class="form-select">
-              <option value="">Seçiniz...</option>
-            </select>
+        <div id="grpAksesuar" class="mt-3 d-none">
+          <div class="row g-2 mb-2">
+            <div class="col-12">
+              <label class="form-label">Donanım Tipi (opsiyonel)</label>
+              <select id="donanim_tipi" name="donanim_tipi" class="form-select">
+                <option value="">Seçiniz...</option>
+              </select>
+            </div>
           </div>
-          <div class="col-6">
-            <label class="form-label">IFS No (opsiyonel)</label>
-            <input name="ifs_no" class="form-control" placeholder="IFS No">
-          </div>
-          <div class="col-6">
-            <label class="form-label">Miktar (opsiyonel)</label>
-            <input name="miktar" type="number" min="1" class="form-control" placeholder="Miktar">
-          </div>
-          <div class="col-6">
-            <label class="form-label">Marka (opsiyonel)</label>
-            <input name="marka" class="form-control" placeholder="Marka">
-          </div>
-          <div class="col-6">
-            <label class="form-label">Model (opsiyonel)</label>
-            <input name="model" class="form-control" placeholder="Model">
-          </div>
+          <div id="aksesuarList"></div>
+          <button type="button" class="btn btn-outline-primary btn-sm mt-2" onclick="aksesuarSatirEkle()">+</button>
         </div>
 
         <!-- Envanter alanları (opsiyonel) -->
@@ -164,6 +169,7 @@
   const grpEnvanter = document.getElementById('grpEnvanter');
   const grpLisans = document.getElementById('grpLisans');
   const grpAksesuar = document.getElementById('grpAksesuar');
+  const aksesuarList = document.getElementById('aksesuarList');
 
   function toggleGroups() {
     const val = turSel.value;
@@ -179,6 +185,33 @@
     list.forEach(n=>{ const o=document.createElement('option'); o.value=o.textContent=n; sel.appendChild(o); });
   });
 
+  function aksesuarSatirEkle() {
+    const row = document.createElement('div');
+    row.className = 'row g-2 align-items-end aksesuar-row mt-2';
+    row.innerHTML = `
+      <div class="col"><input name="ifs_no" class="form-control" placeholder="IFS No"></div>
+      <div class="col"><input name="miktar" type="number" min="1" class="form-control" placeholder="Miktar"></div>
+      <div class="col"><input name="marka" class="form-control" placeholder="Marka"></div>
+      <div class="col"><input name="model" class="form-control" placeholder="Model"></div>
+      <div class="col-auto">
+        <button type="button" class="btn btn-outline-danger btn-sm d-none aks-remove">-</button>
+      </div>`;
+    aksesuarList.appendChild(row);
+    guncelleAksButtons();
+  }
+
+  function guncelleAksButtons() {
+    const rows = document.querySelectorAll('#aksesuarList .aksesuar-row');
+    rows.forEach(r => {
+      const btn = r.querySelector('.aks-remove');
+      btn.onclick = () => { r.remove(); guncelleAksButtons(); };
+      if (rows.length > 1) btn.classList.remove('d-none');
+      else btn.classList.add('d-none');
+    });
+  }
+
+  aksesuarSatirEkle();
+
   async function talepGonder(e) {
     e.preventDefault();
     const form = document.getElementById('frmTalep');
@@ -188,6 +221,18 @@
     if (data.ok) location.reload();
     else alert('Kayıt hatası');
     return false;
+  }
+
+  async function talepIptal(id) {
+    if (!confirm('Talep iptal edilsin mi?')) return;
+    const res = await fetch(`/talepler/${id}/cancel`, {method:'POST'});
+    if (res.ok) location.reload();
+  }
+
+  async function talepKapat(id) {
+    if (!confirm('Talep kapatılsın mı?')) return;
+    const res = await fetch(`/talepler/${id}/close`, {method:'POST'});
+    if (res.ok) location.reload();
   }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- group requests by IFS number in tables and add action dropdown
- allow adding multiple accessory rows in request form via + / - buttons
- support cancelling and closing requests via new API endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b194b15aec832b9cd92bb5834a11bc