### PR TITLE
Add animated network background

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,9 +10,6 @@
   <style>
     html, body {
       height:100%;
-      background: url('{{ url_for('static', path='img/network-bg.svg') }}')
-                  no-repeat center center fixed;
-      background-size: cover;
     }
     nav.navbar, .container-fluid { position:relative; z-index:1; }
   </style>
@@ -198,5 +195,75 @@ window.addEventListener("message", (e) => {
     }
     </style>
     {% endblock %}
+    <canvas id="bg"></canvas>
+
+    <style>
+      body {
+        margin:0;
+        background: linear-gradient(180deg,#dbeafe,#bfdbfe); /* açık mavi degrade */
+      }
+      #bg {
+        position:fixed;
+        inset:0;
+        z-index:-1;
+      }
+    </style>
+
+    <script>
+    const canvas=document.getElementById("bg"),ctx=canvas.getContext("2d");
+    let w,h;
+    function resize(){
+      w=canvas.width=innerWidth;
+      h=canvas.height=innerHeight;
+    }
+    window.addEventListener("resize",resize);
+    resize();
+
+    // parçacıklar
+    let particles=[];
+    for(let i=0;i<80;i++){ // nokta sayısı
+      particles.push({
+        x:Math.random()*w,
+        y:Math.random()*h,
+        vx:(Math.random()-.5)*0.3,  // x hızı
+        vy:(Math.random()-.5)*0.3   // y hızı
+      });
+    }
+
+    function draw(){
+      ctx.clearRect(0,0,w,h);
+
+      // noktalar
+      for(let p of particles){
+        p.x+=p.vx; p.y+=p.vy;
+        if(p.x<0||p.x>w) p.vx*=-1;
+        if(p.y<0||p.y>h) p.vy*=-1;
+
+        ctx.beginPath();
+        ctx.arc(p.x,p.y,2,0,Math.PI*2);
+        ctx.fillStyle="rgba(0,120,255,0.7)";
+        ctx.fill();
+      }
+
+      // çizgiler
+      for(let i=0;i<particles.length;i++){
+        for(let j=i+1;j<particles.length;j++){
+          let dx=particles[i].x-particles[j].x;
+          let dy=particles[i].y-particles[j].y;
+          let dist=Math.sqrt(dx*dx+dy*dy);
+          if(dist<140){ // mesafe limit
+            ctx.strokeStyle="rgba(0,120,255,"+(1-dist/140)*0.4+")";
+            ctx.beginPath();
+            ctx.moveTo(particles[i].x,particles[i].y);
+            ctx.lineTo(particles[j].x,particles[j].y);
+            ctx.stroke();
+          }
+        }
+      }
+
+      requestAnimationFrame(draw);
+    }
+    draw();
+    </script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- Replace static background with animated canvas-based blue network
- Add gradient background and particle movement script for all pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5966724b4832b8f60acf1850c1d85