### PR TITLE
Add user and inventory filters to logs

### DIFF
--- a/routers/logs.py
+++ b/routers/logs.py
@@ -5,7 +5,7 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
 from database import get_db
-from models import Inventory, InventoryLog
+from models import Inventory, InventoryLog, User
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
@@ -25,11 +25,15 @@ def logs_home(request: Request, db: Session = Depends(get_db)):
         .order_by(InventoryLog.created_at.desc())
         .all()
     )
+    users = [u[0] for u in db.query(User.username).order_by(User.username).all()]
+    inventory_numbers = [i[0] for i in db.query(Inventory.no).order_by(Inventory.no).all()]
     return templates.TemplateResponse(
         "logs/index.html",
         {
             "request": request,
             "user_logs": user_logs,
             "inventory_logs": inventory_logs,
+            "users": users,
+            "inventory_numbers": inventory_numbers,
         },
     )

--- a/static/js/logs.js
+++ b/static/js/logs.js
@@ -1,30 +1,33 @@
 // Simple search & action filtering for logs page
 (function () {
-  function setupFilter(inputId, tableSelector, actionSelectId) {
+  function setupFilter(inputId, tableSelector, selectId, dataAttr) {
     const input = document.getElementById(inputId);
-    const actionSel = document.getElementById(actionSelectId);
-    if (!input && !actionSel) return;
+    const select = document.getElementById(selectId);
+    if (!input && !select) return;
     const rows = document.querySelectorAll(`${tableSelector} tbody tr`);
 
     function apply() {
       const q = input ? input.value.toLowerCase() : "";
-      const act = actionSel ? actionSel.value : "";
+      const selVal = select ? select.value : "";
       rows.forEach((row) => {
         const text = row.textContent.toLowerCase();
-        const actionCell = row.querySelector('td[data-action]');
-        const action = actionCell ? actionCell.getAttribute('data-action') : "";
+        let attrVal = "";
+        if (select && dataAttr) {
+          const cell = row.querySelector(`[${dataAttr}]`);
+          attrVal = cell ? cell.getAttribute(dataAttr) : "";
+        }
         const matchText = !q || text.includes(q);
-        const matchAction = !act || action === act;
-        row.classList.toggle('d-none', !(matchText && matchAction));
+        const matchSelect = !selVal || attrVal === selVal;
+        row.classList.toggle('d-none', !(matchText && matchSelect));
       });
     }
 
     if (input) input.addEventListener('input', apply);
-    if (actionSel) actionSel.addEventListener('change', apply);
+    if (select) select.addEventListener('change', apply);
   }
 
   document.addEventListener('DOMContentLoaded', () => {
-    setupFilter('searchUserLogs', '#userlogs', 'filterUserAction');
-    setupFilter('searchInventoryLogs', '#inventorylogs', 'filterInventoryAction');
+    setupFilter('searchUserLogs', '#userlogs', 'filterUserName', 'data-user');
+    setupFilter('searchInventoryLogs', '#inventorylogs', 'filterInventoryNo', 'data-inv');
   });
 })();

--- a/templates/logs/index.html
+++ b/templates/logs/index.html
@@ -18,13 +18,13 @@
   <div class="tab-pane fade show active" id="userlogs" role="tabpanel" aria-labelledby="userlogs-tab">
     <div class="card p-0">
       <div class="p-2 d-flex justify-content-end gap-2">
-        <select id="filterUserAction" class="form-select form-select-sm" style="max-width:160px;">
-          <option value="">İşlem...</option>
-          {% for key, val in islem_map.items() %}
-          <option value="{{ key }}">{{ val }}</option>
+        <select id="filterUserName" class="form-select form-select-sm" style="max-width:160px;">
+          <option value="">Kullanıcı...</option>
+          {% for u in users %}
+          <option value="{{ u }}">{{ u }}</option>
           {% endfor %}
         </select>
-        <input type="text" id="searchUserLogs" class="form-control form-control-sm" placeholder="Ara..." style="max-width:200px;">
+        <input type="text" id="searchUserLogs" class="form-control form-control-sm py-0" placeholder="Ara..." style="max-width:200px;">
       </div>
       <div class="table-responsive">
         <table class="table table-sm table-striped mb-0">
@@ -39,7 +39,7 @@
           <tbody>
           {% for log, inv_no in user_logs %}
             <tr>
-              <td>{{ log.actor }}</td>
+              <td data-user="{{ log.actor }}">{{ log.actor }}</td>
               <td data-action="{{ log.action }}">{{ islem_map.get(log.action, log.action) }}</td>
               <td>{{ inv_no }}</td>
               <td>{{ log.created_at.strftime("%d.%m.%Y %H:%M:%S") }}</td>
@@ -55,13 +55,13 @@
   <div class="tab-pane fade" id="inventorylogs" role="tabpanel" aria-labelledby="inventorylogs-tab">
     <div class="card p-0">
       <div class="p-2 d-flex justify-content-end gap-2">
-        <select id="filterInventoryAction" class="form-select form-select-sm" style="max-width:160px;">
-          <option value="">İşlem...</option>
-          {% for key, val in islem_map.items() %}
-          <option value="{{ key }}">{{ val }}</option>
+        <select id="filterInventoryNo" class="form-select form-select-sm" style="max-width:160px;">
+          <option value="">Envanter No...</option>
+          {% for no in inventory_numbers %}
+          <option value="{{ no }}">{{ no }}</option>
           {% endfor %}
         </select>
-        <input type="text" id="searchInventoryLogs" class="form-control form-control-sm" placeholder="Ara..." style="max-width:200px;">
+        <input type="text" id="searchInventoryLogs" class="form-control form-control-sm py-0" placeholder="Ara..." style="max-width:200px;">
       </div>
       <div class="table-responsive">
         <table class="table table-sm table-striped mb-0">
@@ -78,7 +78,7 @@
           <tbody>
           {% for log, inv_no in inventory_logs %}
             <tr>
-              <td>{{ inv_no }}</td>
+              <td data-inv="{{ inv_no }}">{{ inv_no }}</td>
               <!-- İşlem Türkçeleştirme -->
               <td data-action="{{ log.action }}">{{ islem_map.get(log.action, log.action) }}</td>
 


### PR DESCRIPTION
## Summary
- pull user list and inventory numbers server-side to drive filters
- add dropdown filters for user names and inventory numbers with compact search fields
- generalize logs filtering script to handle attribute-based selections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b58139da40832bb3c19c82a1f568ae