### PR TITLE
Fix unclickable pages by disabling background canvas pointer events

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -233,6 +233,7 @@ window.addEventListener("message", (e) => {
         position:fixed;
         inset:0;
         z-index:-1;
+        pointer-events:none;
       }
     </style>
 


### PR DESCRIPTION
## Summary
- prevent background animation canvas from intercepting user clicks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a1dfd8ec832b959dcaa8f60b9a14