### PR TITLE
feat: add generic lookup script and update modal forms

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="api-root" content="/api">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link href="{{ url_for('static', path='css/custom.css') }}" rel="stylesheet">
@@ -337,6 +338,137 @@ window.addEventListener("message", (e) => {
       }
       draw();
     }
+    </script>
+    <script>
+(function () {
+  // ---- API kökünü tespit et (meta varsa onu kullan, yoksa mantıklı varsayılan) ----
+  const META_API = document.querySelector('meta[name="api-root"]')?.content;
+  const API_ROOT = (META_API && META_API.replace(/\/$/, '')) || '/api';
+
+  // ---- Lookup cache + güvenli fetch ----
+  const Cache = new Map();
+  async function fetchLookup(entity, params = {}) {
+    const key = entity + '::' + JSON.stringify(params);
+    if (Cache.has(key)) return Cache.get(key);
+
+    const url = new URL(`${API_ROOT}/lookup/${encodeURIComponent(entity)}`, window.location.origin);
+    Object.entries(params).forEach(([k, v]) => (v != null && v !== '') && url.searchParams.set(k, v));
+
+    const res = await fetch(url.toString(), { credentials: 'same-origin' });
+    const ct = res.headers.get('content-type') || '';
+    // Login'e yönlendirme / HTML dönerse yakala
+    if (!res.ok || !ct.includes('application/json')) {
+      console.error('[lookup] Hatalı cevap:', res.status, ct);
+      const text = await res.text().catch(() => '');
+      if (text.includes('<form') && text.toLowerCase().includes('login')) {
+        console.warn('[lookup] Muhtemel oturum/redirect. Sayfada giriş/çerez kontrol et.');
+      }
+      Cache.set(key, []); return [];
+    }
+    const data = await res.json().catch(() => []);
+    Cache.set(key, Array.isArray(data) ? data : []);
+    return Cache.get(key);
+  }
+
+  // ---- Select eklentileri için evrensel doldurucu ----
+  function fillSelect(el, items) {
+    if (!el) return;
+
+    // Native temizle
+    el.innerHTML = '';
+    const first = document.createElement('option');
+    first.value = ''; first.textContent = 'Seçiniz…';
+    el.appendChild(first);
+
+    for (const v of (items || [])) {
+      const opt = document.createElement('option');
+      opt.value = v; opt.textContent = v;
+      el.appendChild(opt);
+    }
+
+    // jQuery + Bootstrap-select
+    if (window.jQuery) {
+      const $el = jQuery(el);
+      if ($el.hasClass('selectpicker') && jQuery.fn.selectpicker) $el.selectpicker('refresh');
+
+      // Select2
+      if (jQuery.fn.select2) {
+        if ($el.data('select2')) { $el.trigger('change.select2'); }
+        else { $el.select2({ width: '100%', language: { noResults: ()=>'Seçenek yok', searching:()=> 'Aranıyor…' } }); }
+      }
+    }
+
+    // TomSelect
+    if (el.tomselect) {
+      el.tomselect.clearOptions();
+      el.tomselect.addOptions((items||[]).map(v => ({ value: v, text: v })));
+    }
+
+    // Choices.js
+    if (window.Choices && el.classList.contains('choices')) {
+      if (el._choices && el._choices.destroy) el._choices.destroy();
+      el._choices = new Choices(el, { searchEnabled: true, itemSelectText: '' });
+      el._choices.setChoices((items||[]).map(v => ({ value: v, label: v })), 'value', 'label', true);
+    }
+  }
+
+  // ---- Tek satırı initialize et ----
+  async function initRow(container, rowEl) {
+    const donanim = rowEl.querySelector('select[data-lookup="donanim_tipi"]');
+    const marka   = rowEl.querySelector('select[data-lookup="marka"]');
+    const model   = rowEl.querySelector('select[data-lookup="model"]');
+
+    if (donanim) fillSelect(donanim, await fetchLookup('donanim_tipi'));
+    if (marka)   fillSelect(marka,   await fetchLookup('marka'));
+
+    // model marka'ya bağımlıysa
+    if (model) {
+      const depSel = model.getAttribute('data-depends');
+      const depEl  = depSel ? (rowEl.querySelector(depSel) || container.querySelector(depSel) || document.querySelector(depSel)) : marka;
+      fillSelect(model, []); // başta boş
+      if (depEl) {
+        depEl.addEventListener('change', async () => {
+          const m = depEl.value || '';
+          const list = await fetchLookup('model', m ? { marka: m } : {});
+          fillSelect(model, list);
+        }, { passive: true });
+      } else {
+        // Bağımlı yoksa tüm modeller
+        fillSelect(model, await fetchLookup('model'));
+      }
+    }
+  }
+
+  // ---- Bir konteyner içindeki tüm satırları kur ----
+  async function initContainer(container) {
+    const rows = container.querySelectorAll('.talep-row, .stok-row');
+    if (rows.length) {
+      for (const r of rows) await initRow(container, r);
+      return;
+    }
+    // Eğer tek satırlık formsa
+    await initRow(container, container);
+  }
+
+  // ---- Modal açıldığında doldur ----
+  document.addEventListener('shown.bs.modal', (ev) => {
+    const modal = ev.target;
+    initContainer(modal);
+  });
+
+  // ---- Sonradan eklenen satırları yakala ----
+  const mo = new MutationObserver((muts) => {
+    for (const m of muts) {
+      m.addedNodes.forEach(n => {
+        if (n.nodeType !== 1) return;
+        if (n.matches?.('.talep-row, .stok-row, .modal')) initContainer(n);
+        const inner = n.querySelector?.('select[data-lookup]');
+        if (inner) initContainer(n.closest('.modal') || document);
+      });
+    }
+  });
+  mo.observe(document.body, { childList: true, subtree: true });
+})();
     </script>
   </body>
   </html>

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -89,7 +89,7 @@
           <div class="row g-2 align-items-end talep-row">
             <div class="col-md-3">
               <label class="form-label">Donanım Tipi</label>
-              <select class="form-select js-donanim"><option value="">Seçiniz…</option></select>
+              <select class="form-select" data-lookup="donanim_tipi"></select>
             </div>
             <div class="col-md-2">
               <label class="form-label">Miktar</label>
@@ -97,11 +97,11 @@
             </div>
             <div class="col-md-3">
               <label class="form-label">Marka</label>
-              <select class="form-select js-marka"><option value="">Seçiniz…</option></select>
+              <select class="form-select" data-lookup="marka" id="talep_marka_1"></select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Model</label>
-              <select class="form-select js-model"><option value="">Seçiniz…</option></select>
+              <select class="form-select" data-lookup="model" data-depends="#talep_marka_1"></select>
             </div>
             <div class="col-md-1">
               <button type="button" class="btn btn-outline-danger" data-action="row-remove">✕</button>
@@ -130,7 +130,7 @@
   <div class="row g-2 align-items-end talep-row mt-2">
     <div class="col-md-3">
       <label class="form-label">Donanım Tipi</label>
-      <select class="form-select js-donanim"><option value="">Seçiniz…</option></select>
+      <select class="form-select" data-lookup="donanim_tipi"></select>
     </div>
     <div class="col-md-2">
       <label class="form-label">Miktar</label>
@@ -138,11 +138,11 @@
     </div>
     <div class="col-md-3">
       <label class="form-label">Marka</label>
-      <select class="form-select js-marka"><option value="">Seçiniz…</option></select>
+      <select class="form-select" data-lookup="marka"></select>
     </div>
     <div class="col-md-3">
       <label class="form-label">Model</label>
-      <select class="form-select js-model"><option value="">Seçiniz…</option></select>
+      <select class="form-select" data-lookup="model" data-depends="[data-lookup='marka']"></select>
     </div>
     <div class="col-md-1">
       <button type="button" class="btn btn-outline-danger" data-action="row-remove">✕</button>
@@ -154,123 +154,22 @@
 </template>
 
 <script>
-// ====== Lookup cache ve yardımcılar ======
-const LookupCache = {};
-
-async function fetchLookup(entity, params = {}) {
-  const key = entity + JSON.stringify(params);
-  if (LookupCache[key]) return LookupCache[key];
-
-  const url = new URL(`/api/lookup/${encodeURIComponent(entity)}`, window.location.origin);
-  Object.entries(params).forEach(([k, v]) => {
-    if (v !== undefined && v !== null && v !== '') url.searchParams.set(k, v);
-  });
-
-  const res = await fetch(url.toString());
-  if (!res.ok) return [];
-  const data = await res.json();
-  LookupCache[key] = data;
-  return data;
-}
-
-function initSelectPlugin(selectEl) {
-  // Select2 kullanıyorsan:
-  if (window.jQuery && jQuery(selectEl).data && jQuery(selectEl).data('select2')) {
-    jQuery(selectEl).select2('destroy');
-  }
-  if (window.jQuery && jQuery.fn && jQuery.fn.select2) {
-    jQuery(selectEl).select2({
-      width: '100%',
-      language: {
-        noResults: () => 'Seçenek yok',
-        searching: () => 'Aranıyor…'
-      }
-    });
-  }
-
-  // Choices kullanıyorsan:
-  if (selectEl._choices && selectEl._choices.destroy) {
-    selectEl._choices.destroy();
-  }
-  if (window.Choices && selectEl.classList.contains('choices')) {
-    selectEl._choices = new Choices(selectEl, { searchEnabled: true, itemSelectText: '' });
-  }
-}
-
-function fillOptions(selectEl, items) {
-  if (!selectEl) return;
-  const opts = ['<option value="">Seçiniz…</option>']
-    .concat(items.map(v => `<option value="${v}">${v}</option>`)).join('');
-  selectEl.innerHTML = opts;
-  initSelectPlugin(selectEl);
-}
-
-// ====== Satır başlatma (tek satır) ======
-async function initTalepRow(rowEl) {
-  const donanimSel = rowEl.querySelector('.js-donanim');
-  const markaSel   = rowEl.querySelector('.js-marka');
-  const modelSel   = rowEl.querySelector('.js-model');
-
-  // 1) donanım tipi & marka & (şimdilik) boş model
-  const [donanimList, markaList] = await Promise.all([
-    fetchLookup('donanim_tipi'),
-    fetchLookup('marka')
-  ]);
-
-  fillOptions(donanimSel, donanimList);
-  fillOptions(markaSel, markaList);
-  fillOptions(modelSel, []); // marka seçilince dolduracağız
-
-  // 2) Marka seçilince model doldur
-  markaSel.addEventListener('change', async (e) => {
-    const selectedMarka = e.target.value || '';
-    // önce tamamen temizle
-    fillOptions(modelSel, []);
-    // marka yoksa tüm modelleri getirmek istersen aşağıyı değiştir:
-    const modelList = await fetchLookup('model', { marka: selectedMarka });
-    fillOptions(modelSel, modelList);
-  }, { passive: true });
-}
-
-// ====== Modal içindeki tüm satırları başlat ======
-async function initAllRows(modal) {
-  const rows = modal.querySelectorAll('.talep-row');
-  for (const row of rows) {
-    await initTalepRow(row);
-  }
-}
-
-// ====== Modal ve satır ekleme/çıkarma ======
-document.addEventListener('DOMContentLoaded', () => {
-  const modal = document.getElementById('modalTalepAc'); // modal id'n bu olmalı
+document.addEventListener('click', (ev) => {
+  const modal = document.getElementById('modalTalepAc');
   if (!modal) return;
-
-  // Modal açıldığında var olan satırları doldur
-  modal.addEventListener('shown.bs.modal', async () => {
-    await initAllRows(modal);
-  });
-
-  // "Satır Ekle" butonu (data-action="row-add")
-  modal.addEventListener('click', async (ev) => {
-    const btn = ev.target.closest('[data-action="row-add"]');
-    if (btn) {
-      const container = modal.querySelector('.talep-rows');
-      const tpl = modal.querySelector('#talep-row-template');
-      if (!container || !tpl) return;
-
-      const clone = document.importNode(tpl.content, true);
-      container.appendChild(clone);
-      // yeni eklenen satırı başlat
-      const newRow = container.lastElementChild;
-      await initTalepRow(newRow);
+  const addBtn = ev.target.closest('[data-action="row-add"]');
+  if (addBtn) {
+    const container = modal.querySelector('.talep-rows');
+    const tpl = document.getElementById('talep-row-template');
+    if (container && tpl) {
+      container.appendChild(document.importNode(tpl.content, true));
     }
-
-    const rm = ev.target.closest('[data-action="row-remove"]');
-    if (rm) {
-      const row = rm.closest('.talep-row');
-      if (row) row.remove();
-    }
-  });
+  }
+  const rm = ev.target.closest('[data-action="row-remove"]');
+  if (rm) {
+    const row = rm.closest('.talep-row');
+    if (row) row.remove();
+  }
 });
 </script>
 {% endblock %}

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -108,26 +108,30 @@
           </div>
         </div>
 
-        <div id="hardwareFields" class="col-12 row g-3">
-          <div class="col-md-4">
-            <label class="form-label">Donanım Tipi</label>
-            <select id="stok_donanim_tipi" name="donanim_tipi" class="form-select" required></select>
+        <div id="hardwareFields" class="col-12">
+          <div class="row g-3 stok-row">
+            <div class="col-md-4">
+              <label class="form-label">Donanım Tipi</label>
+              <select name="donanim_tipi" class="form-select" data-lookup="donanim_tipi" required></select>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Marka (ops.)</label>
+              <select name="marka" class="form-select" data-lookup="marka" id="stok_marka"></select>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label">Model (ops.)</label>
+              <select name="model" class="form-select" data-lookup="model" data-depends="#stok_marka"></select>
+            </div>
           </div>
-          <div class="col-md-3">
-            <label class="form-label">Marka (opsiyonel)</label>
-            <select id="stok_marka" name="marka" class="form-select"></select>
-          </div>
-          <div class="col-md-3">
-            <label class="form-label">Model (opsiyonel)</label>
-            <select id="stok_model" name="model" class="form-select"></select>
-          </div>
-          <div class="col-md-2" id="rowMiktar">
-            <label class="form-label">Miktar</label>
-            <input type="number" min="1" id="miktar" name="miktar" class="form-control" required>
-          </div>
-          <div class="col-md-3">
-            <label class="form-label">IFS No (opsiyonel)</label>
-            <input type="text" id="ifs_no" name="ifs_no" class="form-control">
+          <div class="row g-3 mt-0">
+            <div class="col-md-2" id="rowMiktar">
+              <label class="form-label">Miktar</label>
+              <input type="number" min="1" id="miktar" name="miktar" class="form-control" required>
+            </div>
+            <div class="col-md-3">
+              <label class="form-label">IFS No (opsiyonel)</label>
+              <input type="text" id="ifs_no" name="ifs_no" class="form-control">
+            </div>
           </div>
         </div>
 

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -96,41 +96,35 @@
           <input id="ifsNoGlobal" class="form-control" placeholder="IFS No">
         </div>
         <div id="talepRows">
-          <div class="talep-row row g-2 align-items-end mb-2 flex-nowrap">
+          <div class="row g-2 align-items-end talep-row">
             <div class="col-md-3">
               <label class="form-label">Donanım Tipi</label>
-              <select name="donanim_tipi" class="form-select">
-                <option value="">Seçiniz...</option>
-              </select>
+              <select name="donanim_tipi" class="form-select" data-lookup="donanim_tipi"></select>
             </div>
-            <div class="col-md-1">
+            <div class="col-md-2">
               <label class="form-label">Miktar</label>
               <input name="miktar" type="number" min="1" class="form-control" placeholder="Miktar">
             </div>
-            <div class="col-md-2">
+            <div class="col-md-3">
               <label class="form-label">Marka</label>
-              <select name="marka" class="form-select">
-                <option value="">Seçiniz...</option>
-              </select>
+              <select name="marka" class="form-select" data-lookup="marka"></select>
             </div>
-            <div class="col-md-2">
+            <div class="col-md-3">
               <label class="form-label">Model</label>
-              <select name="model" class="form-select">
-                <option value="">Seçiniz...</option>
-              </select>
+              <select name="model" class="form-select" data-lookup="model" data-depends="[data-lookup='marka']"></select>
             </div>
             <div class="col-md-3">
               <label class="form-label">Açıklama</label>
               <input name="aciklama" class="form-control" placeholder="Açıklama">
             </div>
             <div class="col-md-1 text-end">
-              <button type="button" class="btn btn-outline-danger" onclick="talepSatirSil(this)">
+              <button type="button" class="btn btn-outline-danger" data-action="row-remove">
                 <i class="bi bi-x"></i>
               </button>
             </div>
           </div>
         </div>
-        <button type="button" class="btn btn-outline-secondary" onclick="talepSatirEkle()">Satır Ekle</button>
+        <button type="button" class="btn btn-outline-secondary" data-action="row-add">Satır Ekle</button>
       </div>
 
       <div class="modal-footer">
@@ -140,62 +134,22 @@
     </form>
   </div>
 </div>
-<script>
-  const rowContainer = document.getElementById('talepRows');
-  let templateRow;
+  <script>
+    const rowContainer = document.getElementById('talepRows');
+    let templateRow = rowContainer.firstElementChild.cloneNode(true);
 
-  function bindRow(row) {
-    const markaSel = row.querySelector('select[name="marka"]');
-    const modelSel = row.querySelector('select[name="model"]');
-    markaSel.addEventListener('change', () => {
-      const id = markaSel.selectedOptions[0]?.dataset.id || '';
-      modelSel.innerHTML = '<option value="">Seçiniz...</option>';
-      if (!id) return;
-      fetch(`/api/lookup/model?marka_id=${id}`).then(r => r.json()).then(list => {
-        const opts = list.map(n => `<option value="${n.name ?? n}">${n.name ?? n}</option>`).join('');
-        modelSel.insertAdjacentHTML('beforeend', opts);
-      });
-    });
-  }
-
-  function talepSatirEkle() {
-    const clone = templateRow.cloneNode(true);
-    clone.querySelectorAll('input').forEach(i => i.value = '');
-    clone.querySelectorAll('select').forEach(sel => {
-      sel.selectedIndex = 0;
-      if (sel.name === 'model') sel.innerHTML = '<option value="">Seçiniz...</option>';
-    });
-    rowContainer.appendChild(clone);
-    bindRow(clone);
-  }
-
-  function talepSatirSil(btn) {
-    if (rowContainer.children.length > 1) {
-      btn.closest('.talep-row').remove();
+  document.addEventListener('click', (ev) => {
+    const addBtn = ev.target.closest('[data-action="row-add"]');
+    if (addBtn) {
+      const clone = templateRow.cloneNode(true);
+      clone.querySelectorAll('input').forEach(i => i.value = '');
+      clone.querySelectorAll('select').forEach(sel => sel.value = '');
+      rowContainer.appendChild(clone);
     }
-  }
-
-  const lookups = Promise.all([
-    fetch('/api/lookup/donanim-tipi').then(r => r.json()),
-    fetch('/api/lookup/marka').then(r => r.json()),
-  ]);
-
-  lookups.then(([donanimList, markaList]) => {
-    const donanimOpts = donanimList
-      .map(n => `<option value="${n.name ?? n}">${n.name ?? n}</option>`)
-      .join('');
-    const markaOpts = markaList
-      .map(n => `<option value="${n.name ?? n}" data-id="${n.id ?? ''}">${n.name ?? n}</option>`)
-      .join('');
-    const firstRow = rowContainer.firstElementChild;
-    firstRow
-      .querySelector('select[name="donanim_tipi"]')
-      .insertAdjacentHTML('beforeend', donanimOpts);
-    firstRow
-      .querySelector('select[name="marka"]')
-      .insertAdjacentHTML('beforeend', markaOpts);
-    templateRow = firstRow.cloneNode(true);
-    bindRow(firstRow);
+    const rmBtn = ev.target.closest('[data-action="row-remove"]');
+    if (rmBtn && rowContainer.children.length > 1) {
+      rmBtn.closest('.talep-row').remove();
+    }
   });
 
   async function talepGonder(e) {


### PR DESCRIPTION
## Summary
- add universal lookup/fill script with API root meta
- convert stock and request modals to data-driven selects

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b81ce75d54832bbf4802b4fe2b0e5b