### PR TITLE
Add navigation tabs for key sections

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Admin Paneli{% endblock %}
+{% from "components/main_tabs.html" import main_tabs %}
 
 {% block content %}
 <div class="container-fluid p-3">
+  {{ main_tabs('admin') }}
 
   <!-- SEKME BAŞLIKLARI -->
   <ul class="nav nav-tabs" id="adminTabs" role="tablist">

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Admin Paneli{% endblock %}
+{% from "components/main_tabs.html" import main_tabs %}
 
 {% block content %}
 <div class="container-fluid p-2">
+  {{ main_tabs('admin') }}
 
 <ul class='nav nav-tabs' id='adminTab' role='tablist'>
   <li class='nav-item' role='presentation'>

--- a/templates/components/main_tabs.html
+++ b/templates/components/main_tabs.html
@@ -1,0 +1,14 @@
+{% from "components/tabs.html" import tabs %}
+{% macro main_tabs(active_key) %}
+  {% set items = [
+    {"label": "Talep Takip", "href": url_for('talep_list'), "key": "talepler"},
+    {"label": "Hurdalar", "href": url_for('inventory.hurdalar'), "key": "hurdalar"}
+  ] %}
+  {% if request.session.get('user_role') == 'admin' %}
+    {% set items = items + [
+      {"label": "Admin Paneli", "href": url_for('admin_index'), "key": "admin"},
+      {"label": "Kayıtlar", "href": url_for('logs_page'), "key": "logs"}
+    ] %}
+  {% endif %}
+  {{ tabs(items=items, active_key=active_key) }}
+{% endmacro %}

--- a/templates/hurdalar.html
+++ b/templates/hurdalar.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
+{% from "components/main_tabs.html" import main_tabs %}
 {% from "components/tabs.html" import tabs %}
 {% set active_key = request.query_params.get("tur") or "envanter" %}
 {% block title %}Hurdalar{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
+  {{ main_tabs('hurdalar') }}
   {{ tabs(
     items=[
       {"label":"Envanter Hurda","href": url_for('inventory.hurdalar') ~ "?tur=envanter","key":"envanter"},

--- a/templates/logs/index.html
+++ b/templates/logs/index.html
@@ -1,8 +1,11 @@
 {% extends "base.html" %}{% block title %}Kayıtlar{% endblock %}
+{% from "components/main_tabs.html" import main_tabs %}
 {% from "components/tabs.html" import tabs %}
 {% set active_key = request.query_params.get("tab") or "kullanici" %}
 {% block content %}
-{% set islem_map = {
+<div class="container-fluid p-3">
+  {{ main_tabs('logs') }}
+  {% set islem_map = {
   "assign": "Atama",
   "edit": "Düzenleme",
   "scrap": "Hurdaya Ayır"

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
+{% from "components/main_tabs.html" import main_tabs %}
 {% from "components/tabs.html" import tabs %}
 {% set active_key = request.query_params.get("durum") or "aktif" %}
 {% block title %}Talep Takip{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
+  {{ main_tabs('talepler') }}
   {% set right_slot %}
     <a href="{{ url_for('talep_export_excel') }}" class="btn btn-outline-secondary btn-sm">Excel</a>
     <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#talepModal">Talep Aç</button>


### PR DESCRIPTION
## Summary
- Add reusable `main_tabs` macro to render Bootstrap nav-tabs for Talep Takip, Hurdalar, Admin Paneli and Kayıtlar
- Include the new navigation tabs on request, scrap, admin and log pages

## Testing
- `pytest` *(fails: command not found)*
- `python3 -m venv venv && venv/bin/pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a5c6bf70832b8b2e6886ce1e5cbb