### PR TITLE
Fix request type selector in cloned rows

### DIFF
--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -150,6 +150,15 @@
 
 <script>
   const rowContainer = document.getElementById('talepRows');
+  const templateRow = rowContainer.firstElementChild.cloneNode(true);
+
+  function addRow() {
+    const clone = templateRow.cloneNode(true);
+    clone.querySelectorAll('input').forEach(i => i.value = '');
+    clone.querySelectorAll('select').forEach(s => s.selectedIndex = 0);
+    rowContainer.appendChild(clone);
+    bindRow(clone);
+  }
 
   function bindRow(row) {
     const tur = row.querySelector('.tur');
@@ -162,13 +171,7 @@
     tur.addEventListener('change', toggle);
     toggle();
 
-    row.querySelector('.add-row').addEventListener('click', () => {
-      const clone = row.cloneNode(true);
-      clone.querySelectorAll('input').forEach(i => i.value = '');
-      clone.querySelectorAll('select').forEach(s => { if(!s.classList.contains('tur')) s.selectedIndex = 0; });
-      rowContainer.appendChild(clone);
-      bindRow(clone);
-    });
+    row.querySelector('.add-row').addEventListener('click', addRow);
 
     row.querySelector('.remove-row').addEventListener('click', () => {
       if (rowContainer.children.length > 1) row.remove();

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -167,6 +167,15 @@
 
 <script>
   const rowContainer = document.getElementById('talepRows');
+  const templateRow = rowContainer.firstElementChild.cloneNode(true);
+
+  function addRow() {
+    const clone = templateRow.cloneNode(true);
+    clone.querySelectorAll('input').forEach(i => i.value = '');
+    clone.querySelectorAll('select').forEach(s => s.selectedIndex = 0);
+    rowContainer.appendChild(clone);
+    bindRow(clone);
+  }
 
   function bindRow(row) {
     const tur = row.querySelector('.tur');
@@ -180,13 +189,7 @@
     tur.addEventListener('change', toggle);
     toggle();
 
-    row.querySelector('.add-row').addEventListener('click', () => {
-      const clone = row.cloneNode(true);
-      clone.querySelectorAll('input').forEach(i => i.value = '');
-      clone.querySelectorAll('select').forEach(s => s.selectedIndex = 0);
-      rowContainer.appendChild(clone);
-      bindRow(clone);
-    });
+    row.querySelector('.add-row').addEventListener('click', addRow);
 
     row.querySelector('.remove-row').addEventListener('click', () => {
       if (rowContainer.children.length > 1) row.remove();


### PR DESCRIPTION
## Summary
- Ensure newly added request rows use a clean template and bind fresh event listeners
- Allow changing request type (`Talep Türü`) for rows added via the green plus button

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1a0747828832b91bc48ab212f27f8