### PR TITLE
Refactor tab styling and markup

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -16,35 +16,46 @@
   </style>
   <title>{% block title %}{% endblock %}</title>
   <style>
-  /* — Sekmeler — */
-  .tabs-wrap .nav-tabs { border-bottom: 0; gap: .25rem; }
-  .tabs-wrap .nav-link{
-    border:1px solid #dee2e6; border-bottom:0;
-    background:#f3f4f6; color:#444; text-decoration:none;
-    border-radius:.9rem .9rem 0 0; padding:.5rem .9rem; margin-bottom:0;
-  }
-  .tabs-wrap .nav-link:hover{ background:#e9ecef; color:#222; }
-  .tabs-wrap .nav-link.active{
-    background:#fff; color:#111; position:relative; z-index:2;
-    border-color:#dee2e6 #dee2e6 #fff; /* alttaki çizgiyi kaldır */
-  }
+/* SEKME + TABLO BİRLEŞTİRME — ÇAKIŞMA KESİN DÜZELTME */
+.tabs-wrap .nav.nav-tabs,
+.tabs-wrap .nav.nav-pills { border-bottom: 0 !important; gap: .25rem; }
 
-  /* — Sekme altı içerik kutusu, tabloyla birleşsin — */
-  .page-section{
-    background:#fff; border:1px solid #dee2e6;
-    border-radius:0 .9rem .9rem .9rem;
-    padding:1rem; margin-top:-1px; /* sekmeyle birleşme */
-  }
+/* Tüm sekmeler (tabs/pills) aynı görünüm */
+.tabs-wrap .nav .nav-link{
+  border: 1px solid #dee2e6 !important;
+  border-bottom: 0 !important;
+  background: #f3f4f6 !important;
+  color: #444 !important;
+  text-decoration: none !important;
+  border-radius: .9rem .9rem 0 0 !important; /* pill değil, sekme */
+  padding: .5rem .9rem !important;
+  margin-bottom: 0 !important;
+  line-height: 1.2 !important;
+}
+.tabs-wrap .nav .nav-link:hover{ background:#e9ecef !important; color:#222 !important; }
 
-  /* — Bootstrap tablo iyileştirmeleri — */
-  .table { margin-bottom:0; }                    /* alt boşluk şişmesin   */
-  .table td, .table th { vertical-align: middle; }
-  .table thead th { white-space: nowrap; }       /* başlıklar taşmasın     */
+/* Aktif sekme: alt sınırı kes ve üstte kalsın */
+.tabs-wrap .nav .nav-link.active{
+  background:#fff !important; color:#111 !important;
+  position: relative !important; z-index: 2 !important;
+  border-color:#dee2e6 #dee2e6 #fff !important;
+}
 
-  /* — Çakışma düzeltmeleri (Tailwind/Preflight kullanan projelerde) — */
-  .nav-tabs .nav-item { margin-bottom:0; }       /* bootstrap default’ı    */
-  .nav-tabs .nav-link.active { border-bottom-color:#fff; }
-  .table-responsive { overflow-y: hidden; }      /* yatay scroll varsa dikey çizgi kırmasın */
+/* Sekme altı kutu */
+.page-section{
+  background:#fff !important; border:1px solid #dee2e6 !important;
+  border-radius:0 .9rem .9rem .9rem !important;
+  padding:1rem !important; margin-top:-1px !important;
+}
+
+/* Bootstrap tablo iyileştirme */
+.page-section .table{ margin-bottom:0 !important; }
+.page-section .table td, .page-section .table th{ vertical-align:middle !important; }
+.page-section .table thead th{ white-space:nowrap !important; }
+.page-section .table-responsive{ overflow-y:hidden !important; }
+
+/* Olası global pill stili/tema müdahalesini sıfırla */
+.tabs-wrap .nav .nav-link{ box-shadow:none !important; }
   </style>
 </head>
 <body class="theme-{{ request.session.get('user_theme', 'default') }} anim-{{ request.session.get('user_anim', 'none') }}">

--- a/templates/components/main_tabs.html
+++ b/templates/components/main_tabs.html
@@ -10,5 +10,7 @@
       {"label": "Kayıtlar", "href": url_for('logs_page'), "key": "logs"}
     ] %}
   {% endif %}
-  {{ tabs(items=items, active_key=active_key) }}
+  <div class="tabs-wrap">
+    {{ tabs(items=items, active_key=active_key) }}
+  </div>
 {% endmacro %}

--- a/templates/components/tabs.html
+++ b/templates/components/tabs.html
@@ -1,6 +1,6 @@
 {# ortak sekme bileşeni #}
 {% macro tabs(items=[], active_key="", right_slot="") -%}
-  <div class="tabs-wrap d-flex align-items-center justify-content-between mb-2">
+  <div class="d-flex align-items-center justify-content-between">
     <ul class="nav nav-tabs">
       {%- for it in items %}
         <li class="nav-item">

--- a/templates/hurdalar.html
+++ b/templates/hurdalar.html
@@ -4,14 +4,16 @@
 {% block title %}Hurdalar{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
-  {{ tabs(
-    items=[
-      {"label":"Envanter Hurda","href": url_for('inventory.hurdalar') ~ "?tur=envanter","key":"envanter"},
-      {"label":"Lisans","href": url_for('inventory.hurdalar') ~ "?tur=lisans","key":"lisans"},
-      {"label":"Yazıcı","href": url_for('inventory.hurdalar') ~ "?tur=yazici","key":"yazici"},
-    ],
-    active_key=active_key
-  ) }}
+  <div class="tabs-wrap">
+    {{ tabs(
+      items=[
+        {"label":"Envanter Hurda","href": url_for('inventory.hurdalar') ~ "?tur=envanter","key":"envanter"},
+        {"label":"Lisans","href": url_for('inventory.hurdalar') ~ "?tur=lisans","key":"lisans"},
+        {"label":"Yazıcı","href": url_for('inventory.hurdalar') ~ "?tur=yazici","key":"yazici"},
+      ],
+      active_key=active_key
+    ) }}
+  </div>
   <div class="page-section">
     {% if active_key == "envanter" %}
     <div id="envanter">

--- a/templates/logs/index.html
+++ b/templates/logs/index.html
@@ -8,14 +8,16 @@
   "edit": "Düzenleme",
   "scrap": "Hurdaya Ayır"
 } %}
-{{ tabs(
-  items=[
-    {"label":"Kullanıcı Kayıtları","href": url_for('logs_page') ~ "?tab=kullanici","key":"kullanici"},
-    {"label":"Envanter Kayıtları","href": url_for('logs_page') ~ "?tab=envanter","key":"envanter"},
-  ],
-  active_key=active_key
-) }}
-<div class="page-section">
+  <div class="tabs-wrap">
+  {{ tabs(
+    items=[
+      {"label":"Kullanıcı Kayıtları","href": url_for('logs_page') ~ "?tab=kullanici","key":"kullanici"},
+      {"label":"Envanter Kayıtları","href": url_for('logs_page') ~ "?tab=envanter","key":"envanter"},
+    ],
+    active_key=active_key
+  ) }}
+  </div>
+  <div class="page-section">
 {% if active_key == "kullanici" %}
   <div class="card p-0">
     <div class="p-2 d-flex justify-content-end gap-2">

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -9,15 +9,17 @@
     <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#talepModal">Talep Aç</button>
   {% endset %}
 
-  {{ tabs(
-      items=[
-        {"label":"Aktif","href": url_for('talep_list') ~ "?durum=aktif", "key":"aktif"},
-        {"label":"Kapalı","href": url_for('talep_list') ~ "?durum=kapali","key":"kapali"},
-        {"label":"İptal","href": url_for('talep_list') ~ "?durum=iptal","key":"iptal"},
-      ],
-      active_key=active_key,
-      right_slot=right_slot
-  ) }}
+  <div class="tabs-wrap">
+    {{ tabs(
+        items=[
+          {"label":"Aktif","href": url_for('talep_list') ~ "?durum=aktif", "key":"aktif"},
+          {"label":"Kapalı","href": url_for('talep_list') ~ "?durum=kapali","key":"kapali"},
+          {"label":"İptal","href": url_for('talep_list') ~ "?durum=iptal","key":"iptal"},
+        ],
+        active_key=active_key,
+        right_slot=right_slot
+    ) }}
+  </div>
 
   {% macro render_table(rows, empty_msg, show_actions=False) %}
   <div class="table-responsive">


### PR DESCRIPTION
## Summary
- Replace old tab styles with unified `.tabs-wrap` CSS for tab/table integration
- Wrap tab macros with `tabs-wrap` and `page-section` containers across request, scrap, and log views
- Adjust tab component to remove wrapper and support new structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6ca30f2a4832b8a6b804b794a2e99