### PR TITLE
Simplify request creation

### DIFF
--- a/routers/requests.py
+++ b/routers/requests.py
@@ -101,30 +101,21 @@ async def list_requests(request: Request, db: Session = Depends(get_db)):
 
 @router.post("/", response_class=JSONResponse)
 async def create_request(
-    tur: TalepTuru = Form(...),
     donanim_tipi: Optional[str] = Form(None),
     ifs_no: Optional[str] = Form(None),
     miktar: Optional[int] = Form(None),
     marka: Optional[str] = Form(None),
     model: Optional[str] = Form(None),
-    envanter_no: Optional[str] = Form(None),
-    sorumlu_personel: Optional[str] = Form(None),
-    bagli_envanter_no: Optional[str] = Form(None),
-    lisans_adi: Optional[str] = Form(None),
     aciklama: Optional[str] = Form(None),
     db: Session = Depends(get_db),
 ):
     talep = Talep(
-        tur=tur,
+        tur=TalepTuru.AKSESUAR,
         donanim_tipi=donanim_tipi,
         ifs_no=ifs_no,
         miktar=miktar,
         marka=marka,
         model=model,
-        envanter_no=envanter_no,
-        sorumlu_personel=sorumlu_personel,
-        bagli_envanter_no=bagli_envanter_no,
-        lisans_adi=lisans_adi,
         aciklama=aciklama,
     )
     db.add(talep)

--- a/routes/talepler.py
+++ b/routes/talepler.py
@@ -34,30 +34,21 @@ def liste(request: Request, db: Session = Depends(get_db)):
 
 @router.post("", response_class=JSONResponse)
 def olustur(
-    tur: TalepTuru = Form(...),
     donanim_tipi: Optional[str] = Form(None),
     ifs_no: Optional[str] = Form(None),
     miktar: Optional[int] = Form(None),
     marka: Optional[str] = Form(None),
     model: Optional[str] = Form(None),
-    envanter_no: Optional[str] = Form(None),
-    sorumlu_personel: Optional[str] = Form(None),
-    bagli_envanter_no: Optional[str] = Form(None),
-    lisans_adi: Optional[str] = Form(None),
     aciklama: Optional[str] = Form(None),
     db: Session = Depends(get_db),
 ):
     talep = Talep(
-        tur=tur,
+        tur=TalepTuru.AKSESUAR,
         donanim_tipi=donanim_tipi,
         ifs_no=ifs_no,
         miktar=miktar,
         marka=marka,
         model=model,
-        envanter_no=envanter_no,
-        sorumlu_personel=sorumlu_personel,
-        bagli_envanter_no=bagli_envanter_no,
-        lisans_adi=lisans_adi,
         aciklama=aciklama,
     )
     db.add(talep)

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -82,51 +82,27 @@
       <div class="modal-body">
         <div id="talepRows">
           <div class="talep-row row g-2 align-items-end mb-2">
-            <div class="col-md-2">
-              <label class="form-label">Talep Türü</label>
-              <select class="form-select tur" name="tur">
-                <option value="envanter">Envanter</option>
-                <option value="lisans">Lisans</option>
-                <option value="aksesuar">Aksesuar</option>
-              </select>
-            </div>
-            <div class="col-md-2 envanter-field">
-              <label class="form-label">Envanter No</label>
-              <input name="envanter_no" class="form-control" placeholder="Envanter No">
-            </div>
-            <div class="col-md-2 envanter-field">
-              <label class="form-label">Sorumlu</label>
-              <input name="sorumlu_personel" class="form-control" placeholder="Ad Soyad">
-            </div>
-            <div class="col-md-2 envanter-field">
-              <label class="form-label">Bağlı Envanter</label>
-              <input name="bagli_envanter_no" class="form-control" placeholder="Bağlı Envanter No">
-            </div>
-            <div class="col-md-2 lisans-field d-none">
-              <label class="form-label">Lisans Adı</label>
-              <input name="lisans_adi" class="form-control" placeholder="Lisans Adı">
-            </div>
-            <div class="col-md-2 aksesuar-field d-none">
+            <div class="col-md-3">
               <label class="form-label">Donanım Tipi</label>
               <select name="donanim_tipi" class="form-select">
                 <option value="">Seçiniz...</option>
               </select>
             </div>
-            <div class="col-md-2 aksesuar-field d-none">
-              <label class="form-label">IFS No</label>
-              <input name="ifs_no" class="form-control" placeholder="IFS No">
-            </div>
-            <div class="col-md-1 aksesuar-field d-none">
+            <div class="col-md-1">
               <label class="form-label">Miktar</label>
               <input name="miktar" type="number" min="1" class="form-control" placeholder="Miktar">
             </div>
-            <div class="col-md-2 aksesuar-field d-none">
+            <div class="col-md-2">
               <label class="form-label">Marka</label>
-              <input name="marka" class="form-control" placeholder="Marka">
+              <select name="marka" class="form-select">
+                <option value="">Seçiniz...</option>
+              </select>
             </div>
-            <div class="col-md-2 aksesuar-field d-none">
+            <div class="col-md-2">
               <label class="form-label">Model</label>
-              <input name="model" class="form-control" placeholder="Model">
+              <select name="model" class="form-select">
+                <option value="">Seçiniz...</option>
+              </select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Açıklama</label>
@@ -150,40 +126,51 @@
 
 <script>
   const rowContainer = document.getElementById('talepRows');
-  const templateRow = rowContainer.firstElementChild.cloneNode(true);
-
-  function addRow() {
-    const clone = templateRow.cloneNode(true);
-    clone.querySelectorAll('input').forEach(i => i.value = '');
-    clone.querySelectorAll('select').forEach(s => s.selectedIndex = 0);
-    rowContainer.appendChild(clone);
-    bindRow(clone);
-  }
+  let templateRow;
 
   function bindRow(row) {
-    const tur = row.querySelector('.tur');
-    function toggle() {
-      const val = tur.value;
-      row.querySelectorAll('.envanter-field').forEach(e => e.classList.toggle('d-none', val !== 'envanter'));
-      row.querySelectorAll('.lisans-field').forEach(e => e.classList.toggle('d-none', val !== 'lisans'));
-      row.querySelectorAll('.aksesuar-field').forEach(e => e.classList.toggle('d-none', val !== 'aksesuar'));
-    }
-    tur.addEventListener('change', toggle);
-    toggle();
+    const markaSel = row.querySelector('select[name="marka"]');
+    const modelSel = row.querySelector('select[name="model"]');
+    markaSel.addEventListener('change', () => {
+      const id = markaSel.selectedOptions[0]?.dataset.id || '';
+      modelSel.innerHTML = '<option value="">Seçiniz...</option>';
+      if (!id) return;
+      fetch(`/api/lookup/model?marka_id=${id}`).then(r=>r.json()).then(list=>{
+        const opts = list.map(n=>`<option value="${n.name ?? n}">${n.name ?? n}</option>`).join('');
+        modelSel.insertAdjacentHTML('beforeend', opts);
+      });
+    });
 
     row.querySelector('.add-row').addEventListener('click', addRow);
-
     row.querySelector('.remove-row').addEventListener('click', () => {
       if (rowContainer.children.length > 1) row.remove();
     });
   }
 
-  bindRow(rowContainer.firstElementChild);
+  function addRow() {
+    const clone = templateRow.cloneNode(true);
+    clone.querySelectorAll('input').forEach(i => i.value = '');
+    clone.querySelectorAll('select').forEach(sel => {
+      sel.selectedIndex = 0;
+      if (sel.name === 'model') sel.innerHTML = '<option value="">Seçiniz...</option>';
+    });
+    rowContainer.appendChild(clone);
+    bindRow(clone);
+  }
 
-  // donanım tipleri
-  fetch('/api/lookup/donanim_tipi').then(r=>r.json()).then(list=>{
-    const opts = list.map(n=>`<option value="${n}">${n}</option>`).join('');
-    document.querySelectorAll('select[name="donanim_tipi"]').forEach(sel=>sel.insertAdjacentHTML('beforeend', opts));
+  const lookups = Promise.all([
+    fetch('/api/lookup/donanim_tipi').then(r=>r.json()),
+    fetch('/api/lookup/marka').then(r=>r.json()),
+  ]);
+
+  lookups.then(([donanimList, markaList]) => {
+    const donanimOpts = donanimList.map(n=>`<option value="${n.name ?? n}">${n.name ?? n}</option>`).join('');
+    const markaOpts = markaList.map(n=>`<option value="${n.name ?? n}" data-id="${n.id ?? ''}">${n.name ?? n}</option>`).join('');
+    const firstRow = rowContainer.firstElementChild;
+    firstRow.querySelector('select[name="donanim_tipi"]').insertAdjacentHTML('beforeend', donanimOpts);
+    firstRow.querySelector('select[name="marka"]').insertAdjacentHTML('beforeend', markaOpts);
+    templateRow = firstRow.cloneNode(true);
+    bindRow(firstRow);
   });
 
   async function talepGonder(e) {

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -105,49 +105,29 @@
         </div>
         <div id="talepRows">
           <div class="talep-row row g-2 align-items-end mb-2 flex-nowrap">
-            <div class="col-md-2">
-              <label class="form-label">Talep Türü</label>
-              <select class="form-select tur" name="tur">
-                <option value="envanter">Envanter</option>
-                <option value="lisans">Lisans</option>
-                <option value="aksesuar">Aksesuar</option>
-              </select>
-            </div>
-            <div class="col-md-2 d-none" data-types="envanter">
-              <label class="form-label">Envanter No</label>
-              <input name="envanter_no" class="form-control" placeholder="Envanter No">
-            </div>
-            <div class="col-md-2 d-none" data-types="envanter,lisans">
-              <label class="form-label">Sorumlu</label>
-              <input name="sorumlu_personel" class="form-control" placeholder="Ad Soyad">
-            </div>
-            <div class="col-md-2 d-none" data-types="envanter,lisans">
-              <label class="form-label">Bağlı Envanter</label>
-              <input name="bagli_envanter_no" class="form-control" placeholder="Bağlı Envanter No">
-            </div>
-            <div class="col-md-2 d-none" data-types="lisans">
-              <label class="form-label">Lisans Adı</label>
-              <input name="lisans_adi" class="form-control" placeholder="Lisans Adı">
-            </div>
-            <div class="col-md-2 d-none" data-types="aksesuar">
+            <div class="col-md-3">
               <label class="form-label">Donanım Tipi</label>
               <select name="donanim_tipi" class="form-select">
                 <option value="">Seçiniz...</option>
               </select>
             </div>
-            <div class="col-md-1 d-none" data-types="aksesuar">
+            <div class="col-md-1">
               <label class="form-label">Miktar</label>
               <input name="miktar" type="number" min="1" class="form-control" placeholder="Miktar">
             </div>
-            <div class="col-md-2 d-none" data-types="aksesuar">
+            <div class="col-md-2">
               <label class="form-label">Marka</label>
-              <input name="marka" class="form-control" placeholder="Marka">
-            </div>
-            <div class="col-md-2 d-none" data-types="aksesuar">
-              <label class="form-label">Model</label>
-              <input name="model" class="form-control" placeholder="Model">
+              <select name="marka" class="form-select">
+                <option value="">Seçiniz...</option>
+              </select>
             </div>
             <div class="col-md-2">
+              <label class="form-label">Model</label>
+              <select name="model" class="form-select">
+                <option value="">Seçiniz...</option>
+              </select>
+            </div>
+            <div class="col-md-3">
               <label class="form-label">Not</label>
               <input name="aciklama" class="form-control" placeholder="Not">
             </div>
@@ -169,40 +149,51 @@
 
 <script>
   const rowContainer = document.getElementById('talepRows');
-  const templateRow = rowContainer.firstElementChild.cloneNode(true);
-
-  function addRow() {
-    const clone = templateRow.cloneNode(true);
-    clone.querySelectorAll('input').forEach(i => i.value = '');
-    clone.querySelectorAll('select').forEach(s => s.selectedIndex = 0);
-    rowContainer.appendChild(clone);
-    bindRow(clone);
-  }
+  let templateRow;
 
   function bindRow(row) {
-    const tur = row.querySelector('.tur');
-    function toggle() {
-      const val = tur.value;
-      row.querySelectorAll('[data-types]').forEach(el => {
-        const types = el.dataset.types.split(',');
-        el.classList.toggle('d-none', !types.includes(val));
+    const markaSel = row.querySelector('select[name="marka"]');
+    const modelSel = row.querySelector('select[name="model"]');
+    markaSel.addEventListener('change', () => {
+      const id = markaSel.selectedOptions[0]?.dataset.id || '';
+      modelSel.innerHTML = '<option value="">Seçiniz...</option>';
+      if (!id) return;
+      fetch(`/api/lookup/model?marka_id=${id}`).then(r=>r.json()).then(list=>{
+        const opts = list.map(n=>`<option value="${n.name ?? n}">${n.name ?? n}</option>`).join('');
+        modelSel.insertAdjacentHTML('beforeend', opts);
       });
-    }
-    tur.addEventListener('change', toggle);
-    toggle();
+    });
 
     row.querySelector('.add-row').addEventListener('click', addRow);
-
     row.querySelector('.remove-row').addEventListener('click', () => {
       if (rowContainer.children.length > 1) row.remove();
     });
   }
 
-  bindRow(rowContainer.firstElementChild);
+  function addRow() {
+    const clone = templateRow.cloneNode(true);
+    clone.querySelectorAll('input').forEach(i => i.value = '');
+    clone.querySelectorAll('select').forEach(sel => {
+      sel.selectedIndex = 0;
+      if (sel.name === 'model') sel.innerHTML = '<option value="">Seçiniz...</option>';
+    });
+    rowContainer.appendChild(clone);
+    bindRow(clone);
+  }
 
-  fetch('/api/lookup/donanim_tipi').then(r=>r.json()).then(list=>{
-    const opts = list.map(n=>`<option value="${n}">${n}</option>`).join('');
-    document.querySelectorAll('select[name="donanim_tipi"]').forEach(sel=>sel.insertAdjacentHTML('beforeend', opts));
+  const lookups = Promise.all([
+    fetch('/api/lookup/donanim_tipi').then(r=>r.json()),
+    fetch('/api/lookup/marka').then(r=>r.json()),
+  ]);
+
+  lookups.then(([donanimList, markaList]) => {
+    const donanimOpts = donanimList.map(n=>`<option value="${n.name ?? n}">${n.name ?? n}</option>`).join('');
+    const markaOpts = markaList.map(n=>`<option value="${n.name ?? n}" data-id="${n.id ?? ''}">${n.name ?? n}</option>`).join('');
+    const firstRow = rowContainer.firstElementChild;
+    firstRow.querySelector('select[name="donanim_tipi"]').insertAdjacentHTML('beforeend', donanimOpts);
+    firstRow.querySelector('select[name="marka"]').insertAdjacentHTML('beforeend', markaOpts);
+    templateRow = firstRow.cloneNode(true);
+    bindRow(firstRow);
   });
 
   async function talepGonder(e) {


### PR DESCRIPTION
## Summary
- remove request type field and default to accessories
- populate hardware type and brand/model from lookup tables
- streamline request forms to only include hardware, quantity, brand, model, note

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5b0580c48832bbcbbcfe1c44e3671