### PR TITLE
Add search and filter to log pages

### DIFF
--- a/routers/logs.py
+++ b/routers/logs.py
@@ -22,7 +22,7 @@ def logs_home(request: Request, db: Session = Depends(get_db)):
     inventory_logs = (
         db.query(InventoryLog, Inventory.no.label("inv_no"))
         .join(Inventory, Inventory.id == InventoryLog.inventory_id)
-        .order_by(Inventory.no.asc(), InventoryLog.created_at.desc())
+        .order_by(InventoryLog.created_at.desc())
         .all()
     )
     return templates.TemplateResponse(

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -1,0 +1,30 @@
+// Simple search & action filtering for logs page
+(function () {
+  function setupFilter(inputId, tableSelector, actionSelectId) {
+    const input = document.getElementById(inputId);
+    const actionSel = document.getElementById(actionSelectId);
+    if (!input && !actionSel) return;
+    const rows = document.querySelectorAll(`${tableSelector} tbody tr`);
+
+    function apply() {
+      const q = input ? input.value.toLowerCase() : "";
+      const act = actionSel ? actionSel.value : "";
+      rows.forEach((row) => {
+        const text = row.textContent.toLowerCase();
+        const actionCell = row.querySelector('td[data-action]');
+        const action = actionCell ? actionCell.getAttribute('data-action') : "";
+        const matchText = !q || text.includes(q);
+        const matchAction = !act || action === act;
+        row.classList.toggle('d-none', !(matchText && matchAction));
+      });
+    }
+
+    if (input) input.addEventListener('input', apply);
+    if (actionSel) actionSel.addEventListener('change', apply);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    setupFilter('searchUserLogs', '#userlogs', 'filterUserAction');
+    setupFilter('searchInventoryLogs', '#inventorylogs', 'filterInventoryAction');
+  });
+})();

--- a/templates/logs/index.html
+++ b/templates/logs/index.html
@@ -17,6 +17,15 @@
 <div class="tab-content pt-3">
   <div class="tab-pane fade show active" id="userlogs" role="tabpanel" aria-labelledby="userlogs-tab">
     <div class="card p-0">
+      <div class="p-2 d-flex justify-content-end gap-2">
+        <select id="filterUserAction" class="form-select form-select-sm" style="max-width:160px;">
+          <option value="">İşlem...</option>
+          {% for key, val in islem_map.items() %}
+          <option value="{{ key }}">{{ val }}</option>
+          {% endfor %}
+        </select>
+        <input type="text" id="searchUserLogs" class="form-control form-control-sm" placeholder="Ara..." style="max-width:200px;">
+      </div>
       <div class="table-responsive">
         <table class="table table-sm table-striped mb-0">
           <thead>
@@ -31,7 +40,7 @@
           {% for log, inv_no in user_logs %}
             <tr>
               <td>{{ log.actor }}</td>
-              <td>{{ islem_map.get(log.action, log.action) }}</td>
+              <td data-action="{{ log.action }}">{{ islem_map.get(log.action, log.action) }}</td>
               <td>{{ inv_no }}</td>
               <td>{{ log.created_at.strftime("%d.%m.%Y %H:%M:%S") }}</td>
             </tr>
@@ -45,6 +54,15 @@
   </div>
   <div class="tab-pane fade" id="inventorylogs" role="tabpanel" aria-labelledby="inventorylogs-tab">
     <div class="card p-0">
+      <div class="p-2 d-flex justify-content-end gap-2">
+        <select id="filterInventoryAction" class="form-select form-select-sm" style="max-width:160px;">
+          <option value="">İşlem...</option>
+          {% for key, val in islem_map.items() %}
+          <option value="{{ key }}">{{ val }}</option>
+          {% endfor %}
+        </select>
+        <input type="text" id="searchInventoryLogs" class="form-control form-control-sm" placeholder="Ara..." style="max-width:200px;">
+      </div>
       <div class="table-responsive">
         <table class="table table-sm table-striped mb-0">
           <thead>
@@ -62,7 +80,7 @@
             <tr>
               <td>{{ inv_no }}</td>
               <!-- İşlem Türkçeleştirme -->
-              <td>{{ islem_map.get(log.action, log.action) }}</td>
+              <td data-action="{{ log.action }}">{{ islem_map.get(log.action, log.action) }}</td>
 
               <!-- Önce -->
               <td>
@@ -101,5 +119,11 @@
     </div>
   </div>
 </div>
+
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="{{ url_for('static', path='js/logs.js') }}"></script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- allow log page to query most recent items
- add search and action filters for log tables
- support client-side log filtering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b57b182aa4832bad9a342ebce2a1c3