### PR TITLE
Add lookup entries for stock and request lookups

### DIFF
--- a/routers/lookup.py
+++ b/routers/lookup.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import text
 
 from database import get_db  # projedeki mevcut get_db
+from models import Lookup
 
 router = APIRouter(prefix="/api/lookup", tags=["lookup"])
 
@@ -10,11 +11,17 @@ router = APIRouter(prefix="/api/lookup", tags=["lookup"])
 # (Gerekirse tablo adlarını birebir DB'nizdeki adlarla düzeltin.)
 ENTITY_TABLE = {
     "marka": "brands",
-    "model": "models",           # Not: model listesi brand_id filtresi bekleyebilir.
+    "model": "models",  # Not: model listesi brand_id filtresi bekleyebilir.
     "fabrika": "factories",
     "kullanim-alani": "usage_areas",
     "donanim-tipi": "hardware_types",
     "lisans-adi": "license_names",
+}
+
+# Kolon/lookup bulunmadığında dönecek güvenli değerler
+FALLBACK_LISTS = {
+    "stok_durumu": ["Stokta", "Rezerve", "Atandı", "Hurda"],
+    "islem": ["Girdi", "Çıktı", "Hurda"],
 }
 
 # Liste sayfalarındaki filtrelerde kullanılabilecek distinct kolon bilgileri
@@ -65,29 +72,48 @@ def lookup_list(
     db: Session = Depends(get_db),
 ):
     table = ENTITY_TABLE.get(entity)
-    if not table:
-        raise HTTPException(404, "Geçersiz entity")
 
-    # Temel sorgu: id, ad kolonlarını bekliyoruz (modellerde marka_id var)
-    params = {"limit": limit}
-    where = []
-    if q:
-        where.append("LOWER(name) LIKE LOWER(:q)")
-        params["q"] = f"%{q}%"
-    if entity == "model":
-        if marka_id is None:
-            return []  # Model listesi marka seçimi olmadan boş dönsün
-        where.append("brand_id = :brand_id")
-        params["brand_id"] = marka_id
+    if table:
+        # Temel sorgu: id, ad kolonlarını bekliyoruz (modellerde marka_id var)
+        params = {"limit": limit}
+        where = []
+        if q:
+            where.append("LOWER(name) LIKE LOWER(:q)")
+            params["q"] = f"%{q}%"
+        if entity == "model":
+            if marka_id is None:
+                return []  # Model listesi marka seçimi olmadan boş dönsün
+            where.append("brand_id = :brand_id")
+            params["brand_id"] = marka_id
 
-    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
-    sql = text(f"SELECT id, name FROM {table}{where_sql} ORDER BY name LIMIT :limit")
-    rows = db.execute(sql, params).mappings().all()
-    # API'ler genellikle {id, name} döndürür; "text" gibi farklı anahtarlar
-    # istemcilerde karışıklığa yol açıyordu. Tutarlılık için "name" alanı
-    # döndürüyoruz ve eski "text" beklentisi olan istemcilerde de sorun
-    # yaşanmaması için çağrı tarafında gerekli uyarlamayı yapıyoruz.
-    return [{"id": r["id"], "name": r["name"]} for r in rows]
+        where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+        sql = text(
+            f"SELECT id, name FROM {table}{where_sql} ORDER BY name LIMIT :limit"
+        )
+        rows = db.execute(sql, params).mappings().all()
+        # API'ler genellikle {id, name} döndürür; "text" gibi farklı anahtarlar
+        # istemcilerde karışıklığa yol açıyordu. Tutarlılık için "name" alanı
+        # döndürüyoruz ve eski "text" beklentisi olan istemcilerde de sorun
+        # yaşanmaması için çağrı tarafında gerekli uyarlamayı yapıyoruz.
+        return [{"id": r["id"], "name": r["name"]} for r in rows]
+
+    # Kolon bazlı tablo yoksa Lookup.type tablosunu dene
+    try:
+        q_expr = db.query(Lookup.value).filter(Lookup.type == entity)
+        if q:
+            q_expr = q_expr.filter(Lookup.value.ilike(f"%{q}%"))
+        q_expr = q_expr.order_by(Lookup.value.asc()).limit(limit)
+        rows = [r[0] for r in q_expr.all() if r and r[0]]
+        if rows:
+            return rows
+    except Exception:
+        pass
+
+    # Kolon yoksa veya boş döndüyse: fallback listesi varsa onu döndür
+    if entity in FALLBACK_LISTS:
+        return FALLBACK_LISTS[entity]
+
+    raise HTTPException(404, "Geçersiz entity")
 
 
 @router.get("/distinct/{entity}/{column}", name="lookup.distinct")

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -79,8 +79,55 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
 
-      <div class="modal-body">
-        <div id="talepRows">
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Talep Türü</label>
+            <select id="talep_turu" class="form-select">
+              <option value="">Seçiniz…</option>
+              <option value="envanter">Envanter</option>
+              <option value="lisans">Lisans</option>
+              <option value="aksesuar">Aksesuar</option>
+            </select>
+          </div>
+
+          <div id="grup_envanter" class="row g-2 d-none">
+            <div class="col-md-6">
+              <label class="form-label">Donanım Tipi</label>
+              <select id="talep_donanim_tipi" class="form-select"></select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Marka</label>
+              <select id="talep_marka" class="form-select"></select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Model</label>
+              <select id="talep_model" class="form-select"></select>
+            </div>
+          </div>
+
+          <div id="grup_lisans" class="row g-2 d-none">
+            <div class="col-md-8">
+              <label class="form-label">Lisans Adı</label>
+              <select id="talep_lisans_adi" class="form-select"></select>
+            </div>
+          </div>
+
+          <div id="grup_aksesuar" class="row g-2 d-none">
+            <div class="col-md-6">
+              <label class="form-label">Donanım Tipi</label>
+              <select id="talep_aksesuar_tip" class="form-select"></select>
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">Miktar</label>
+              <input id="talep_miktar" type="number" min="1" class="form-control" />
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">IFS No (opsiyonel)</label>
+              <input id="talep_ifs" type="text" class="form-control" />
+            </div>
+          </div>
+
+          <div id="talepRows">
           <div class="talep-row row g-2 align-items-end mb-2">
             <div class="col-md-3">
               <label class="form-label">Donanım Tipi</label>
@@ -191,5 +238,40 @@
     location.reload();
     return false;
   }
+</script>
+<script>
+const E = sel => document.querySelector(sel);
+const show = el => el.classList.remove('d-none');
+const hide = el => el.classList.add('d-none');
+
+async function fill(id, entity){
+  const el = document.getElementById(id);
+  if(!el) return;
+  el.innerHTML = '<option value="">Yükleniyor…</option>';
+  const r = await fetch(`/api/lookup/${entity}`);
+  const data = r.ok ? await r.json() : [];
+  el.innerHTML = '<option value="">Seçiniz…</option>' + data.map(v => `<option value="${v}">${v}</option>`).join('');
+}
+
+E('#talep_turu')?.addEventListener('change', async (ev) => {
+  const v = ev.target.value;
+  hide(E('#grup_envanter')); hide(E('#grup_lisans')); hide(E('#grup_aksesuar'));
+  if (v === 'envanter') {
+    show(E('#grup_envanter'));
+    await fill('talep_donanim_tipi', 'donanim_tipi');
+    await fill('talep_marka', 'marka');
+    await fill('talep_model', 'model');
+  } else if (v === 'lisans') {
+    show(E('#grup_lisans'));
+    await fill('talep_lisans_adi', 'lisans_adi');
+  } else if (v === 'aksesuar') {
+    show(E('#grup_aksesuar'));
+    await fill('talep_aksesuar_tip', 'donanim_tipi');
+  }
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  // gerekirse başlangıçta bir tür seçiliyse onu doldur
+});
 </script>
 {% endblock %}

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -268,13 +268,45 @@
       <div class="modal-footer">
         <button class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
         <button id="sa_submit" class="btn btn-primary">Atamayı Yap</button>
-      </div>
-    </div>
   </div>
+  </div>
+</div>
+</div>
+</div>
+
+<!-- Lookup ile doldurulacak örnek selectler -->
+<div class="d-none" id="lookup-demo-selects">
+  <select id="stok_durumu_select" class="form-select" name="stok_durumu"></select>
+  <select id="islem_select" class="form-select" name="islem"></select>
+  <select id="donanim_tipi_select" class="form-select" name="donanim_tipi"></select>
+  <!-- <select id="ifs_no_select" class="form-select" name="ifs_no"></select> -->
 </div>
 {% endblock %}
 
 {% block scripts %}
 <script src="/static/js/stock.js"></script>
+<script>
+async function fillSelect(id, entity) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.innerHTML = '<option value="">Yükleniyor...</option>';
+  try {
+    const r = await fetch(`/api/lookup/${entity}`);
+    if (!r.ok) throw new Error(await r.text());
+    const data = await r.json();
+    el.innerHTML = '<option value="">Seçiniz…</option>' + (data || []).map(v => `<option value="${v}">${v}</option>`).join('');
+  } catch (e) {
+    console.error(e);
+    el.innerHTML = '<option value="">(Veri Yok)</option>';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fillSelect('stok_durumu_select', 'stok_durumu');
+  fillSelect('islem_select', 'islem');
+  fillSelect('donanim_tipi_select', 'donanim_tipi');
+  // fillSelect('ifs_no_select', 'ifs_no');
+});
+</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- extend lookup router with fallback lists and support for querying Lookup table when dedicated table not found
- add stock page script to populate lookup-driven selects (stok_durumu, islem, donanim_tipi)
- add request modal with dynamic sections and JS to load lookups based on selected type

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7fa82ba88832ba33c29937caa4f28