### PR TITLE
Enable hardware and usage type lookup in API

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -8,9 +8,9 @@ router = APIRouter(prefix="/api", tags=["API"])
 
 # Basit lookup tablosu
 ENTITY_TABLE = {
-    # "donanim_tipi": models.HardwareType,
-    # "kullanim_alani": models.UsageArea,
-    # "license_names": models.LicenseName,  # lisans adlarını ayrı tabloda tutuyorsan
+    "donanim_tipi": models.HardwareType,
+    "kullanim_alani": models.UsageArea,
+    "license_names": models.LicenseName,  # lisans adlarını ayrı tabloda tutuyorsan
 }
 
 

--- a/tests/test_lookup_entity.py
+++ b/tests/test_lookup_entity.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import pytest
+import models
+from routers.api import lookup_entity
+
+
+@pytest.fixture()
+def db_session():
+    models.Base.metadata.create_all(models.engine)
+    db = models.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        models.Base.metadata.drop_all(models.engine)
+
+
+def test_lookup_donanim_tipi(db_session):
+    db = db_session
+    db.add_all([
+        models.HardwareType(name="B"),
+        models.HardwareType(name="A"),
+    ])
+    db.commit()
+
+    res = lookup_entity("donanim_tipi", db=db)
+    assert res == ["A", "B"]


### PR DESCRIPTION
## Summary
- map hardware and usage types for `/api/lookup` endpoint to avoid 404
- test hardware type lookup returns sorted names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b68d1724e4832baf940063d5e8e090