### PR TITLE
Load stock modal lookups from admin picker API on open

### DIFF
--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -10,14 +10,7 @@ async function loadPicker(sel, url){
   }
 }
 
-const donanimSel = document.getElementById('donanim_tipi');
-const markaSel    = document.getElementById('marka');
-const modelSel    = document.getElementById('model');
-const lisansSel   = document.getElementById('lisans_adi');
-
-loadPicker(donanimSel, '/api/picker/donanim_tipi');
-loadPicker(markaSel, '/api/picker/marka').then(()=> loadModels());
-loadPicker(lisansSel, '/api/picker/lisans_adi');
+let donanimSel, markaSel, modelSel, lisansSel;
 
 async function loadModels(){
   if(!modelSel) return;
@@ -33,7 +26,21 @@ async function loadModels(){
   }catch(e){ console.error('model lookup failed', e); }
 }
 
-markaSel?.addEventListener('change', loadModels);
+document.getElementById('stockAddModal')?.addEventListener('shown.bs.modal', async () => {
+  donanimSel = document.getElementById('donanim_tipi');
+  markaSel    = document.getElementById('marka');
+  modelSel    = document.getElementById('model');
+  lisansSel   = document.getElementById('lisans_adi');
+
+  await Promise.all([
+    loadPicker(donanimSel, '/api/picker/donanim_tipi'),
+    loadPicker(markaSel, '/api/picker/marka'),
+    loadPicker(lisansSel, '/api/picker/lisans_adi'),
+  ]);
+
+  loadModels();
+  if(markaSel) markaSel.onchange = loadModels;
+});
 
 // Ekle form submit
 const chkIsLicense = document.getElementById('chkIsLicense');


### PR DESCRIPTION
## Summary
- Populate stock add modal drop-downs using picker API when modal opens
- Refresh model list based on selected brand

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7ef694df0832bb4ba5af5d9c79973