### PR TITLE
Enable lookup fallback for picker endpoints

### DIFF
--- a/routers/picker.py
+++ b/routers/picker.py
@@ -7,7 +7,16 @@ from typing import List, Dict, Any, Optional
 from database import get_db
 
 # ==== MODELLERİNİ İMPORT ET (projeye göre güncellenmiş) ====
-from models import UsageArea, LicenseName, Factory, HardwareType, Brand, Model, User
+from models import (
+    UsageArea,
+    LicenseName,
+    Factory,
+    HardwareType,
+    Brand,
+    Model,
+    User,
+    Lookup,
+)
 
 router = APIRouter(prefix="/api/picker", tags=["Picker"])
 
@@ -109,6 +118,18 @@ def picker_list(
         query = query.filter(getattr(Model, label).ilike(f"%{q}%"))
 
     rows = query.order_by(getattr(Model, label).asc()).limit(200).all()
+
+    if not rows:
+        fallback = (
+            db.query(Lookup)
+            .filter(Lookup.type == entity)
+            .order_by(Lookup.value.asc())
+            .limit(200)
+            .all()
+        )
+        if fallback:
+            return [{"id": r.id, "text": r.value} for r in fallback]
+
     return [{"id": getattr(r, "id"), "text": getattr(r, label)} for r in rows]
 
 # ---- EKLE (kullanici HARİÇ) ----

--- a/tests/test_picker_fallback.py
+++ b/tests/test_picker_fallback.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import pytest
+import models
+from routers.picker import picker_list
+
+
+@pytest.fixture()
+def db_session():
+    models.Base.metadata.create_all(models.engine)
+    db = models.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        models.Base.metadata.drop_all(models.engine)
+
+
+def test_picker_list_uses_lookup_table_when_primary_empty(db_session):
+    db = db_session
+    db.add(models.Lookup(type="donanim_tipi", value="Monitör"))
+    db.commit()
+    req = SimpleNamespace(query_params={})
+    res = picker_list("donanim_tipi", request=req, db=db)
+    assert res == [{"id": 1, "text": "Monitör"}]


### PR DESCRIPTION
## Summary
- populate picker dropdowns from legacy `lookups` table when dedicated tables are empty
- add regression test to ensure fallback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fde5d3ec832b9c1c881df2237126