### PR TITLE
Fix request modal submission and model lookup

### DIFF
--- a/static/js/selects.js
+++ b/static/js/selects.js
@@ -42,8 +42,12 @@ async function bindMarkaModel(markaSelectId, modelSelectId) {
 
   async function updateModels() {
     const m = markaEl.value;
-    if (!m) { modelInst.clearStore(); modelEl.disabled = true; return; }
-    modelEl.disabled = false;
+    if (!m) {
+      modelInst.clearStore();
+      modelInst.disable();
+      return;
+    }
+    modelInst.enable();
     await fillChoices({ endpoint: "/api/lookup/model", selectId: modelSelectId, params: { marka_id: m }, placeholder: "Model seçiniz…" });
   }
   markaEl.addEventListener("change", updateModels);

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -166,7 +166,8 @@
       }
       if (markaSel && modelSel){
         modelSel.id = modelSel.id || `talep_model_${rowIdx}`;
-        _selects.bindMarkaModel(markaSel.id, modelSel.id);
+        modelSel.disabled = true;
+        await _selects.bindMarkaModel(markaSel.id, modelSel.id);
       }
       updateRemoveButtons();
     }
@@ -201,7 +202,7 @@
         const fd = new FormData();
         if (ifsNo) fd.append('ifs_no', ifsNo);
         row.querySelectorAll('input, select').forEach(el => {
-          const val = el._choices ? (el._choices.getValue()[0]?.label || '') : el.value;
+          const val = el._choices ? (el._choices.getValue()[0]?.value || '') : el.value;
           if (el.name && val) fd.append(el.name, val);
         });
         const res = await fetch('/talepler', { method: 'POST', body: fd });


### PR DESCRIPTION
## Summary
- Ensure model select is disabled until a brand is chosen and bind updates asynchronously
- Submit request form with correct select values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baa3dcf084832b810ca22d7fae6012