### PR TITLE
Fix talep modal selects and submission

### DIFF
--- a/static/js/selects.js
+++ b/static/js/selects.js
@@ -28,8 +28,17 @@ async function fillChoices({ endpoint, selectId, params={}, placeholder="Seçini
   const data = res.ok ? await res.json() : [];
   const current = keepValue ? el.value : null;
   inst.clearStore();
-  const map = mapFn || (r => ({ value: r.id, label: r.text ?? r.ad ?? r.name }));
-  inst.setChoices(data.map(map), 'value', 'label', true);
+  const map =
+    mapFn ||
+    (r => {
+      // Support both object and plain string responses
+      if (typeof r === "string") return { value: r, label: r };
+      return {
+        value: r.id ?? r.value ?? "",
+        label: r.name || r.text || r.ad || r.label || "",
+      };
+    });
+  inst.setChoices(data.map(map), "value", "label", true);
   if (keepValue && current) inst.setChoiceByValue(current);
 }
 

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -88,7 +88,7 @@
 <!-- Talep Aç Modal -->
 <div class="modal fade" id="talepModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-lg">
-    <form id="frmTalep" class="modal-content" onsubmit="return talepGonder(event)">
+    <form id="frmTalep" class="modal-content" method="post">
       <div class="modal-header">
         <h5 class="modal-title">Talep Aç</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
@@ -175,6 +175,8 @@
     document.addEventListener('DOMContentLoaded', () => {
       initRow(rowContainer.firstElementChild);
       updateRemoveButtons();
+      const frm = document.getElementById('frmTalep');
+      frm.addEventListener('submit', talepGonder);
     });
 
     document.addEventListener('click', async (ev) => {
@@ -182,7 +184,13 @@
       if (addBtn) {
         const clone = templateRow.cloneNode(true);
         clone.querySelectorAll('input').forEach(i => i.value = '');
-        clone.querySelectorAll('select').forEach(sel => sel.value = '');
+        clone.querySelectorAll('select').forEach(sel => {
+          sel.value = '';
+          if (sel._choices) {
+            sel._choices.destroy();
+            delete sel._choices;
+          }
+        });
         rowContainer.appendChild(clone);
         await initRow(clone);
         updateRemoveButtons();


### PR DESCRIPTION
## Summary
- Improve select option mapping to handle plain strings and varied keys
- Convert talep modal form to JS-based submission and clean cloned selects

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bac6840138832b88535c82f6ef873d