### PR TITLE
Fix modal overlay blocking add dialogs

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,8 @@
     html, body {
       height:100%;
     }
-    nav.navbar, .container-fluid { position:relative; z-index:1; }
+    nav.navbar, .container-fluid { position:relative; }
+    nav.navbar { z-index:1; }
   </style>
   <title>{% block title %}{% endblock %}</title>
 </head>


### PR DESCRIPTION
## Summary
- prevent `.container-fluid` z-index from covering modals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a3bd1738832bab9cc4e7ed3974d7