### PR TITLE
Refine stock form layout and display

### DIFF
--- a/routers/stock.py
+++ b/routers/stock.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from security import SessionUser, current_user
-from models import StockAssignment, StockLog, HardwareType, UsageArea
+from models import StockAssignment, StockLog, HardwareType, UsageArea, LicenseName
 
 
 router = APIRouter(prefix="/stock", tags=["Stock"])
@@ -124,6 +124,9 @@ def current_stock(db: Session):
 def stock_list(request: Request, db: Session = Depends(get_db)):
     logs = db.query(StockLog).order_by(StockLog.tarih.desc(), StockLog.id.desc()).all()
     hardware_types = db.query(HardwareType).order_by(HardwareType.name).all()
+    license_names = db.query(LicenseName).order_by(LicenseName.name).all()
+    hardware_map = {str(h.id): h.name for h in hardware_types}
+    license_map = {str(l.id): l.name for l in license_names}
     users = [r[0] for r in db.execute(text("SELECT full_name FROM users ORDER BY full_name")).fetchall()]
     usage_areas = db.query(UsageArea).order_by(UsageArea.name).all()
     return templates.TemplateResponse(
@@ -132,6 +135,8 @@ def stock_list(request: Request, db: Session = Depends(get_db)):
             "request": request,
             "logs": logs,
             "hardware_types": hardware_types,
+            "hardware_map": hardware_map,
+            "license_map": license_map,
             "users": users,
             "usage_areas": usage_areas,
         },

--- a/templates/base.html
+++ b/templates/base.html
@@ -380,9 +380,18 @@ window.addEventListener("message", (e) => {
     first.value = ''; first.textContent = 'Seçiniz…';
     el.appendChild(first);
 
-    for (const v of (items || [])) {
+    const list = (items || []).map(v => {
+      if (v && typeof v === 'object') {
+        return { id: v.id ?? '', text: v.name ?? v.ad ?? v.text ?? v.value ?? '' };
+      }
+      return { id: '', text: v };
+    });
+
+    for (const v of list) {
       const opt = document.createElement('option');
-      opt.value = v; opt.textContent = v;
+      opt.value = v.text;
+      opt.textContent = v.text;
+      if (v.id) opt.dataset.id = v.id;
       el.appendChild(opt);
     }
 
@@ -401,14 +410,14 @@ window.addEventListener("message", (e) => {
     // TomSelect
     if (el.tomselect) {
       el.tomselect.clearOptions();
-      el.tomselect.addOptions((items||[]).map(v => ({ value: v, text: v })));
+      el.tomselect.addOptions(list.map(v => ({ value: v.text, text: v.text })));
     }
 
     // Choices.js
     if (window.Choices && el.classList.contains('choices')) {
       if (el._choices && el._choices.destroy) el._choices.destroy();
       el._choices = new Choices(el, { searchEnabled: true, itemSelectText: '' });
-      el._choices.setChoices((items||[]).map(v => ({ value: v, label: v })), 'value', 'label', true);
+      el._choices.setChoices(list.map(v => ({ value: v.text, label: v.text })), 'value', 'label', true);
     }
   }
 

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -49,7 +49,7 @@
         {% for r in logs %}
         <tr>
           <td>#{{ r.id }}</td>
-          <td>{{ r.donanim_tipi }}</td>
+          <td>{{ hardware_map.get(r.donanim_tipi) or license_map.get(r.donanim_tipi) or r.donanim_tipi }}</td>
           <td>{{ r.miktar }}</td>
           <td>{{ r.ifs_no or '-' }}</td>
           <td>{{ (r.tarih).strftime("%d.%m.%Y %H:%M") if r.tarih else '-' }}</td>
@@ -110,25 +110,23 @@
 
         <div id="hardwareFields" class="col-12">
           <div class="row g-3 stok-row">
-            <div class="col-md-4">
+            <div class="col-md-3">
               <label class="form-label">Donanım Tipi</label>
               <select name="donanim_tipi" class="form-select" data-lookup="donanim_tipi" id="stok_donanim_tipi" required></select>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-3">
               <label class="form-label">Marka (ops.)</label>
               <select name="marka" class="form-select" data-lookup="marka" id="stok_marka"></select>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-2">
               <label class="form-label">Model (ops.)</label>
               <select name="model" class="form-select" data-lookup="model" data-depends="#stok_marka" id="stok_model"></select>
             </div>
-          </div>
-          <div class="row g-3 mt-0">
             <div class="col-md-2" id="rowMiktar">
               <label class="form-label">Miktar</label>
               <input type="number" min="1" id="miktar" name="miktar" class="form-control" required>
             </div>
-            <div class="col-md-3">
+            <div class="col-md-2">
               <label class="form-label">IFS No (opsiyonel)</label>
               <input type="text" id="ifs_no" name="ifs_no" class="form-control">
             </div>


### PR DESCRIPTION
## Summary
- Lay out quantity and IFS fields inline with hardware selectors in stock add modal
- Show hardware and license names instead of numeric IDs in stock logs
- Improve lookup helper to handle objects and keep option values readable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b829703c24832b8280d8c74cbfe9d0