### PR TITLE
Resolve lookup API conflict for model fetch

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -17,7 +17,7 @@ ENTITY_TABLE = {
 }
 
 
-@router.get("/lookup/{entity}", response_model=List[str])
+@router.get("/lookup_plain/{entity}", response_model=List[str])
 def lookup_entity(entity: str, db: Session = Depends(get_db)):
     entity = entity.strip().lower()
     tbl = ENTITY_TABLE.get(entity)


### PR DESCRIPTION
## Summary
- Move old lookup endpoint to `/lookup_plain/{entity}` so `/api/lookup` serves detailed results with IDs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b801260588832bbcf0a10a9010b661