### PR TITLE
Fix user delete in admin panel

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -52,7 +52,12 @@
                         data-id="{{ u.id }}" data-username="{{ u.username }}" data-first_name="{{ u.first_name or '' }}"
                         data-last_name="{{ u.last_name or '' }}" data-email="{{ u.email or '' }}"
                         data-is_admin="{{ 1 if u.is_admin else 0 }}">Düzenle</button>
-                <button class="btn btn-outline-danger btn-sm">Sil</button>
+                <form method="post" action="/admin/users/{{ u.id }}/delete" class="d-inline">
+                  <button type="submit" class="btn btn-outline-danger btn-sm"
+                          onclick="return confirm('\'{{ u.username }}\' kullanıcısını silmek istediğinize emin misiniz?')">
+                    Sil
+                  </button>
+                </form>
               </td>
             </tr>
             {% else %}


### PR DESCRIPTION
## Summary
- Allow deleting users via admin panel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6dc92625c832b94f6e096025a5601