### PR TITLE
Enable HTTPS-only session cookies with env override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # En az 32+ karakterlik rastgele bir değer kullanın
 SESSION_SECRET=degistir-beni-baya-uzun-bir-gizli-anahtar
+# Yerel geliştirme için HTTP kullanırken kapatabilirsiniz
+SESSION_HTTPS_ONLY=False
 
 # Yerel geliştirme için SQLite dosyası
 DATABASE_URL=sqlite:///./data/app.db

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## Çalıştırma (Yerel)s
-
+## Çalıştırma (Yerel)
 
 ```bash
 python -m venv .venv && source .venv/bin/activate # Windows: .venv\\Scripts\\activate
 pip install -r requirements.txt
-cp .env.example .env # düzenleyin
+cp .env.example .env # düzenleyin, gerekirse SESSION_HTTPS_ONLY=False yapın
 uvicorn app:app --reload --port 5000
+```

--- a/app.py
+++ b/app.py
@@ -61,6 +61,7 @@ if not SESSION_SECRET or len(SESSION_SECRET) < 32:
 DEFAULT_ADMIN_USERNAME = os.getenv("DEFAULT_ADMIN_USERNAME", "admin")
 DEFAULT_ADMIN_PASSWORD = os.getenv("DEFAULT_ADMIN_PASSWORD", "admin123")
 DEFAULT_ADMIN_FULLNAME = os.getenv("DEFAULT_ADMIN_FULLNAME", "Sistem Yöneticisi")
+SESSION_HTTPS_ONLY = os.getenv("SESSION_HTTPS_ONLY", "true").lower() in ("1", "true", "t", "yes")
 
 # --- App & Middleware ---------------------------------------------------------
 app = FastAPI(title="Envanter Takip – Login")
@@ -88,7 +89,7 @@ app.add_middleware(
     secret_key=SESSION_SECRET,
     max_age=60 * 60 * 8,
     same_site="lax",
-    https_only=False,
+    https_only=SESSION_HTTPS_ONLY,
 )
 
 # Statik dosyalar ve şablonlar


### PR DESCRIPTION
## Summary
- default session middleware to HTTPS-only
- allow toggling via `SESSION_HTTPS_ONLY` environment variable
- document `SESSION_HTTPS_ONLY` in `.env.example` and `README`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b550fda058832b99be2dfb3e95fdfe