### PR TITLE
Populate stock add modal via lookup endpoints

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from database import get_db
 import models
 from sqlalchemy import func, case, and_, or_
+from typing import List
 
 router = APIRouter(prefix="/api", tags=["API"])
 
@@ -11,11 +12,14 @@ ENTITY_TABLE = {
     "donanim_tipi": models.HardwareType,
     "kullanim_alani": models.UsageArea,
     "license_names": models.LicenseName,  # lisans adlarını ayrı tabloda tutuyorsan
+    "marka": models.Brand,
+    "model": models.Model,
 }
 
 
-@router.get("/lookup/{entity}")
+@router.get("/lookup/{entity}", response_model=List[str])
 def lookup_entity(entity: str, db: Session = Depends(get_db)):
+    entity = entity.strip().lower()
     tbl = ENTITY_TABLE.get(entity)
     if not tbl:
         raise HTTPException(status_code=404, detail="Entity not found")

--- a/routers/lookup.py
+++ b/routers/lookup.py
@@ -14,8 +14,11 @@ ENTITY_TABLE = {
     "model": "models",  # Not: model listesi brand_id filtresi bekleyebilir.
     "fabrika": "factories",
     "kullanim-alani": "usage_areas",
+    "kullanim_alani": "usage_areas",
     "donanim-tipi": "hardware_types",
+    "donanim_tipi": "hardware_types",
     "lisans-adi": "license_names",
+    "lisans_adi": "license_names",
 }
 
 # Kolon/lookup bulunmadığında dönecek güvenli değerler
@@ -71,6 +74,7 @@ def lookup_list(
     marka_id: int | None = None,
     db: Session = Depends(get_db),
 ):
+    entity = entity.strip().lower()
     table = ENTITY_TABLE.get(entity)
 
     if table:

--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -18,40 +18,13 @@ async function loadLookup(sel, url){
 
 let donanimSel, markaSel, modelSel, lisansSel;
 
-async function loadModels(){
-  if(!modelSel) return;
-  const opt = markaSel?.selectedOptions[0];
-  const markaId = opt?.dataset.id;
-  modelSel.innerHTML = '<option value="">Seçiniz</option>';
-  if(!markaId) return;
-  try{
-    const res = await fetch(`/api/lookup/model?marka_id=${markaId}`, {headers:{Accept:'application/json'}});
-    if(!res.ok) return;
-    const data = await res.json();
-    const opts = (data || []).map(x => {
-      const label = x.name || x.ad || x.text || x;
-      const val   = x.name || x.ad || x.text || x;
-      const id    = x.id ?? '';
-      return `<option value="${val}" data-id="${id}">${label}</option>`;
-    }).join('');
-    modelSel.innerHTML = '<option value="">Seçiniz</option>' + opts;
-  }catch(e){ console.error('model lookup failed', e); }
-}
-
-document.getElementById('stockAddModal')?.addEventListener('shown.bs.modal', async () => {
-  donanimSel = document.getElementById('donanim_tipi');
-  markaSel    = document.getElementById('marka');
-  modelSel    = document.getElementById('model');
+document.getElementById('modalStockAdd')?.addEventListener('shown.bs.modal', async () => {
+  donanimSel = document.getElementById('stok_donanim_tipi');
+  markaSel    = document.getElementById('stok_marka');
+  modelSel    = document.getElementById('stok_model');
   lisansSel   = document.getElementById('lisans_adi');
 
-  await Promise.all([
-    loadLookup(donanimSel, '/api/lookup/donanim-tipi'),
-    loadLookup(markaSel, '/api/lookup/marka'),
-    loadLookup(lisansSel, '/api/lookup/lisans-adi'),
-  ]);
-
-  loadModels();
-  if(markaSel) markaSel.onchange = loadModels;
+  await loadLookup(lisansSel, '/api/lookup/lisans-adi');
 });
 
 // Ekle form submit

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -10,7 +10,7 @@
               data-bs-toggle="modal" data-bs-target="#stockStatusModal">
         Stok Durumu
       </button>
-      <button class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#stockAddModal">
+      <button class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#modalStockAdd">
         <i class="bi bi-plus-lg"></i>
         <span>Ekle</span>
       </button>
@@ -93,7 +93,7 @@
 </div>
 
 <!-- STOK EKLE MODALI -->
-<div class="modal fade" id="stockAddModal" tabindex="-1" aria-hidden="true">
+<div class="modal fade" id="modalStockAdd" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-lg">
     <form id="frmStockAdd" class="modal-content">
       <div class="modal-header">
@@ -111,15 +111,15 @@
         <div id="hardwareFields" class="col-12 row g-3">
           <div class="col-md-4">
             <label class="form-label">Donanım Tipi</label>
-            <select id="donanim_tipi" name="donanim_tipi" class="form-select" required></select>
+            <select id="stok_donanim_tipi" name="donanim_tipi" class="form-select" required></select>
           </div>
           <div class="col-md-3">
             <label class="form-label">Marka (opsiyonel)</label>
-            <select id="marka" name="marka" class="form-select"></select>
+            <select id="stok_marka" name="marka" class="form-select"></select>
           </div>
           <div class="col-md-3">
             <label class="form-label">Model (opsiyonel)</label>
-            <select id="model" name="model" class="form-select"></select>
+            <select id="stok_model" name="model" class="form-select"></select>
           </div>
           <div class="col-md-2" id="rowMiktar">
             <label class="form-label">Miktar</label>
@@ -306,6 +306,88 @@ document.addEventListener('DOMContentLoaded', () => {
   fillSelect('islem_select', 'islem');
   fillSelect('donanim_tipi_select', 'donanim_tipi');
   // fillSelect('ifs_no_select', 'ifs_no');
+});
+</script>
+<script>
+// Basit fetch helper
+async function getLookup(entity) {
+  try {
+    const r = await fetch(`/api/lookup/${encodeURIComponent(entity)}`);
+    if (!r.ok) return [];
+    return await r.json();
+  } catch (_) {
+    return [];
+  }
+}
+
+// Select'e seçenek yazan helper
+function setOptions(selectEl, items) {
+  if (!selectEl) return;
+
+  // Düz <select> içeriği
+  const html = ['<option value="">Seçiniz…</option>']
+    .concat(items.map(v => `<option value="${v}">${v}</option>`))
+    .join('');
+  selectEl.innerHTML = html;
+
+  // Eğer Select2 kullanıyorsan yeniden kur
+  if (window.jQuery && jQuery(selectEl).data('select2')) {
+    jQuery(selectEl).off('select2:select');          // olası eski event'leri temizle
+    jQuery(selectEl).select2('destroy');             // eski instance'ı yok et
+    jQuery(selectEl).select2({
+      width: '100%',
+      language: {
+        noResults: () => 'Seçenek yok',
+        searching: () => 'Aranıyor…'
+      }
+    });
+  }
+
+  // Eğer Choices.js kullanıyorsan:
+  if (selectEl.classList.contains('choices')) {
+    // basit bir reset için:
+    selectEl._choices && selectEl._choices.destroy && selectEl._choices.destroy();
+    const choices = items.map(v => ({ value: v, label: v }));
+    // global Choices varsa:
+    if (window.Choices) {
+      selectEl._choices = new Choices(selectEl, { searchEnabled: true, shouldSort: true, itemSelectText: '' });
+      // mevcut “Seçiniz…” kalsın, diğerlerini ekle
+      choices.forEach(c => selectEl._choices.setChoices([c], 'value', 'label', false));
+    }
+  }
+}
+
+// Modal açıldığında doldur
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('modalStockAdd'); // Modal id’n bu olmalı
+  if (!modal) return;
+
+  modal.addEventListener('shown.bs.modal', async () => {
+    const donanimSel = document.getElementById('stok_donanim_tipi');
+    const markaSel   = document.getElementById('stok_marka');
+    const modelSel   = document.getElementById('stok_model');
+
+    // Paralel çek
+    const [donanimlar, markalar, modeller] = await Promise.all([
+      getLookup('donanim_tipi'),
+      getLookup('marka'),
+      getLookup('model')
+    ]);
+
+    setOptions(donanimSel, donanimlar);
+    setOptions(markaSel, markalar);
+    setOptions(modelSel, modeller);
+  });
+
+  // Eğer modal içeriği dinamik yükleniyorsa (HTMX/AJAX),
+  // butona tıklayınca da zorla açılışta doldurt:
+  const openBtn = document.querySelector('[data-bs-target="#modalStockAdd"]');
+  if (openBtn) {
+    openBtn.addEventListener('click', () => {
+      // Bootstrap modal açılınca zaten shown.bs.modal ateşlenecek
+      // burada ekstra işleme gerek yok.
+    });
+  }
 });
 </script>
 {% endblock %}

--- a/tests/test_lookup_entity.py
+++ b/tests/test_lookup_entity.py
@@ -31,3 +31,14 @@ def test_lookup_donanim_tipi(db_session):
 
     res = lookup_entity("donanim_tipi", db=db)
     assert res == ["A", "B"]
+
+
+def test_lookup_marka_model(db_session):
+    db = db_session
+    brand = models.Brand(name="Dell")
+    model = models.Model(name="XPS", brand=brand)
+    db.add_all([brand, model])
+    db.commit()
+
+    assert lookup_entity("marka", db=db) == ["Dell"]
+    assert lookup_entity("model", db=db) == ["XPS"]


### PR DESCRIPTION
## Summary
- Fill stock add modal selects dynamically on open and standardize element IDs
- Expose lookup endpoints for hardware, brand, and model with normalized entity names
- Expand lookup tests for brand and model coverage

## Testing
- `pytest tests/test_lookup_entity.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7fdd183b0832bbb2ba91fd3283a17