### PR TITLE
Add migration for missing user theme column

### DIFF
--- a/models.py
+++ b/models.py
@@ -467,6 +467,12 @@ def init_db():
             conn.execute(
                 text("ALTER TABLE users ADD COLUMN role VARCHAR(16) DEFAULT 'admin'")
             )
+        if "theme" not in cols:
+            conn.execute(
+                text(
+                    "ALTER TABLE users ADD COLUMN theme VARCHAR(20) DEFAULT 'default'"
+                )
+            )
         if "created_at" not in cols:
             conn.execute(
                 text(

--- a/tests/test_theme_migration.py
+++ b/tests/test_theme_migration.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+import pytest
+from sqlalchemy import inspect
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_init_db_adds_theme_column(tmp_path):
+    db_file = tmp_path / "theme.db"
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_file}"
+    import models
+    importlib.reload(models)
+
+    with models.engine.begin() as conn:
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY, 
+                username VARCHAR(64) UNIQUE,
+                password_hash VARCHAR(255),
+                first_name VARCHAR(60) DEFAULT '',
+                last_name VARCHAR(60) DEFAULT '',
+                full_name VARCHAR(120) DEFAULT '',
+                email VARCHAR(255),
+                role VARCHAR(16) DEFAULT 'admin',
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+    models.init_db()
+
+    insp = inspect(models.engine)
+    cols = {c["name"] for c in insp.get_columns("users")}
+    assert "theme" in cols
+
+    # restore default in-memory database for subsequent tests
+    models.engine.dispose()
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    importlib.reload(models)


### PR DESCRIPTION
## Summary
- ensure `init_db` adds the `theme` column to existing `users` tables
- add regression test covering user theme migration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b598c6531c832bba69e10e9eee5d99