### PR TITLE
Show inventory scrap details in modal

### DIFF
--- a/templates/hurdalar.html
+++ b/templates/hurdalar.html
@@ -48,9 +48,9 @@
               </ul>
             </td>
             <td class="text-nowrap">
-              <a href="/inventory/{{ item.id }}" class="btn btn-outline-secondary btn-sm" title="Detayı Göster">
+              <button class="btn btn-outline-secondary btn-sm view-btn" data-id="{{ item.id }}" title="Detayı Göster">
                 <i class="bi bi-eye"></i>
-              </a>
+              </button>
             </td>
           </tr>
           {% endfor %}
@@ -140,6 +140,16 @@
 </div>
 
 <script>
+document.querySelectorAll('#envanter .view-btn').forEach(b=>{
+  b.addEventListener('click', async ()=>{
+    const id = b.dataset.id;
+    const r = await fetch('/scrap/inventory/'+id);
+    const h = await r.text();
+    document.getElementById('hurdaDetayBody').innerHTML = h;
+    new bootstrap.Modal(document.getElementById('hurdaDetayModal')).show();
+  });
+});
+
 document.querySelectorAll('#yazici .view-btn').forEach(b=>{
   b.addEventListener('click', async ()=>{
     const id = b.dataset.id;

--- a/templates/partials/scrap_inventory_detail.html
+++ b/templates/partials/scrap_inventory_detail.html
@@ -1,0 +1,21 @@
+<div class="row g-3">
+  <div class="col-md-6"><strong>Envanter No:</strong> {{ inv.no }}</div>
+  <div class="col-md-6"><strong>Marka:</strong> {{ inv.marka or '-' }}</div>
+  <div class="col-md-6"><strong>Model:</strong> {{ inv.model or '-' }}</div>
+  <div class="col-md-6"><strong>Seri No:</strong> {{ inv.seri_no or '-' }}</div>
+  <div class="col-md-6"><strong>Fabrika:</strong> {{ inv.fabrika or '-' }}</div>
+  <div class="col-md-6"><strong>Kullanım Alanı:</strong> {{ inv.kullanim_alani or '-' }}</div>
+  <div class="col-md-6"><strong>Sorumlu:</strong> {{ inv.sorumlu_personel or '-' }}</div>
+  <div class="col-md-6"><strong>Bağlı Env.:</strong> {{ inv.bagli_envanter_no or '-' }}</div>
+  <div class="col-md-6"><strong>Not:</strong> {{ inv.not_ or '-' }}</div>
+  <div class="col-md-6"><strong>Tarih:</strong> {{ inv.tarih }}</div>
+</div>
+<hr>
+<h6>Geçmiş İşlemler</h6>
+<ul class="list-group">
+  {% for log in logs %}
+  <li class="list-group-item">{{ log|humanize_log }}</li>
+  {% else %}
+  <li class="list-group-item text-muted">Kayıt yok.</li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- Add endpoint for fetching inventory scrap details
- Display inventory scrap information in modal rather than navigating away
- Create partial template for scrap inventory detail view

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'models')*

------
https://chatgpt.com/codex/tasks/task_e_68b56367e170832bbc418b9e9aaa5091