### PR TITLE
Enable user search in admin panel and hide scrapped printers

### DIFF
--- a/routers/printers.py
+++ b/routers/printers.py
@@ -133,6 +133,10 @@ def list_printers(
     durum: Optional[str] = None,
 ):
     query = db.query(Printer)
+    if durum:
+        query = query.filter(Printer.durum == durum)
+    else:
+        query = query.filter(Printer.durum != "hurda")
     if q:
         like = f"%{q}%"
         query = query.filter(
@@ -145,8 +149,6 @@ def list_printers(
             | (Printer.ip_adresi.ilike(like))
             | (Printer.hostname.ilike(like))
         )
-    if durum:
-        query = query.filter(Printer.durum == durum)
 
     printers = query.order_by(Printer.id.desc()).all()
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -23,7 +23,13 @@
     <div class="tab-pane fade show active" id="pane-users" role="tabpanel" aria-labelledby="tab-users">
       <div class="d-flex align-items-center justify-content-between mb-3">
         <h5 class="mb-0">Kullanıcı Yönetimi</h5>
-        <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#modalUserCreate">+ Yeni Kullanıcı</button>
+        <div class="d-flex align-items-center gap-2">
+          <form method="get" action="/admin" class="d-flex align-items-center gap-2">
+            <input type="text" name="q" value="{{ q or '' }}" class="form-control form-control-sm" placeholder="Ara...">
+            <button class="btn btn-outline-secondary btn-sm" type="submit">Ara</button>
+          </form>
+          <button class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#modalUserCreate">+ Yeni Kullanıcı</button>
+        </div>
       </div>
 
       <div class="table-responsive">


### PR DESCRIPTION
## Summary
- add server-side search filter for admin users
- include search form in admin template
- exclude scrapped printers from main printer list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b57ec79554832b8bcef7582a954d7c