### PR TITLE
Expand dashboard logs and correct profile name display

### DIFF
--- a/routers/profile.py
+++ b/routers/profile.py
@@ -2,21 +2,24 @@
 from fastapi import APIRouter, Request, Depends
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
 
+from database import get_db
+from models import User
 from security import SessionUser, current_user
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
 
 @router.get("/", response_class=HTMLResponse)
-async def profile_home(request: Request, user: SessionUser = Depends(current_user)):
-    first_name = ""
-    last_name = ""
-    if user.full_name:
-        parts = user.full_name.split(" ", 1)
-        first_name = parts[0]
-        if len(parts) > 1:
-            last_name = parts[1]
+async def profile_home(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: SessionUser = Depends(current_user),
+):
+    u = db.get(User, user.id)
+    first_name = u.first_name if u and u.first_name else ""
+    last_name = u.last_name if u and u.last_name else ""
     return templates.TemplateResponse(
         "profile/index.html",
         {


### PR DESCRIPTION
## Summary
- Show recent activity from inventory, stock and license logs on the dashboard
- Display profile first and last names from stored user fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5675e98f8832bb63f078c539cf6fc