### PR TITLE
Fix stock add required field toggle

### DIFF
--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -18,7 +18,7 @@ chkIsLicense?.addEventListener('change', e=>{
   const isLic = e.target.checked;
   hardwareFields?.classList.toggle('d-none', isLic);
   licenseFields?.classList.toggle('d-none', !isLic);
-  donanimSel.required = !isLic;
+  donanimSel?.toggleAttribute('required', !isLic);
   rowMiktar?.classList.toggle('d-none', isLic);
   hardwareFields?.querySelectorAll('input,select').forEach(el=> el.disabled = isLic);
   licenseFields?.querySelectorAll('input,select').forEach(el=> el.disabled = !isLic);


### PR DESCRIPTION
## Summary
- prevent crash when toggling license checkbox in stock add modal by safely updating required attribute

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b831ba8d98832b99c360940af0727e