### PR TITLE
Remove spacing between nav tabs

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -53,3 +53,14 @@
   box-shadow: none;
   outline: none;
 }
+
+/* Remove spacing between adjacent nav tabs to match admin panel styling */
+.nav-tabs .nav-link {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
+.nav-tabs .nav-item {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}


### PR DESCRIPTION
## Summary
- Remove extra spacing around nav tab buttons to match admin panel styling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a90bc534832b8840103b678503de