### PR TITLE
Handle missing kapanma_tarihi column for requests

### DIFF
--- a/models.py
+++ b/models.py
@@ -632,6 +632,10 @@ def init_db():
             conn.execute(
                 text("ALTER TABLE talepler ADD COLUMN donanim_tipi VARCHAR(150)")
             )
+        if "kapanma_tarihi" not in cols:
+            conn.execute(
+                text("ALTER TABLE talepler ADD COLUMN kapanma_tarihi DATETIME")
+            )
 
     # -- Printers --------------------------------------------------------------
     insp = inspect(engine)

--- a/tests/test_talep_kapanma_migration.py
+++ b/tests/test_talep_kapanma_migration.py
@@ -1,0 +1,31 @@
+import os
+import importlib
+
+from sqlalchemy import inspect
+
+
+def test_init_db_adds_kapanma_tarihi_column(tmp_path):
+    db_file = tmp_path / "talepler.db"
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_file}"
+    import models
+    importlib.reload(models)
+
+    with models.engine.begin() as conn:
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE talepler (
+                id INTEGER PRIMARY KEY,
+                tur VARCHAR(50)
+            )
+            """
+        )
+
+    models.init_db()
+
+    insp = inspect(models.engine)
+    cols = {c["name"] for c in insp.get_columns("talepler")}
+    assert "kapanma_tarihi" in cols
+
+    models.engine.dispose()
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    importlib.reload(models)


### PR DESCRIPTION
## Summary
- Ensure SQLite migrations add `kapanma_tarihi` to `talepler`
- Test that `init_db` populates missing `kapanma_tarihi`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba9378badc832b92afb15de94877b9