### PR TITLE
Implement talep modal submission and dependent model lookup

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,7 @@ from routers.api import router as api_router
 from routes.admin import router as admin_router
 from routes.scrap import router as scrap_router
 from routes.talepler import router as talepler_router
+from routes.talep_api import router as talep_api_router
 from utils.template_filters import register_filters
 from security import current_user, require_roles
 
@@ -134,6 +135,7 @@ app.include_router(profile.router, prefix="/profile", tags=["Profile"], dependen
 app.include_router(api_router)
 app.include_router(picker_router)
 app.include_router(lookup_router)
+app.include_router(talep_api_router)
 app.include_router(refdata.router, dependencies=[Depends(current_user)])
 
 @app.get("/licenses", include_in_schema=False)

--- a/routes/talep_api.py
+++ b/routes/talep_api.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from sqlalchemy import cast, Integer
+
+from database import get_db
+from models import Talep, TalepTuru, TalepDurum, HardwareType, Brand, Model
+
+router = APIRouter(prefix="/api/talep", tags=["Talep"])
+
+@router.post("/ekle")
+def talep_ekle(item: dict, db: Session = Depends(get_db)):
+    rec = Talep(
+        tur=TalepTuru.AKSESUAR,
+        ifs_no=item.get("ifs_no"),
+        donanim_tipi=item.get("donanim_tipi_id"),
+        marka=item.get("marka_id"),
+        model=item.get("model_id"),
+        miktar=item.get("miktar"),
+        aciklama=item.get("aciklama"),
+    )
+    db.add(rec)
+    db.commit()
+    db.refresh(rec)
+    return {"ok": True, "id": rec.id}
+
+@router.get("/liste")
+def talep_liste(db: Session = Depends(get_db)):
+    q = (
+        db.query(
+            Talep,
+            HardwareType.name.label("donanim_tipi_name"),
+            Brand.name.label("marka_name"),
+            Model.name.label("model_name"),
+        )
+        .outerjoin(HardwareType, HardwareType.id == cast(Talep.donanim_tipi, Integer))
+        .outerjoin(Brand, Brand.id == cast(Talep.marka, Integer))
+        .outerjoin(Model, Model.id == cast(Talep.model, Integer))
+        .order_by(Talep.id.desc())
+    )
+    rows = []
+    for t, dt_name, marka_name, model_name in q.all():
+        rows.append(
+            {
+                "id": t.id,
+                "ifs_no": t.ifs_no,
+                "donanim_tipi": dt_name or t.donanim_tipi,
+                "marka": marka_name or t.marka,
+                "model": model_name or t.model,
+                "miktar": t.miktar,
+                "aciklama": t.aciklama,
+                "tarih": t.olusturma_tarihi,
+            }
+        )
+    return rows

--- a/static/js/talep.js
+++ b/static/js/talep.js
@@ -1,0 +1,49 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const form = document.getElementById("talepForm");
+
+  // initial lookup fills
+  if (window._selects) {
+    _selects.fillChoices({ endpoint: "/api/lookup/donanim_tipi", selectId: "donanim_tipi", placeholder: "Donanım tipi" });
+    _selects.fillChoices({ endpoint: "/api/lookup/marka", selectId: "marka", placeholder: "Marka" });
+  }
+
+  const markaSel = document.getElementById("marka");
+  const modelSel = document.getElementById("model");
+
+  markaSel?.addEventListener("change", async function () {
+    const markaId = this.value;
+    modelSel.innerHTML = '<option value="">Yükleniyor...</option>';
+    try {
+      const r = await fetch(`/api/lookup/model?marka_id=${encodeURIComponent(markaId)}`);
+      const data = await r.json();
+      modelSel.innerHTML = data.map(m => `<option value="${m.id}">${m.name || m.adi}</option>`).join("");
+    } catch {
+      modelSel.innerHTML = '<option value="">Model bulunamadı</option>';
+    }
+  });
+
+  form?.addEventListener("submit", async (e) => {
+    e.preventDefault();
+
+    const payload = {
+      ifs_no: document.getElementById("ifs_no").value?.trim(),
+      donanim_tipi_id: Number(document.getElementById("donanim_tipi").value || 0),
+      marka_id: Number(markaSel?.value || 0),
+      model_id: Number(modelSel?.value || 0),
+      miktar: Number(document.getElementById("miktar").value || 0),
+      aciklama: document.getElementById("aciklama").value?.trim() || null
+    };
+
+    try {
+      const resp = await fetch("/api/talep/ekle", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      if (!resp.ok) throw new Error(await resp.text());
+      window.location.reload();
+    } catch (err) {
+      alert("Talep kaydedilemedi: " + err.message);
+    }
+  });
+});

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -79,133 +79,45 @@
 </div>
 <!-- Talep Aç Modal -->
 <div class="modal fade" id="modalTalepAc" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-centered">
-    <form id="frmTalepAc" class="modal-content" method="post">
+  <div class="modal-dialog modal-dialog-centered">
+    <form id="talepForm" class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Talep Aç</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
-
       <div class="modal-body">
         <div class="mb-3">
           <label class="form-label">IFS No</label>
-          <input type="text" class="form-control" name="ifs_no" placeholder="IFS No">
+          <input id="ifs_no" name="ifs_no" class="form-control" />
         </div>
-
-        <div class="talep-rows">
-          <!-- İlk satır -->
-          <div class="row g-2 align-items-end talep-row">
-            <div class="col-md-3">
-              <label class="form-label">Donanım Tipi</label>
-              <select class="form-select" name="donanim_tipi" data-lookup="donanim_tipi"></select>
-            </div>
-            <div class="col-md-2">
-              <label class="form-label">Miktar</label>
-              <input type="number" min="1" value="1" class="form-control" name="miktar">
-            </div>
-            <div class="col-md-3">
-              <label class="form-label">Marka</label>
-              <select class="form-select" name="marka" data-lookup="marka"></select>
-            </div>
-            <div class="col-md-3">
-              <label class="form-label">Model</label>
-              <select class="form-select" name="model" data-lookup="model" data-depends="[data-lookup='marka']"></select>
-            </div>
-            <div class="col-md-1">
-              <button type="button" class="btn btn-outline-danger" data-action="row-remove">✕</button>
-            </div>
-            <div class="col-12 mt-2">
-              <input type="text" class="form-control" name="aciklama" placeholder="Açıklama">
-            </div>
-          </div>
+        <div class="mb-3">
+          <label class="form-label">Donanım Tipi</label>
+          <select id="donanim_tipi" name="donanim_tipi" class="form-select"></select>
         </div>
-
-        <div class="mt-3">
-          <button type="button" class="btn btn-light" data-action="row-add">Satır Ekle</button>
+        <div class="mb-3">
+          <label class="form-label">Miktar</label>
+          <input id="miktar" name="miktar" type="number" class="form-control" />
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Marka</label>
+          <select id="marka" name="marka" class="form-select"></select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Model</label>
+          <select id="model" name="model" class="form-select"></select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Açıklama</label>
+          <input id="aciklama" name="aciklama" class="form-control" />
         </div>
       </div>
-
       <div class="modal-footer">
-        <button class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
         <button type="submit" class="btn btn-primary">Gönder</button>
       </div>
     </form>
   </div>
 </div>
 
-<!-- Satır template'i -->
-<template id="talep-row-template">
-  <div class="row g-2 align-items-end talep-row mt-2">
-    <div class="col-md-3">
-      <label class="form-label">Donanım Tipi</label>
-      <select class="form-select" name="donanim_tipi" data-lookup="donanim_tipi"></select>
-    </div>
-    <div class="col-md-2">
-      <label class="form-label">Miktar</label>
-      <input type="number" min="1" value="1" class="form-control" name="miktar">
-    </div>
-    <div class="col-md-3">
-      <label class="form-label">Marka</label>
-      <select class="form-select" name="marka" data-lookup="marka"></select>
-    </div>
-    <div class="col-md-3">
-      <label class="form-label">Model</label>
-      <select class="form-select" name="model" data-lookup="model" data-depends="[data-lookup='marka']"></select>
-    </div>
-    <div class="col-md-1">
-      <button type="button" class="btn btn-outline-danger" data-action="row-remove">✕</button>
-    </div>
-    <div class="col-12 mt-2">
-      <input type="text" class="form-control" name="aciklama" placeholder="Açıklama">
-    </div>
-  </div>
-</template>
-
-<script>
-document.addEventListener('click', (ev) => {
-  const modal = document.getElementById('modalTalepAc');
-  if (!modal) return;
-  const addBtn = ev.target.closest('[data-action="row-add"]');
-  if (addBtn) {
-    const container = modal.querySelector('.talep-rows');
-    const tpl = document.getElementById('talep-row-template');
-    if (container && tpl) {
-      container.appendChild(document.importNode(tpl.content, true));
-    }
-  }
-  const rm = ev.target.closest('[data-action="row-remove"]');
-  if (rm) {
-    const row = rm.closest('.talep-row');
-    if (row) row.remove();
-  }
-});
-
-document.addEventListener('submit', async (ev) => {
-  const form = ev.target.closest('#frmTalepAc');
-  if (!form) return;
-  ev.preventDefault();
-
-  const modal = document.getElementById('modalTalepAc');
-  const ifsNo = form.querySelector('[name="ifs_no"]')?.value || '';
-  const rows = form.querySelectorAll('.talep-row');
-
-  for (const row of rows) {
-    const fd = new FormData();
-    if (ifsNo) fd.append('ifs_no', ifsNo);
-    row.querySelectorAll('input, select').forEach(el => {
-      const val = el._choices ? (el._choices.getValue()[0]?.value || '') : el.value;
-      if (el.name && val) fd.append(el.name, val);
-    });
-    const res = await fetch('/requests', { method: 'POST', body: fd });
-    const data = await res.json();
-    if (!data.ok) {
-      alert('Kayıt hatası');
-      return;
-    }
-  }
-
-  bootstrap.Modal.getInstance(modal).hide();
-  location.reload();
-});
-</script>
+<script src="/static/js/talep.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add `/api/talep/ekle` and `/api/talep/liste` endpoints and wire router
- Post talep form via new `static/js/talep.js` and load models based on selected brand
- Join lookup tables so list view shows names instead of raw IDs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bae8e0697c832ba41c3c5408498185