### PR TITLE
Prevent duplicate navigation on inventory actions

### DIFF
--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -407,6 +407,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // İşlem seçimi
   document.querySelectorAll('.action-select').forEach(sel => {
     sel.addEventListener('change', async (e) => {
+      e.stopImmediatePropagation();
       const id = e.target.dataset.id;
       const val = e.target.value;
       if (!val) return;


### PR DESCRIPTION
## Summary
- Avoid triggering default action routing when assigning inventory items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5832eb568832b9813689276c66fc8