### PR TITLE
Handle None IFS numbers in requests listing

### DIFF
--- a/routes/talepler.py
+++ b/routes/talepler.py
@@ -23,7 +23,12 @@ def liste(request: Request, durum: str = "aktif", db: Session = Depends(get_db))
         "iptal": TalepDurum.IPTAL,
     }
     selected = durum_map.get(durum, TalepDurum.AKTIF)
-    rows = db.query(Talep).filter(Talep.durum == selected).all()
+    rows = (
+        db.query(Talep)
+        .filter(Talep.durum == selected)
+        .order_by(Talep.ifs_no.asc(), Talep.id.asc())
+        .all()
+    )
 
     return templates.TemplateResponse(
         "talepler.html",

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -32,12 +32,14 @@
         </tr>
       </thead>
       <tbody>
-        {% set groups = rows|groupby('ifs_no') %}
-        {% for g in groups %}
-        <tr class="table-light">
-          <td colspan="{{ 13 if show_actions else 12 }}">IFS No: {{ g.grouper or '-' }}</td>
-        </tr>
-          {% for t in g.list %}
+        {% set last_ifs = None %}
+        {% for t in rows %}
+          {% if t.ifs_no != last_ifs %}
+          <tr class="table-light">
+            <td colspan="{{ 13 if show_actions else 12 }}">IFS No: {{ t.ifs_no or '-' }}</td>
+          </tr>
+          {% set last_ifs = t.ifs_no %}
+          {% endif %}
           <tr>
             <td>{{ t.id }}</td>
             <td>{{ t.tur }}</td>
@@ -63,7 +65,6 @@
             </td>
             {% endif %}
           </tr>
-          {% endfor %}
         {% endfor %}
         {% if rows|length == 0 %}
         <tr>


### PR DESCRIPTION
## Summary
- Sort requests by IFS number in backend and group manually in template
- Avoid Jinja `groupby` crash when `ifs_no` is null

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b958421248832bb83ba2f13972dca6