### PR TITLE
Remove manual operation selection for stock entry

### DIFF
--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -34,6 +34,7 @@ chkIsLicense?.addEventListener('change', e=>{
 document.getElementById('frmStockAdd')?.addEventListener('submit', async (e)=>{
   e.preventDefault();
   const fd = new FormData(e.target);
+  fd.set('islem', 'girdi');
   if(chkIsLicense?.checked){
     fd.set('miktar','1');
     fd.set('donanim_tipi', fd.get('lisans_adi')||'');

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -146,15 +146,6 @@
           </div>
         </div>
 
-        <div class="col-md-3">
-          <label class="form-label">İşlem</label>
-          <select id="islem" name="islem" class="form-select" required>
-            <option value="">Seçiniz</option>
-            <option value="girdi">Girdi</option>
-            <option value="cikti">Çıktı</option>
-            <option value="hurda">Hurda</option>
-          </select>
-        </div>
       </div>
       <div class="modal-footer">
         <button class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>


### PR DESCRIPTION
## Summary
- Remove manual operation selection from stock add modal
- Default stock addition to "girdi" automatically when saving

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b583e2ad78832b9de8c533701e2568