### PR TITLE
Fix request and stock tracking pickers

### DIFF
--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -112,7 +112,7 @@
           <div class="row g-3 stok-row">
             <div class="col-md-4">
               <label class="form-label">Donanım Tipi</label>
-              <select name="donanim_tipi" class="form-select" data-lookup="donanim_tipi" required></select>
+              <select name="donanim_tipi" class="form-select" data-lookup="donanim_tipi" id="stok_donanim_tipi" required></select>
             </div>
             <div class="col-md-4">
               <label class="form-label">Marka (ops.)</label>
@@ -120,7 +120,7 @@
             </div>
             <div class="col-md-4">
               <label class="form-label">Model (ops.)</label>
-              <select name="model" class="form-select" data-lookup="model" data-depends="#stok_marka"></select>
+              <select name="model" class="form-select" data-lookup="model" data-depends="#stok_marka" id="stok_model"></select>
             </div>
           </div>
           <div class="row g-3 mt-0">
@@ -138,7 +138,7 @@
         <div id="licenseFields" class="col-12 row g-3 d-none">
           <div class="col-md-4">
             <label class="form-label">Lisans Adı</label>
-            <select id="lisans_adi" name="lisans_adi" class="form-select" required></select>
+            <select id="lisans_adi" name="lisans_adi" class="form-select" data-lookup="lisans_adi" required></select>
           </div>
           <div class="col-md-4">
             <label class="form-label">Lisans Anahtarı</label>
@@ -298,7 +298,10 @@ async function fillSelect(id, entity) {
     const r = await fetch(`/api/lookup/${entity}`);
     if (!r.ok) throw new Error(await r.text());
     const data = await r.json();
-    el.innerHTML = '<option value="">Seçiniz…</option>' + (data || []).map(v => `<option value="${v}">${v}</option>`).join('');
+    el.innerHTML = '<option value="">Seçiniz…</option>' + (data || []).map(v => {
+      const text = typeof v === 'string' ? v : (v.name || v.text || v.id);
+      return `<option value="${text}">${text}</option>`;
+    }).join('');
   } catch (e) {
     console.error(e);
     el.innerHTML = '<option value="">(Veri Yok)</option>';
@@ -313,85 +316,15 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 </script>
 <script>
-// Basit fetch helper
-async function getLookup(entity) {
-  try {
-    const r = await fetch(`/api/lookup/${encodeURIComponent(entity)}`);
-    if (!r.ok) return [];
-    return await r.json();
-  } catch (_) {
-    return [];
-  }
-}
-
-// Select'e seçenek yazan helper
-function setOptions(selectEl, items) {
-  if (!selectEl) return;
-
-  // Düz <select> içeriği
-  const html = ['<option value="">Seçiniz…</option>']
-    .concat(items.map(v => `<option value="${v}">${v}</option>`))
-    .join('');
-  selectEl.innerHTML = html;
-
-  // Eğer Select2 kullanıyorsan yeniden kur
-  if (window.jQuery && jQuery(selectEl).data('select2')) {
-    jQuery(selectEl).off('select2:select');          // olası eski event'leri temizle
-    jQuery(selectEl).select2('destroy');             // eski instance'ı yok et
-    jQuery(selectEl).select2({
-      width: '100%',
-      language: {
-        noResults: () => 'Seçenek yok',
-        searching: () => 'Aranıyor…'
-      }
-    });
-  }
-
-  // Eğer Choices.js kullanıyorsan:
-  if (selectEl.classList.contains('choices')) {
-    // basit bir reset için:
-    selectEl._choices && selectEl._choices.destroy && selectEl._choices.destroy();
-    const choices = items.map(v => ({ value: v, label: v }));
-    // global Choices varsa:
-    if (window.Choices) {
-      selectEl._choices = new Choices(selectEl, { searchEnabled: true, shouldSort: true, itemSelectText: '' });
-      // mevcut “Seçiniz…” kalsın, diğerlerini ekle
-      choices.forEach(c => selectEl._choices.setChoices([c], 'value', 'label', false));
-    }
-  }
-}
-
-// Modal açıldığında doldur
 document.addEventListener('DOMContentLoaded', () => {
-  const modal = document.getElementById('modalStockAdd'); // Modal id’n bu olmalı
+  const modal = document.getElementById('modalStockAdd');
   if (!modal) return;
-
   modal.addEventListener('shown.bs.modal', async () => {
-    const donanimSel = document.getElementById('stok_donanim_tipi');
-    const markaSel   = document.getElementById('stok_marka');
-    const modelSel   = document.getElementById('stok_model');
-
-    // Paralel çek
-    const [donanimlar, markalar, modeller] = await Promise.all([
-      getLookup('donanim_tipi'),
-      getLookup('marka'),
-      getLookup('model')
-    ]);
-
-    setOptions(donanimSel, donanimlar);
-    setOptions(markaSel, markalar);
-    setOptions(modelSel, modeller);
+    await _selects.fillChoices({ endpoint: '/api/lookup/donanim_tipi', selectId: 'stok_donanim_tipi', placeholder: 'Donanım tipi seçiniz…' });
+    await _selects.fillChoices({ endpoint: '/api/lookup/marka', selectId: 'stok_marka', placeholder: 'Marka seçiniz…' });
+    await _selects.fillChoices({ endpoint: '/api/lookup/lisans_adi', selectId: 'lisans_adi', placeholder: 'Lisans adı seçiniz…' });
+    _selects.bindMarkaModel('stok_marka', 'stok_model');
   });
-
-  // Eğer modal içeriği dinamik yükleniyorsa (HTMX/AJAX),
-  // butona tıklayınca da zorla açılışta doldurt:
-  const openBtn = document.querySelector('[data-bs-target="#modalStockAdd"]');
-  if (openBtn) {
-    openBtn.addEventListener('click', () => {
-      // Bootstrap modal açılınca zaten shown.bs.modal ateşlenecek
-      // burada ekstra işleme gerek yok.
-    });
-  }
 });
 </script>
 {% endblock %}

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -138,36 +138,61 @@
     const rowContainer = document.getElementById('talepRows');
     let templateRow = rowContainer.firstElementChild.cloneNode(true);
 
-  document.addEventListener('click', (ev) => {
-    const addBtn = ev.target.closest('[data-action="row-add"]');
-    if (addBtn) {
-      const clone = templateRow.cloneNode(true);
-      clone.querySelectorAll('input').forEach(i => i.value = '');
-      clone.querySelectorAll('select').forEach(sel => sel.value = '');
-      rowContainer.appendChild(clone);
+    let rowIdx = 0;
+    async function initRow(row){
+      rowIdx++;
+      const donSel = row.querySelector("[data-lookup='donanim_tipi']");
+      const markaSel = row.querySelector("[data-lookup='marka']");
+      const modelSel = row.querySelector("[data-lookup='model']");
+      if (donSel){
+        donSel.id = donSel.id || `talep_donanim_${rowIdx}`;
+        await _selects.fillChoices({ endpoint: '/api/lookup/donanim_tipi', selectId: donSel.id, placeholder: 'Donanım tipi seçiniz…' });
+      }
+      if (markaSel){
+        markaSel.id = markaSel.id || `talep_marka_${rowIdx}`;
+        await _selects.fillChoices({ endpoint: '/api/lookup/marka', selectId: markaSel.id, placeholder: 'Marka seçiniz…' });
+      }
+      if (markaSel && modelSel){
+        modelSel.id = modelSel.id || `talep_model_${rowIdx}`;
+        _selects.bindMarkaModel(markaSel.id, modelSel.id);
+      }
     }
-    const rmBtn = ev.target.closest('[data-action="row-remove"]');
-    if (rmBtn && rowContainer.children.length > 1) {
-      rmBtn.closest('.talep-row').remove();
-    }
-  });
 
-  async function talepGonder(e) {
-    e.preventDefault();
-    const ifsNo = document.getElementById('ifsNoGlobal').value;
-    const rows = rowContainer.querySelectorAll('.talep-row');
-    for (const row of rows) {
-      const fd = new FormData();
-      if (ifsNo) fd.append('ifs_no', ifsNo);
-      row.querySelectorAll('input, select').forEach(el => {
-        if (el.name && el.value) fd.append(el.name, el.value);
-      });
-      const res = await fetch('/talepler', { method: 'POST', body: fd });
-      const data = await res.json();
-      if (!data.ok) { alert('Kayıt hatası'); return false; }
+    document.addEventListener('DOMContentLoaded', () => {
+      initRow(rowContainer.firstElementChild);
+    });
+
+    document.addEventListener('click', async (ev) => {
+      const addBtn = ev.target.closest('[data-action="row-add"]');
+      if (addBtn) {
+        const clone = templateRow.cloneNode(true);
+        clone.querySelectorAll('input').forEach(i => i.value = '');
+        clone.querySelectorAll('select').forEach(sel => sel.value = '');
+        rowContainer.appendChild(clone);
+        await initRow(clone);
+      }
+      const rmBtn = ev.target.closest('[data-action="row-remove"]');
+      if (rmBtn && rowContainer.children.length > 1) {
+        rmBtn.closest('.talep-row').remove();
+      }
+    });
+
+    async function talepGonder(e) {
+      e.preventDefault();
+      const ifsNo = document.getElementById('ifsNoGlobal').value;
+      const rows = rowContainer.querySelectorAll('.talep-row');
+      for (const row of rows) {
+        const fd = new FormData();
+        if (ifsNo) fd.append('ifs_no', ifsNo);
+        row.querySelectorAll('input, select').forEach(el => {
+          if (el.name && el.value) fd.append(el.name, el.value);
+        });
+        const res = await fetch('/talepler', { method: 'POST', body: fd });
+        const data = await res.json();
+        if (!data.ok) { alert('Kayıt hatası'); return false; }
+      }
+      location.reload();
+      return false;
     }
-    location.reload();
-    return false;
-  }
-</script>
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Ensure request modal populates hardware, brand and model choices via picker API
- Load stock modal select options from lookup tables and bind brand-model relationship

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b822a18668832b8f1253c84630eed4