### PR TITLE
Fix stock modal dropdown initialization

### DIFF
--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -45,11 +45,9 @@ document.getElementById('stockAddModal')?.addEventListener('shown.bs.modal', asy
   lisansSel   = document.getElementById('lisans_adi');
 
   await Promise.all([
- codex/fill-dropdowns-on-modal-open-3646ku
     loadLookup(donanimSel, '/api/lookup/donanim-tipi'),
     loadLookup(markaSel, '/api/lookup/marka'),
     loadLookup(lisansSel, '/api/lookup/lisans-adi'),
- main
   ]);
 
   loadModels();


### PR DESCRIPTION
## Summary
- ensure stock add modal loads lookup data without script errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7f8143034832b955dfd1628e2e01d