### PR TITLE
Add fallback dropdown menu styling

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -31,9 +31,39 @@
   font-size: .75rem;
 }
 
-/* Dropdown hep üstte kalsın */
+/* Dropdown hep üstte kalsın ve Bootstrap yoksa da düzgün görünsün */
 .dropdown-menu {
   z-index: 2000 !important;
+  position: absolute;
+  display: none;
+  min-width: 10rem;
+  margin: 0;
+  padding: .5rem 0;
+  list-style: none;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(0,0,0,.15);
+  border-radius: .375rem;
+}
+
+.dropdown-menu.show {
+  display: block;
+}
+
+.dropdown-item {
+  display: block;
+  width: 100%;
+  padding: .25rem 1rem;
+  clear: both;
+  color: #212529;
+  text-decoration: none;
+  background-color: transparent;
+  border: 0;
+}
+
+.dropdown-item:hover {
+  background-color: #f8f9fa;
+  color: #16181b;
 }
 
 /* Tablo ve kart içinde kesilmesin */


### PR DESCRIPTION
## Summary
- ensure dropdown menus retain proper positioning and appearance even without Bootstrap

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba9c172104832bb0ddbf272048d7f3