### PR TITLE
Validate stock quantity input

### DIFF
--- a/routers/stock.py
+++ b/routers/stock.py
@@ -155,7 +155,15 @@ def stock_status_json(db: Session = Depends(get_db)):
 def stock_add(payload: dict = Body(...), db: Session = Depends(get_db)):
     is_license = payload.get("is_license")
     donanim_tipi = payload.get("donanim_tipi")
-    miktar = 1 if is_license else int(payload.get("miktar") or 0)
+    if is_license:
+        miktar = 1
+    else:
+        try:
+            miktar = int(payload.get("miktar"))
+        except (TypeError, ValueError):
+            return {"ok": False, "error": "Miktar 0'dan büyük olmalı"}
+        if miktar <= 0:
+            return {"ok": False, "error": "Miktar 0'dan büyük olmalı"}
     islem = payload.get("islem") or "girdi"
 
     total = db.get(StockTotal, donanim_tipi) or StockTotal(

--- a/tests/test_stock_add.py
+++ b/tests/test_stock_add.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import models
+from routers.stock import stock_add
+
+
+@pytest.fixture()
+def db_session():
+    models.Base.metadata.create_all(models.engine)
+    db = models.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        models.Base.metadata.drop_all(models.engine)
+
+
+def test_stock_add_zero_amount(db_session):
+    payload = {
+        "is_license": False,
+        "donanim_tipi": "cpu",
+        "miktar": 0,
+        "islem_yapan": "test",
+    }
+    result = stock_add(payload, db_session)
+    assert result == {"ok": False, "error": "Miktar 0'dan büyük olmalı"}
+
+
+def test_stock_add_negative_amount(db_session):
+    payload = {
+        "is_license": False,
+        "donanim_tipi": "cpu",
+        "miktar": -5,
+        "islem_yapan": "test",
+    }
+    result = stock_add(payload, db_session)
+    assert result == {"ok": False, "error": "Miktar 0'dan büyük olmalı"}


### PR DESCRIPTION
## Summary
- ensure stock addition quantity is a positive integer
- add tests covering zero and negative quantities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8542209dc832b971a55b401f34e9c