### PR TITLE
Display open and close/cancel dates for requests

### DIFF
--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -33,7 +33,15 @@
           <td>{{ t.lisans_adi or '-' }}</td>
           <td>{{ t.sorumlu_personel or '-' }}</td>
           <td>{{ t.aciklama or '-' }}</td>
-          <td>{{ (t.kapanma_tarihi if t.durum != 'aktif' and t.kapanma_tarihi else t.olusturma_tarihi).strftime('%Y-%m-%d %H:%M') }}</td>
+          <td>
+            {{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}
+            {% if t.durum != 'aktif' and t.kapanma_tarihi %}
+              <br>
+              <small class="text-muted">
+                {{ 'Kapanma: ' if t.durum == 'tamamlandi' else 'İptal: ' }}{{ t.kapanma_tarihi.strftime('%Y-%m-%d %H:%M') }}
+              </small>
+            {% endif %}
+          </td>
         </tr>
         {% else %}
         <tr>

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -47,7 +47,15 @@
             <td>{{ t.model or '-' }}</td>
             <td>{{ t.miktar or '-' }}</td>
             <td>{{ t.aciklama or '-' }}</td>
-            <td>{{ (t.kapanma_tarihi if t.durum != 'aktif' and t.kapanma_tarihi else t.olusturma_tarihi).strftime('%Y-%m-%d %H:%M') }}</td>
+            <td>
+              {{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }}
+              {% if t.durum != 'aktif' and t.kapanma_tarihi %}
+                <br>
+                <small class="text-muted">
+                  {{ 'Kapanma: ' if t.durum == 'tamamlandi' else 'İptal: ' }}{{ t.kapanma_tarihi.strftime('%Y-%m-%d %H:%M') }}
+                </small>
+              {% endif %}
+            </td>
             {% if show_actions %}
             <td>
               <div class="btn-group">


### PR DESCRIPTION
## Summary
- Always show request creation date
- Show closing or cancellation date for completed and cancelled requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba8f7dc998832b87340cc8b8a617c3