### PR TITLE
Remove duplicate top tab list from multiple pages

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,10 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Admin Paneli{% endblock %}
-{% from "components/main_tabs.html" import main_tabs with context %}
-
 {% block content %}
 <div class="container-fluid p-3">
-  {{ main_tabs('admin') }}
 
   <!-- SEKME BAŞLIKLARI -->
   <ul class="nav nav-tabs" id="adminTabs" role="tablist">

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -1,10 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Admin Paneli{% endblock %}
-{% from "components/main_tabs.html" import main_tabs with context %}
-
 {% block content %}
 <div class="container-fluid p-2">
-  {{ main_tabs('admin') }}
 
 <ul class='nav nav-tabs' id='adminTab' role='tablist'>
   <li class='nav-item' role='presentation'>

--- a/templates/hurdalar.html
+++ b/templates/hurdalar.html
@@ -1,11 +1,9 @@
 {% extends "base.html" %}
-{% from "components/main_tabs.html" import main_tabs with context %}
 {% from "components/tabs.html" import tabs %}
 {% set active_key = request.query_params.get("tur") or "envanter" %}
 {% block title %}Hurdalar{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
-  {{ main_tabs('hurdalar') }}
   {{ tabs(
     items=[
       {"label":"Envanter Hurda","href": url_for('inventory.hurdalar') ~ "?tur=envanter","key":"envanter"},

--- a/templates/logs/index.html
+++ b/templates/logs/index.html
@@ -1,10 +1,8 @@
 {% extends "base.html" %}{% block title %}Kayıtlar{% endblock %}
-{% from "components/main_tabs.html" import main_tabs with context %}
 {% from "components/tabs.html" import tabs %}
 {% set active_key = request.query_params.get("tab") or "kullanici" %}
 {% block content %}
 <div class="container-fluid p-3">
-  {{ main_tabs('logs') }}
   {% set islem_map = {
   "assign": "Atama",
   "edit": "Düzenleme",

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -1,11 +1,9 @@
 {% extends "base.html" %}
-{% from "components/main_tabs.html" import main_tabs with context %}
 {% from "components/tabs.html" import tabs %}
 {% set active_key = request.query_params.get("durum") or "aktif" %}
 {% block title %}Talep Takip{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
-  {{ main_tabs('talepler') }}
   {% set right_slot %}
     <a href="{{ url_for('talep_export_excel') }}" class="btn btn-outline-secondary btn-sm">Excel</a>
     <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#talepModal">Talep Aç</button>


### PR DESCRIPTION
## Summary
- remove main tab navigation from admin templates to avoid duplicate list
- remove main tab navigation from request, scrap, and log templates to avoid redundant tabs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6afa48970832ba31a9d125ba9468b