### PR TITLE
Remove admin page top tab list

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,10 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Admin Paneli{% endblock %}
-{% from "components/main_tabs.html" import main_tabs with context %}
-
 {% block content %}
 <div class="container-fluid p-3">
-  {{ main_tabs('admin') }}
 
   <!-- SEKME BAŞLIKLARI -->
   <ul class="nav nav-tabs" id="adminTabs" role="tablist">

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -1,10 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Admin Paneli{% endblock %}
-{% from "components/main_tabs.html" import main_tabs with context %}
-
 {% block content %}
 <div class="container-fluid p-2">
-  {{ main_tabs('admin') }}
 
 <ul class='nav nav-tabs' id='adminTab' role='tablist'>
   <li class='nav-item' role='presentation'>


### PR DESCRIPTION
## Summary
- remove main tab navigation from admin templates to avoid duplicate list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6afa48970832ba31a9d125ba9468b