### PR TITLE
Track closing time for requests

### DIFF
--- a/alembic/versions/b35f0e3c9b9f_add_kapanma_tarihi_to_talepler.py
+++ b/alembic/versions/b35f0e3c9b9f_add_kapanma_tarihi_to_talepler.py
@@ -1,0 +1,23 @@
+"""Add kapanma_tarihi to talepler
+
+Revision ID: b35f0e3c9b9f
+Revises: c8b2f8041a88
+Create Date: 2024-11-09
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "b35f0e3c9b9f"
+down_revision = "c8b2f8041a88"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("talepler", sa.Column("kapanma_tarihi", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("talepler", "kapanma_tarihi")

--- a/models.py
+++ b/models.py
@@ -420,6 +420,7 @@ class Talep(Base):
     aciklama = Column(Text, nullable=True)
     durum = Column(Enum(TalepDurum), default=TalepDurum.AKTIF, nullable=False)
     olusturma_tarihi = Column(DateTime, default=datetime.utcnow, nullable=False)
+    kapanma_tarihi = Column(DateTime, nullable=True)
 
 
 class Lookup(Base):

--- a/routes/talepler.py
+++ b/routes/talepler.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from typing import Optional
 from io import BytesIO
 from openpyxl import Workbook
+from datetime import datetime
 
 from models import Talep, TalepTuru, TalepDurum
 from database import get_db
@@ -78,6 +79,7 @@ def cancel_request(talep_id: int, adet: int = Form(1), db: Session = Depends(get
     else:
         talep.durum = TalepDurum.IPTAL
         talep.miktar = 0
+        talep.kapanma_tarihi = datetime.utcnow()
     db.commit()
     return {"ok": True}
 
@@ -95,6 +97,7 @@ def close_request(talep_id: int, adet: int = Form(1), db: Session = Depends(get_
     else:
         talep.durum = TalepDurum.TAMAMLANDI
         talep.miktar = 0
+        talep.kapanma_tarihi = datetime.utcnow()
     db.commit()
     return {"ok": True}
 

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -33,7 +33,7 @@
           <td>{{ t.lisans_adi or '-' }}</td>
           <td>{{ t.sorumlu_personel or '-' }}</td>
           <td>{{ t.aciklama or '-' }}</td>
-          <td>{{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}</td>
+          <td>{{ (t.kapanma_tarihi if t.durum != 'aktif' and t.kapanma_tarihi else t.olusturma_tarihi).strftime('%Y-%m-%d %H:%M') }}</td>
         </tr>
         {% else %}
         <tr>

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -47,7 +47,7 @@
             <td>{{ t.model or '-' }}</td>
             <td>{{ t.miktar or '-' }}</td>
             <td>{{ t.aciklama or '-' }}</td>
-            <td>{{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}</td>
+            <td>{{ (t.kapanma_tarihi if t.durum != 'aktif' and t.kapanma_tarihi else t.olusturma_tarihi).strftime('%Y-%m-%d %H:%M') }}</td>
             {% if show_actions %}
             <td>
               <div class="btn-group">

--- a/tests/test_talep_adet_validation.py
+++ b/tests/test_talep_adet_validation.py
@@ -9,7 +9,7 @@ os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 
 import models
 from routes.talepler import cancel_request, close_request
-from models import Talep, TalepTuru
+from models import Talep, TalepTuru, TalepDurum
 
 
 @pytest.fixture()
@@ -50,3 +50,17 @@ def test_close_request_zero_adet(db_session, talep):
 def test_close_request_negative_adet(db_session, talep):
     res = close_request(talep.id, adet=-3, db=db_session)
     assert res.status_code == 400
+
+
+def test_kapanma_tarihi_set_on_cancel(db_session, talep):
+    cancel_request(talep.id, adet=5, db=db_session)
+    refreshed = db_session.get(Talep, talep.id)
+    assert refreshed.durum == TalepDurum.IPTAL
+    assert refreshed.kapanma_tarihi is not None
+
+
+def test_kapanma_tarihi_set_on_close(db_session, talep):
+    close_request(talep.id, adet=5, db=db_session)
+    refreshed = db_session.get(Talep, talep.id)
+    assert refreshed.durum == TalepDurum.TAMAMLANDI
+    assert refreshed.kapanma_tarihi is not None


### PR DESCRIPTION
## Summary
- store closure timestamp for requests
- display closure times for cancelled and completed requests
- test that request closing time is recorded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9953a57a4832bbbf53a034db19402