### PR TITLE
Fix Bootstrap table styling across views

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -33,7 +33,7 @@
       </div>
 
       <div class="table-responsive">
-        <table class="table table-sm align-middle">
+        <table class="table table-striped table-hover table-sm align-middle">
           <thead class="table-light">
             <tr><th>#</th><th>Kullanıcı Adı</th><th>Ad</th><th>Soyad</th><th>E-posta</th><th>Rol</th><th class="text-end">İşlemler</th></tr>
           </thead>

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -226,7 +226,7 @@
 
         <!-- Kullanıcı Listesi -->
         <div class="table-responsive">
-          <table class="table table-sm table-hover align-middle" id="userTable">
+          <table class="table table-striped table-hover table-sm align-middle" id="userTable">
             <thead>
               <tr>
                 <th style="width:36px;"></th>

--- a/templates/hurdalar.html
+++ b/templates/hurdalar.html
@@ -15,7 +15,8 @@
   <div class="page-section">
     {% if active_key == "envanter" %}
     <div id="envanter">
-      <table class="table table-striped align-top">
+      <div class="table-responsive">
+        <table class="table table-striped table-hover table-sm align-middle">
         <thead>
           <tr>
             <th>Envanter No</th>
@@ -54,11 +55,13 @@
           </tr>
           {% endfor %}
         </tbody>
-      </table>
+        </table>
+      </div>
     </div>
     {% elif active_key == "lisans" %}
     <div id="lisans">
-      <table class="table table-sm align-middle">
+      <div class="table-responsive">
+        <table class="table table-striped table-hover table-sm align-middle">
         <thead>
           <tr><th>No</th><th>Lisans Adı</th><th>Key</th><th>Sorumlu</th><th>Bağlı Envanter</th><th>Not</th><th></th></tr>
         </thead>
@@ -81,12 +84,13 @@
           <tr><td colspan="7" class="text-muted">Kayıt yok.</td></tr>
           {% endfor %}
         </tbody>
-      </table>
+        </table>
+      </div>
     </div>
     {% else %}
     <div id="yazici">
       <div class="table-responsive">
-        <table class="table table-sm align-middle">
+        <table class="table table-striped table-hover table-sm align-middle">
           <thead class="table-light">
             <tr>
               <th>ID</th>

--- a/templates/logs/index.html
+++ b/templates/logs/index.html
@@ -27,7 +27,7 @@
       <input type="text" id="searchUserLogs" class="form-control form-control-sm py-0" placeholder="Ara..." style="max-width:200px;">
     </div>
     <div class="table-responsive">
-      <table class="table table-sm table-striped mb-0">
+      <table class="table table-striped table-hover table-sm align-middle mb-0">
         <thead>
           <tr>
             <th>Kullanıcı</th>
@@ -63,7 +63,7 @@
       <input type="text" id="searchInventoryLogs" class="form-control form-control-sm py-0" placeholder="Ara..." style="max-width:200px;">
     </div>
     <div class="table-responsive">
-      <table class="table table-sm table-striped mb-0">
+      <table class="table table-striped table-hover table-sm align-middle mb-0">
         <thead>
           <tr>
             <th>Envanter No</th>

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -12,7 +12,7 @@
 
   {% macro render_table(rows, empty_msg) %}
   <div class="table-responsive">
-    <table class="table table-striped table-sm align-middle">
+    <table class="table table-striped table-hover table-sm align-middle">
       <thead>
         <tr>
           <th>#</th><th>Tür</th><th>Donanım Tipi</th><th>Marka</th><th>Model</th><th>Miktar</th>

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -21,7 +21,7 @@
 
   {% macro render_table(rows, empty_msg, show_actions=False) %}
   <div class="table-responsive">
-    <table class="table table-striped table-sm align-middle">
+    <table class="table table-striped table-hover table-sm align-middle">
       <thead>
         <tr>
           <th>#</th><th>Tür</th><th>Donanım Tipi</th><th>Marka</th><th>Model</th><th>Miktar</th>


### PR DESCRIPTION
## Summary
- ensure request tracking tables use responsive striped hover styling
- align scrap, admin, and log tables with Bootstrap table classes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6a39713f8832b85d1b5140f964d98