### PR TITLE
Remove operation field from stock add form

### DIFF
--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -34,7 +34,6 @@ chkIsLicense?.addEventListener('change', e=>{
 document.getElementById('frmStockAdd')?.addEventListener('submit', async (e)=>{
   e.preventDefault();
   const fd = new FormData(e.target);
-  fd.set('islem', 'girdi');
   if(chkIsLicense?.checked){
     fd.set('miktar','1');
     fd.set('donanim_tipi', fd.get('lisans_adi')||'');

--- a/templates/stock_add.html
+++ b/templates/stock_add.html
@@ -13,14 +13,6 @@
     <label class="form-label">IFS No (opsiyonel)</label>
     <input type="text" name="ifs_no" class="form-control">
   </div>
-  <div class="col-md-6">
-    <label class="form-label">İşlem</label>
-    <select name="islem" class="form-select" required>
-      <option value="girdi">Girdi</option>
-      <option value="cikti">Çıktı</option>
-      <option value="hurda">Hurda</option>
-    </select>
-  </div>
 </div>
 <script>
   // donanım tipleri lookup


### PR DESCRIPTION
## Summary
- Remove operation selection from stock add template
- Stop sending operation field in stock add JS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b586ca64e4832ba1e29887db275360