### PR TITLE
Replace deprecated query.get usages with session.get

### DIFF
--- a/routers/catalog.py
+++ b/routers/catalog.py
@@ -63,7 +63,7 @@ def create_model(brand_id: int, name: str, db: Session = Depends(get_db)):
     name = (name or "").strip()
     if not name:
         raise HTTPException(400, "Model adı boş olamaz")
-    brand = db.query(Brand).get(brand_id)
+    brand = db.get(Brand, brand_id)
     if not brand:
         raise HTTPException(404, "Marka yok")
     exists = (

--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -300,7 +300,7 @@ def assign(
   db: Session = Depends(get_db),
   user=Depends(current_user),
 ):
-  item = db.query(Inventory).get(item_id)
+  item = db.get(Inventory, item_id)
   if not item:
     raise HTTPException(404)
 
@@ -342,7 +342,7 @@ def edit_page(
   db: Session = Depends(get_db),
   user=Depends(current_user),
 ):
-  item = db.query(Inventory).get(item_id)
+  item = db.get(Inventory, item_id)
   if not item:
     raise HTTPException(404)
   return templates.TemplateResponse(
@@ -352,7 +352,7 @@ def edit_page(
 @router.post("/{item_id:int}/edit", name="inventory.edit_post")
 async def edit_post(item_id: int, request: Request, modal: bool = False, db: Session = Depends(get_db), user=Depends(current_user)):
   form = dict(await request.form())
-  item = db.query(Inventory).get(item_id)
+  item = db.get(Inventory, item_id)
   if not item:
     raise HTTPException(404)
 
@@ -378,7 +378,7 @@ async def edit_post(item_id: int, request: Request, modal: bool = False, db: Ses
 
 @router.get("/{item_id:int}/stock", name="inventory.stock")
 def stock_entry(item_id: int, db: Session = Depends(get_db), user=Depends(current_user)):
-  item = db.query(Inventory).get(item_id)
+  item = db.get(Inventory, item_id)
   if not item:
     raise HTTPException(404)
   actor = getattr(user, "full_name", None) or user.username
@@ -405,7 +405,7 @@ def stock_entry(item_id: int, db: Session = Depends(get_db), user=Depends(curren
 
 @router.post("/scrap", name="inventory.scrap")
 def scrap(item_id: int = Form(...), aciklama: str = Form(""), db: Session = Depends(get_db), user=Depends(current_user)):
-  item = db.query(Inventory).get(item_id)
+  item = db.get(Inventory, item_id)
   if not item:
     raise HTTPException(404)
 

--- a/routers/license.py
+++ b/routers/license.py
@@ -121,7 +121,7 @@ def new_license_post(
     db: Session = Depends(get_db),
     user = Depends(current_user),
 ):
-    inv = db.query(Inventory).get(inventory_id) if inventory_id else None
+    inv = db.get(Inventory, inventory_id) if inventory_id else None
     lic = License(
         lisans_adi=adi,
         lisans_anahtari=anahtar or None,
@@ -168,7 +168,7 @@ def create_license(
 
 @router.get("/{lic_id}/edit", response_class=HTMLResponse, name="license.edit_form")
 def edit_license_form(lic_id: int, request: Request, modal: bool = False, db: Session = Depends(get_db)):
-    lic = db.query(License).get(lic_id)
+    lic = db.get(License, lic_id)
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
     envanterler = db.query(Inventory).order_by(Inventory.no).all()
@@ -202,10 +202,10 @@ def edit_license_post(
     db: Session = Depends(get_db),
     user = Depends(current_user),
 ):
-    lic = db.query(License).get(lic_id)
+    lic = db.get(License, lic_id)
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
-    inv = db.query(Inventory).get(inventory_id) if inventory_id else None
+    inv = db.get(Inventory, inventory_id) if inventory_id else None
     lic.lisans_adi = adi
     lic.lisans_anahtari = anahtar or None
     lic.sorumlu_personel = sorumlu_personel or None
@@ -227,7 +227,7 @@ def assign_license_form(
     db: Session = Depends(get_db),
     user=Depends(current_user),
 ):
-    lic = db.query(License).get(lic_id)
+    lic = db.get(License, lic_id)
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
     envanterler = db.query(Inventory).order_by(Inventory.no).all()
@@ -252,7 +252,7 @@ def assign_license(
     request: Request = None,
     db: Session = Depends(get_db),
 ):
-    lic = db.query(License).get(lic_id)
+    lic = db.get(License, lic_id)
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
     eski_sp = lic.sorumlu_personel or ""
@@ -266,7 +266,7 @@ def assign_license(
 
 @router.get("/{lic_id}/stock")
 def stock_license(lic_id: int, db: Session = Depends(get_db), user=Depends(current_user)):
-    lic = db.query(License).get(lic_id)
+    lic = db.get(License, lic_id)
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
     actor = getattr(user, "full_name", None) or user.username
@@ -294,7 +294,7 @@ def scrap_license(
     request: Request = None,
     db: Session = Depends(get_db),
 ):
-    lic = db.query(License).get(lic_id)
+    lic = db.get(License, lic_id)
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
     lic.durum = "hurda"
@@ -314,7 +314,7 @@ def edit_quick_license(
     request: Request = None,
     db: Session = Depends(get_db),
 ):
-    lic = db.query(License).get(lic_id)
+    lic = db.get(License, lic_id)
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
     eski = getattr(lic, "notlar", "")
@@ -351,7 +351,7 @@ def license_scrap_list(request: Request, db: Session = Depends(get_db)):
 
 @router.get("/detail/{lic_id}", response_class=HTMLResponse, name="license.detail_partial")
 def license_detail_partial(lic_id: int, request: Request, db: Session = Depends(get_db)):
-    lic = db.query(License).get(lic_id)
+    lic = db.get(License, lic_id)
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
     return templates.TemplateResponse("partials/license_detail.html", {"request": request, "item": lic})
@@ -359,7 +359,7 @@ def license_detail_partial(lic_id: int, request: Request, db: Session = Depends(
 
 @router.get("/{lic_id}", name="license_detail")
 def license_detail(lic_id: int, request: Request, db: Session = Depends(get_db)):
-    lic = db.query(License).get(lic_id)
+    lic = db.get(License, lic_id)
     if not lic:
         raise HTTPException(status_code=404, detail="Lisans bulunamadı")
     return templates.TemplateResponse("license_detail.html", {"request": request, "item": lic})

--- a/routers/picker.py
+++ b/routers/picker.py
@@ -155,7 +155,7 @@ def picker_delete(entity: str, row_id: int, db: Session = Depends(get_db)):
 
     meta = _resolve(entity)
     Model = meta["model"]
-    obj = db.query(Model).get(row_id)
+    obj = db.get(Model, row_id)
     if not obj:
         raise HTTPException(404, "Kayıt bulunamadı.")
     db.delete(obj)

--- a/routers/printers.py
+++ b/routers/printers.py
@@ -348,7 +348,7 @@ def edit_printer_post(
 
 @router.get("/{printer_id}/stock")
 def stock_printer(printer_id: int, db: Session = Depends(get_db), user=Depends(current_user)):
-    p = db.query(Printer).get(printer_id)
+    p = db.get(Printer, printer_id)
     if not p:
         raise HTTPException(404, "Yazıcı bulunamadı")
     actor = getattr(user, "full_name", None) or user.username

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -82,7 +82,7 @@ def user_edit_post(
     is_admin: bool = Form(False),
     db: Session = Depends(get_db),
 ):
-    u = db.query(User).get(uid)
+    u = db.get(User, uid)
     if not u:
         raise HTTPException(404, "Kullanıcı bulunamadı")
     u.username = username

--- a/routes/scrap.py
+++ b/routes/scrap.py
@@ -11,7 +11,7 @@ def get_templates(request: Request):
 
 @router.get("/scrap/detail/{id}", response_class=HTMLResponse)
 def scrap_detail(id: int, request: Request, db: Session = Depends(get_db)):
-    row = db.query(StockLog).get(id)
+    row = db.get(StockLog, id)
     templates = get_templates(request)
     return templates.TemplateResponse("partials/scrap_detail.html", {"request": request, "row": row})
 

--- a/routes/stock.py
+++ b/routes/stock.py
@@ -52,19 +52,19 @@ def stock_assign(payload: dict = Body(...), db: Session = Depends(get_db)):
     desc = None
     if target_type == "license":
         lic_id = payload.get("license_id")
-        lic = db.query(License).get(int(lic_id)) if lic_id else None
+        lic = db.get(License, int(lic_id)) if lic_id else None
         if not lic:
             return {"ok": False, "error": "Lisans bulunamadı"}
         desc = f"Lisans envantere atandı"
     elif target_type == "inventory":
         inv_id = payload.get("inventory_id")
-        inv = db.query(Inventory).get(int(inv_id)) if inv_id else None
+        inv = db.get(Inventory, int(inv_id)) if inv_id else None
         if not inv:
             return {"ok": False, "error": "Envanter bulunamadı"}
         desc = f"Stok envantere atandı"
     elif target_type == "printer":
         prn_id = payload.get("printer_id")
-        prn = db.query(Printer).get(int(prn_id)) if prn_id else None
+        prn = db.get(Printer, int(prn_id)) if prn_id else None
         if not prn:
             return {"ok": False, "error": "Yazıcı bulunamadı"}
         desc = f"Stok yazıcıya atandı"


### PR DESCRIPTION
## Summary
- refactor stock assignment to use `db.get` for license, inventory and printer lookups
- update picker, catalog, inventory, license, printer, admin and scrap routes to use `session.get`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b555c9f4b8832b8c125f483d47c67d