### PR TITLE
Fix grouping and missing stock modal on requests list

### DIFF
--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -32,14 +32,12 @@
         </tr>
       </thead>
       <tbody>
-        {% set last_ifs = '' %}
         {% for t in rows %}
           {% set current_ifs = t.ifs_no or '-' %}
-          {% if current_ifs != last_ifs %}
+          {% if loop.changed(current_ifs) %}
           <tr class="table-light">
             <td colspan="{{ 8 if show_actions else 7 }}">IFS No: {{ current_ifs }}</td>
           </tr>
-          {% set last_ifs = current_ifs %}
           {% endif %}
           <tr>
             <td>{{ t.id }}</td>
@@ -134,7 +132,7 @@
       </form>
     </div>
   </div>
-</div>
+ </div>
 
 <!-- Talep Kapat Modal -->
 <div class="modal fade" id="talepKapatModal" tabindex="-1" aria-hidden="true">
@@ -171,6 +169,9 @@
   </div>
 </div>
 
-<!-- JS dosyan (sayfanın EN ALTINA koy) -->
-<script src="/static/js/talep.js"></script>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/talep.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Group requests by IFS using Jinja's `loop.changed` helper
- Load `talep.js` in page scripts block so the stock entry modal appears

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfe96db8b0832ba5477feef054c57b