### PR TITLE
Add customizable background animations to profile theme

### DIFF
--- a/app.py
+++ b/app.py
@@ -253,6 +253,7 @@ async def login_submit(
     request.session["user_name"] = user.full_name or user.username
     request.session["user_role"] = getattr(user, "role", "")
     request.session["user_theme"] = getattr(user, "theme", "default")
+    request.session["user_anim"] = getattr(user, "animation", "none")
     _ensure_csrf(request)  # token yenile
     response = RedirectResponse(url="/dashboard", status_code=status.HTTP_303_SEE_OTHER)
     if remember:

--- a/models.py
+++ b/models.py
@@ -61,6 +61,7 @@ class User(Base):
     email: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True)
     role: Mapped[str] = mapped_column(String(16), default="admin")  # admin/staff/user
     theme: Mapped[str] = mapped_column(String(20), default="default")
+    animation: Mapped[str] = mapped_column(String(20), default="none")
     created_at: Mapped[str] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -471,6 +472,12 @@ def init_db():
             conn.execute(
                 text(
                     "ALTER TABLE users ADD COLUMN theme VARCHAR(20) DEFAULT 'default'"
+                )
+            )
+        if "animation" not in cols:
+            conn.execute(
+                text(
+                    "ALTER TABLE users ADD COLUMN animation VARCHAR(20) DEFAULT 'none'"
                 )
             )
         if "created_at" not in cols:

--- a/routers/profile.py
+++ b/routers/profile.py
@@ -21,6 +21,7 @@ async def profile_home(
     first_name = u.first_name if u and u.first_name else ""
     last_name = u.last_name if u and u.last_name else ""
     theme = u.theme if u and getattr(u, "theme", None) else "default"
+    animation = u.animation if u and getattr(u, "animation", None) else "none"
     return templates.TemplateResponse(
         "profile/index.html",
         {
@@ -29,6 +30,7 @@ async def profile_home(
             "first_name": first_name,
             "last_name": last_name,
             "theme": theme,
+            "animation": animation,
         },
     )
 
@@ -37,13 +39,16 @@ async def profile_home(
 async def update_theme(
     request: Request,
     theme: str = Form(...),
+    animation: str = Form(...),
     db: Session = Depends(get_db),
     user: SessionUser = Depends(current_user),
 ):
     u = db.get(User, user.id)
     if u:
         u.theme = theme
+        u.animation = animation
         db.add(u)
         db.commit()
         request.session["user_theme"] = theme
+        request.session["user_anim"] = animation
     return RedirectResponse(url="/profile", status_code=status.HTTP_303_SEE_OTHER)

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
   </style>
   <title>{% block title %}{% endblock %}</title>
 </head>
-<body class="theme-{{ request.session.get('user_theme', 'default') }}">
+<body class="theme-{{ request.session.get('user_theme', 'default') }} anim-{{ request.session.get('user_anim', 'none') }}">
   <nav class="navbar navbar-light bg-transparent p-3 pb-0">
     <div class="container-fluid">
       <a class="navbar-brand fw-semibold"></a>
@@ -219,6 +219,16 @@ window.addEventListener("message", (e) => {
       body.theme-purple {
         background: linear-gradient(180deg,#f3e5f5,#d1c4e9);
       }
+      body.anim-gradient {
+        background-size:400% 400%;
+        animation: gradientMove 15s ease infinite;
+      }
+      @keyframes gradientMove {
+        0% {background-position:0% 50%;}
+        50% {background-position:100% 50%;}
+        100% {background-position:0% 50%;}
+      }
+      body:not(.anim-particles) #bg { display:none; }
       #bg {
         position:fixed;
         inset:0;
@@ -227,60 +237,62 @@ window.addEventListener("message", (e) => {
     </style>
 
     <script>
-    const canvas=document.getElementById("bg"),ctx=canvas.getContext("2d");
-    let w,h;
-    function resize(){
-      w=canvas.width=innerWidth;
-      h=canvas.height=innerHeight;
-    }
-    window.addEventListener("resize",resize);
-    resize();
+    if (document.body.classList.contains("anim-particles")) {
+      const canvas=document.getElementById("bg"),ctx=canvas.getContext("2d");
+      let w,h;
+      function resize(){
+        w=canvas.width=innerWidth;
+        h=canvas.height=innerHeight;
+      }
+      window.addEventListener("resize",resize);
+      resize();
 
-    // parçacıklar
-    let particles=[];
-    for(let i=0;i<80;i++){ // nokta sayısı
-      particles.push({
-        x:Math.random()*w,
-        y:Math.random()*h,
-        vx:(Math.random()-.5)*0.3,  // x hızı
-        vy:(Math.random()-.5)*0.3   // y hızı
-      });
-    }
-
-    function draw(){
-      ctx.clearRect(0,0,w,h);
-
-      // noktalar
-      for(let p of particles){
-        p.x+=p.vx; p.y+=p.vy;
-        if(p.x<0||p.x>w) p.vx*=-1;
-        if(p.y<0||p.y>h) p.vy*=-1;
-
-        ctx.beginPath();
-        ctx.arc(p.x,p.y,2,0,Math.PI*2);
-        ctx.fillStyle="rgba(0,120,255,0.7)";
-        ctx.fill();
+      // parçacıklar
+      let particles=[];
+      for(let i=0;i<80;i++){ // nokta sayısı
+        particles.push({
+          x:Math.random()*w,
+          y:Math.random()*h,
+          vx:(Math.random()-.5)*0.3,  // x hızı
+          vy:(Math.random()-.5)*0.3   // y hızı
+        });
       }
 
-      // çizgiler
-      for(let i=0;i<particles.length;i++){
-        for(let j=i+1;j<particles.length;j++){
-          let dx=particles[i].x-particles[j].x;
-          let dy=particles[i].y-particles[j].y;
-          let dist=Math.sqrt(dx*dx+dy*dy);
-          if(dist<140){ // mesafe limit
-            ctx.strokeStyle="rgba(0,120,255,"+(1-dist/140)*0.4+")";
-            ctx.beginPath();
-            ctx.moveTo(particles[i].x,particles[i].y);
-            ctx.lineTo(particles[j].x,particles[j].y);
-            ctx.stroke();
+      function draw(){
+        ctx.clearRect(0,0,w,h);
+
+        // noktalar
+        for(let p of particles){
+          p.x+=p.vx; p.y+=p.vy;
+          if(p.x<0||p.x>w) p.vx*=-1;
+          if(p.y<0||p.y>h) p.vy*=-1;
+
+          ctx.beginPath();
+          ctx.arc(p.x,p.y,2,0,Math.PI*2);
+          ctx.fillStyle="rgba(0,120,255,0.7)";
+          ctx.fill();
+        }
+
+        // çizgiler
+        for(let i=0;i<particles.length;i++){
+          for(let j=i+1;j<particles.length;j++){
+            let dx=particles[i].x-particles[j].x;
+            let dy=particles[i].y-particles[j].y;
+            let dist=Math.sqrt(dx*dx+dy*dy);
+            if(dist<140){ // mesafe limit
+              ctx.strokeStyle="rgba(0,120,255,"+(1-dist/140)*0.4+")";
+              ctx.beginPath();
+              ctx.moveTo(particles[i].x,particles[i].y);
+              ctx.lineTo(particles[j].x,particles[j].y);
+              ctx.stroke();
+            }
           }
         }
-      }
 
-      requestAnimationFrame(draw);
+        requestAnimationFrame(draw);
+      }
+      draw();
     }
-    draw();
     </script>
   </body>
   </html>

--- a/templates/profile/index.html
+++ b/templates/profile/index.html
@@ -19,6 +19,14 @@
         <option value="purple" {% if theme == 'purple' %}selected{% endif %}>Mor</option>
       </select>
     </div>
+    <div class="mb-3">
+      <label for="animationSelect" class="form-label">Animasyon</label>
+      <select name="animation" id="animationSelect" class="form-select">
+        <option value="none" {% if animation == 'none' %}selected{% endif %}>Yok</option>
+        <option value="particles" {% if animation == 'particles' %}selected{% endif %}>Parçacıklar</option>
+        <option value="gradient" {% if animation == 'gradient' %}selected{% endif %}>Gradyan</option>
+      </select>
+    </div>
     <button type="submit" class="btn btn-primary">Kaydet</button>
   </form>
 </div>

--- a/tests/test_theme_migration.py
+++ b/tests/test_theme_migration.py
@@ -9,7 +9,7 @@ from sqlalchemy import inspect
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 
-def test_init_db_adds_theme_column(tmp_path):
+def test_init_db_adds_theme_and_animation_columns(tmp_path):
     db_file = tmp_path / "theme.db"
     os.environ["DATABASE_URL"] = f"sqlite:///{db_file}"
     import models
@@ -37,6 +37,7 @@ def test_init_db_adds_theme_column(tmp_path):
     insp = inspect(models.engine)
     cols = {c["name"] for c in insp.get_columns("users")}
     assert "theme" in cols
+    assert "animation" in cols
 
     # restore default in-memory database for subsequent tests
     models.engine.dispose()


### PR DESCRIPTION
## Summary
- allow users to choose background animations alongside color themes
- store animation preference in user record and session
- animate gradient backgrounds or particle canvas based on selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b59a13e7ac832b9985bd2552e81f88