### PR TITLE
Allow HTTP session cookies in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 ```bash
 python -m venv .venv && source .venv/bin/activate # Windows: .venv\\Scripts\\activate
 pip install -r requirements.txt
-cp .env.example .env # düzenleyin, gerekirse SESSION_HTTPS_ONLY=False yapın
+cp .env.example .env # düzenleyin, üretimde SESSION_HTTPS_ONLY=true yapın
 uvicorn app:app --reload --port 5000
 ```

--- a/app.py
+++ b/app.py
@@ -61,7 +61,17 @@ if not SESSION_SECRET or len(SESSION_SECRET) < 32:
 DEFAULT_ADMIN_USERNAME = os.getenv("DEFAULT_ADMIN_USERNAME", "admin")
 DEFAULT_ADMIN_PASSWORD = os.getenv("DEFAULT_ADMIN_PASSWORD", "admin123")
 DEFAULT_ADMIN_FULLNAME = os.getenv("DEFAULT_ADMIN_FULLNAME", "Sistem Yöneticisi")
-SESSION_HTTPS_ONLY = os.getenv("SESSION_HTTPS_ONLY", "true").lower() in ("1", "true", "t", "yes")
+# Varsayılan olarak geliştirme ortamına uygun olsun; üretimde .env ile true yapın
+SESSION_HTTPS_ONLY = os.getenv("SESSION_HTTPS_ONLY", "false").lower() in (
+    "1",
+    "true",
+    "t",
+    "yes",
+)
+if not SESSION_HTTPS_ONLY:
+    print(
+        "WARNING: SESSION cookies are not marked secure; set SESSION_HTTPS_ONLY=true in production."
+    )
 
 # --- App & Middleware ---------------------------------------------------------
 app = FastAPI(title="Envanter Takip – Login")


### PR DESCRIPTION
## Summary
- Allow session cookies over HTTP by default and warn when not secure
- Clarify documentation on enabling secure cookies for production

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b55e8b005c832b891854c7dd142022