### PR TITLE
Handle multi-quantity actions for requests

### DIFF
--- a/templates/requests/convert.html
+++ b/templates/requests/convert.html
@@ -1,5 +1,18 @@
 {% extends "base.html" %}{% block title %}Talep – Envantere Dönüştür{% endblock %}
 {% block content %}
-<h2 class="h5 mb-3">Talebi Envantere Dönüştür (ID: {{ request_id }})</h2>
-<div class="card p-3">Dönüştürme adımları...</div>
+<h2 class="h5 mb-3">Talebi Envantere Dönüştür (ID: {{ talep.id }})</h2>
+<form class="card p-3">
+  {% for i in range(adet) %}
+  <fieldset class="mb-3">
+    <legend>Ürün {{ i + 1 }}</legend>
+    {% for field in eksik %}
+    <div class="mb-2">
+      <label class="form-label">{{ field.replace('_', ' ').title() }}</label>
+      <input name="{{ field }}_{{ i }}" class="form-control" required>
+    </div>
+    {% endfor %}
+  </fieldset>
+  {% endfor %}
+  <button class="btn btn-primary" type="submit">Kaydet</button>
+</form>
 {% endblock %}

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -43,9 +43,9 @@
               <div class="btn-group">
                 <button class="btn btn-sm btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">İşlem</button>
                 <ul class="dropdown-menu">
-                  <li><a class="dropdown-item" href="#" onclick="talepIptal({{ t.id }})">İptal Et</a></li>
-                  <li><a class="dropdown-item" href="#" onclick="talepKapat({{ t.id }})">Stok Gir</a></li>
-                  <li><a class="dropdown-item" href="/talepler/convert/{{ t.id }}">Direk Giriş</a></li>
+                  <li><a class="dropdown-item" href="#" onclick="talepIptal({{ t.id }}, {{ t.miktar or 1 }})">İptal Et</a></li>
+                  <li><a class="dropdown-item" href="#" onclick="talepKapat({{ t.id }}, {{ t.miktar or 1 }})">Stok Gir</a></li>
+                  <li><a class="dropdown-item" href="#" onclick="talepConvert({{ t.id }}, {{ t.miktar or 1 }})">Direk Giriş</a></li>
                 </ul>
               </div>
             </td>
@@ -221,16 +221,45 @@
     return false;
   }
 
-  async function talepIptal(id) {
+  async function talepIptal(id, qty) {
     if (!confirm('Talep iptal edilsin mi?')) return;
-    const res = await fetch(`/talepler/${id}/cancel`, {method:'POST'});
+    let count = 1;
+    if (qty > 1) {
+      const input = prompt('Kaç adet iptal edilsin?', qty);
+      if (!input) return;
+      count = parseInt(input, 10);
+      if (isNaN(count) || count < 1) return;
+    }
+    const fd = new FormData();
+    fd.append('adet', count);
+    const res = await fetch(`/talepler/${id}/cancel`, {method:'POST', body: fd});
     if (res.ok) location.reload();
   }
 
-  async function talepKapat(id) {
+  async function talepKapat(id, qty) {
     if (!confirm('Talep kapatılsın mı?')) return;
-    const res = await fetch(`/talepler/${id}/close`, {method:'POST'});
+    let count = 1;
+    if (qty > 1) {
+      const input = prompt('Kaç adet stok girilecek?', qty);
+      if (!input) return;
+      count = parseInt(input, 10);
+      if (isNaN(count) || count < 1) return;
+    }
+    const fd = new FormData();
+    fd.append('adet', count);
+    const res = await fetch(`/talepler/${id}/close`, {method:'POST', body: fd});
     if (res.ok) location.reload();
+  }
+
+  function talepConvert(id, qty) {
+    let count = 1;
+    if (qty > 1) {
+      const input = prompt('Kaç adet dönüştürülecek?', qty);
+      if (!input) return;
+      count = parseInt(input, 10);
+      if (isNaN(count) || count < 1) return;
+    }
+    window.location.href = `/talepler/convert/${id}?adet=${count}`;
   }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow choosing quantity for Talep operations
- split request quantity among cancel/close actions
- gather missing fields per item in direct entry

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1abd71134832bacb4cdbe83ee1b97