### PR TITLE
Fix Jinja slot rendering in requests template

### DIFF
--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -4,6 +4,11 @@
 {% block title %}Talep Takip{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
+  {% set right_slot %}
+    <a href="{{ url_for('talep_export_excel') }}" class="btn btn-outline-secondary btn-sm">Excel</a>
+    <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#talepModal">Talep Aç</button>
+  {% endset %}
+
   {{ tabs(
       items=[
         {"label":"Aktif","href": url_for('talep_list') ~ "?durum=aktif", "key":"aktif"},
@@ -11,10 +16,7 @@
         {"label":"İptal","href": url_for('talep_list') ~ "?durum=iptal","key":"iptal"},
       ],
       active_key=active_key,
-      right_slot='''
-        <a href="{{ url_for('talep_export_excel') }}" class="btn btn-outline-secondary btn-sm">Excel</a>
-        <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#talepModal">Talep Aç</button>
-      '''
+      right_slot=right_slot
   ) }}
 
   {% macro render_table(rows, empty_msg, show_actions=False) %}


### PR DESCRIPTION
## Summary
- pass `right_slot` content via Jinja block instead of triple quoted string in `talepler.html`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b68a9fbdcc832b95c45d1fd8de4ed3