### PR TITLE
Prompt for missing details when moving requests to stock

### DIFF
--- a/models.py
+++ b/models.py
@@ -356,6 +356,7 @@ class StockLog(Base):
     model = Column(String(150), nullable=True)
     lisans_anahtari = Column(String(500), nullable=True)
     mail_adresi = Column(String(200), nullable=True)
+    aciklama = Column(Text, nullable=True)
     tarih = Column(DateTime, default=datetime.utcnow)
     islem = Column(
         Enum("girdi", "cikti", "hurda", "atama", name="stock_islem"), nullable=False

--- a/routers/stock.py
+++ b/routers/stock.py
@@ -180,6 +180,7 @@ def stock_add(payload: dict = Body(...), db: Session = Depends(get_db)):
         mail_adresi=payload.get("mail_adresi") if is_license else None,
         miktar=miktar,
         ifs_no=payload.get("ifs_no") or None,
+        aciklama=payload.get("aciklama"),
         islem=islem,
         tarih=datetime.utcnow(),
         actor=payload.get("islem_yapan") or "Sistem",

--- a/static/js/talep.js
+++ b/static/js/talep.js
@@ -158,3 +158,63 @@
   });
 })();
 
+// Talep iptal
+window.talepIptal = async function(id, mevcut){
+  let adet = 1;
+  if(mevcut > 1){
+    const inp = prompt(`Kaç adet iptal edilecek? (1-${mevcut})`, mevcut);
+    if(!inp) return;
+    adet = Number(inp);
+    if(!adet || adet < 1 || adet > mevcut){ alert('Geçersiz adet'); return; }
+  }
+  const fd = new FormData();
+  fd.append('adet', String(adet));
+  try{
+    const r = await fetch(`/talepler/${id}/cancel`, {method:'POST', body: fd});
+    if(!r.ok){ alert('İşlem başarısız'); return; }
+    location.reload();
+  }catch(err){
+    console.error(err); alert('İşlem başarısız');
+  }
+}
+
+// Talep kapat ve stoğa aktar
+window.talepKapat = async function(id, mevcut){
+  let adet = 1;
+  if(mevcut > 1){
+    const inp = prompt(`Kaç adet stok gireceksiniz? (1-${mevcut})`, mevcut);
+    if(!inp) return;
+    adet = Number(inp);
+    if(!adet || adet < 1 || adet > mevcut){ alert('Geçersiz adet'); return; }
+  }
+
+  // Satırdan marka/model al, yoksa iste
+  const row = Array.from(document.querySelectorAll('tbody tr'))
+    .find(tr => tr.firstElementChild?.textContent.trim() === String(id));
+  let marka = row?.children[2]?.textContent.trim();
+  if(!marka || marka === '-'){
+    marka = prompt('Marka girin');
+    if(!marka) return;
+  }
+  let model = row?.children[3]?.textContent.trim();
+  if(!model || model === '-'){
+    model = prompt('Model girin');
+    if(!model) return;
+  }
+  const note = prompt('Not (opsiyonel)');
+
+  const fd = new FormData();
+  fd.append('adet', String(adet));
+  fd.append('marka', marka);
+  fd.append('model', model);
+  if(note) fd.append('aciklama', note);
+  try{
+    const r = await fetch(`/talepler/${id}/stock`, {method:'POST', body: fd});
+    if(!r.ok){ alert('İşlem başarısız'); return; }
+    location.reload();
+  }catch(err){
+    console.error(err); alert('İşlem başarısız');
+  }
+}
+
+


### PR DESCRIPTION
## Summary
- allow stock logs to store optional notes
- require and persist brand/model when converting requests into stock items
- prompt for quantity, brand/model, and notes on the request list page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee309d1d0832bb688690c03ebef44