### PR TITLE
Validate adet values in talep routes

### DIFF
--- a/routes/talepler.py
+++ b/routes/talepler.py
@@ -62,6 +62,8 @@ def olustur(
 
 @router.post("/{talep_id}/cancel", response_class=JSONResponse)
 def cancel_request(talep_id: int, adet: int = Form(1), db: Session = Depends(get_db)):
+    if adet <= 0:
+        return JSONResponse({"ok": False, "error": "Adet 0'dan büyük olmalı"}, status_code=400)
     talep = db.get(Talep, talep_id)
     if not talep:
         return JSONResponse({"ok": False}, status_code=404)
@@ -77,6 +79,8 @@ def cancel_request(talep_id: int, adet: int = Form(1), db: Session = Depends(get
 
 @router.post("/{talep_id}/close", response_class=JSONResponse)
 def close_request(talep_id: int, adet: int = Form(1), db: Session = Depends(get_db)):
+    if adet <= 0:
+        return JSONResponse({"ok": False, "error": "Adet 0'dan büyük olmalı"}, status_code=400)
     talep = db.get(Talep, talep_id)
     if not talep:
         return JSONResponse({"ok": False}, status_code=404)
@@ -92,6 +96,8 @@ def close_request(talep_id: int, adet: int = Form(1), db: Session = Depends(get_
 
 @router.get("/convert/{talep_id}", response_class=HTMLResponse)
 def convert_request(talep_id: int, request: Request, adet: int = 1, db: Session = Depends(get_db)):
+    if adet <= 0:
+        return HTMLResponse(status_code=400)
     talep = db.get(Talep, talep_id)
     if not talep:
         return HTMLResponse(status_code=404)

--- a/tests/test_talep_adet_validation.py
+++ b/tests/test_talep_adet_validation.py
@@ -1,0 +1,52 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import models
+from routes.talepler import cancel_request, close_request
+from models import Talep, TalepTuru
+
+
+@pytest.fixture()
+def db_session():
+    models.Base.metadata.create_all(models.engine)
+    db = models.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        models.Base.metadata.drop_all(models.engine)
+
+
+@pytest.fixture()
+def talep(db_session):
+    t = Talep(tur=TalepTuru.AKSESUAR, miktar=5)
+    db_session.add(t)
+    db_session.commit()
+    db_session.refresh(t)
+    return t
+
+
+def test_cancel_request_zero_adet(db_session, talep):
+    res = cancel_request(talep.id, adet=0, db=db_session)
+    assert res.status_code == 400
+
+
+def test_cancel_request_negative_adet(db_session, talep):
+    res = cancel_request(talep.id, adet=-1, db=db_session)
+    assert res.status_code == 400
+
+
+def test_close_request_zero_adet(db_session, talep):
+    res = close_request(talep.id, adet=0, db=db_session)
+    assert res.status_code == 400
+
+
+def test_close_request_negative_adet(db_session, talep):
+    res = close_request(talep.id, adet=-3, db=db_session)
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- Reject non-positive `adet` values for cancel, close and convert talep routes
- Add tests for zero and negative `adet` values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b930f0c85c832b818edb6285e55f39