### PR TITLE
Add profile theme selection with multiple styles

### DIFF
--- a/app.py
+++ b/app.py
@@ -252,6 +252,7 @@ async def login_submit(
     request.session["user_id"] = user.id
     request.session["user_name"] = user.full_name or user.username
     request.session["user_role"] = getattr(user, "role", "")
+    request.session["user_theme"] = getattr(user, "theme", "default")
     _ensure_csrf(request)  # token yenile
     response = RedirectResponse(url="/dashboard", status_code=status.HTTP_303_SEE_OTHER)
     if remember:

--- a/models.py
+++ b/models.py
@@ -60,6 +60,7 @@ class User(Base):
     # E-posta artık opsiyonel ve benzersiz
     email: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True)
     role: Mapped[str] = mapped_column(String(16), default="admin")  # admin/staff/user
+    theme: Mapped[str] = mapped_column(String(20), default="default")
     created_at: Mapped[str] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/routers/profile.py
+++ b/routers/profile.py
@@ -1,6 +1,6 @@
 # routers/profile.py
-from fastapi import APIRouter, Request, Depends
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, Request, Depends, Form, status
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
@@ -20,6 +20,7 @@ async def profile_home(
     u = db.get(User, user.id)
     first_name = u.first_name if u and u.first_name else ""
     last_name = u.last_name if u and u.last_name else ""
+    theme = u.theme if u and getattr(u, "theme", None) else "default"
     return templates.TemplateResponse(
         "profile/index.html",
         {
@@ -27,5 +28,22 @@ async def profile_home(
             "user": user,
             "first_name": first_name,
             "last_name": last_name,
+            "theme": theme,
         },
     )
+
+
+@router.post("/theme")
+async def update_theme(
+    request: Request,
+    theme: str = Form(...),
+    db: Session = Depends(get_db),
+    user: SessionUser = Depends(current_user),
+):
+    u = db.get(User, user.id)
+    if u:
+        u.theme = theme
+        db.add(u)
+        db.commit()
+        request.session["user_theme"] = theme
+    return RedirectResponse(url="/profile", status_code=status.HTTP_303_SEE_OTHER)

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
   </style>
   <title>{% block title %}{% endblock %}</title>
 </head>
-<body>
+<body class="theme-{{ request.session.get('user_theme', 'default') }}">
   <nav class="navbar navbar-light bg-transparent p-3 pb-0">
     <div class="container-fluid">
       <a class="navbar-brand fw-semibold"></a>
@@ -198,9 +198,26 @@ window.addEventListener("message", (e) => {
     <canvas id="bg"></canvas>
 
     <style>
-      body {
-        margin:0;
-        background: linear-gradient(180deg,#dbeafe,#bfdbfe); /* açık mavi degrade */
+      body { margin:0; }
+      body.theme-default {
+        background: linear-gradient(180deg,#dbeafe,#bfdbfe);
+      }
+      body.theme-dark {
+        background:#1f1f1f;
+        color:#f8f9fa;
+      }
+      body.theme-dark .soft-card,
+      body.theme-dark .card { background:#2c2c2c; }
+      body.theme-dark .side-link { color:#f8f9fa; }
+      body.theme-dark .side-link:hover { background:#3a3a3a; }
+      body.theme-green {
+        background: linear-gradient(180deg,#e8f5e9,#a5d6a7);
+      }
+      body.theme-red {
+        background: linear-gradient(180deg,#ffebee,#ffcdd2);
+      }
+      body.theme-purple {
+        background: linear-gradient(180deg,#f3e5f5,#d1c4e9);
       }
       #bg {
         position:fixed;

--- a/templates/profile/index.html
+++ b/templates/profile/index.html
@@ -7,4 +7,19 @@
   <div class="mb-2"><strong>Soyad:</strong> {{ last_name }}</div>
   <div class="mb-2"><strong>E-posta:</strong> {{ user.email or '' }}</div>
 </div>
+<div class="card p-3 mt-3">
+  <form method="post" action="/profile/theme">
+    <div class="mb-3">
+      <label for="themeSelect" class="form-label">Tema</label>
+      <select name="theme" id="themeSelect" class="form-select">
+        <option value="default" {% if theme == 'default' %}selected{% endif %}>Varsayılan</option>
+        <option value="dark" {% if theme == 'dark' %}selected{% endif %}>Koyu</option>
+        <option value="green" {% if theme == 'green' %}selected{% endif %}>Yeşil</option>
+        <option value="red" {% if theme == 'red' %}selected{% endif %}>Kırmızı</option>
+        <option value="purple" {% if theme == 'purple' %}selected{% endif %}>Mor</option>
+      </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Kaydet</button>
+  </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow users to choose from several visual themes in their profile
- persist chosen theme and apply it across the app

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5978e5f2c832b8b7f842461a4faea