### PR TITLE
Fix request grouping and restore stock entry modal

### DIFF
--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -10,21 +10,21 @@
     </div>
   </div>
 
-  {% macro render_table(rows, empty_msg) %}
+  {% macro render_table(rows, empty_msg, show_actions=False) %}
   <div class="table-responsive">
     <table class="table table-striped table-hover table-sm align-middle">
       <thead>
         <tr>
           <th>#</th><th>Tür</th><th>Donanım Tipi</th><th>Marka</th><th>Model</th><th>Miktar</th>
           <th>Envanter No</th><th>Lisans Adı</th><th>Sorumlu</th><th>Açıklama</th><th>Tarih</th>
+          {% if show_actions %}<th>İşlem</th>{% endif %}
         </tr>
       </thead>
       <tbody>
-        {% set last_ifs = None %}
         {% for t in rows %}
-          {% if t.ifs_no != last_ifs %}
-          <tr class="table-light"><td colspan="11">IFS No: {{ t.ifs_no or '-' }}</td></tr>
-          {% set last_ifs = t.ifs_no %}
+          {% set current_ifs = t.ifs_no or '-' %}
+          {% if loop.changed(current_ifs) %}
+          <tr class="table-light"><td colspan="{{ 12 if show_actions else 11 }}">IFS No: {{ current_ifs }}</td></tr>
           {% endif %}
           <tr>
             <td>{{ t.id }}</td>
@@ -46,11 +46,22 @@
                 </small>
               {% endif %}
             </td>
+            {% if show_actions %}
+            <td>
+              <div class="btn-group">
+                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" data-bs-toggle="dropdown">İşlem</button>
+                <ul class="dropdown-menu">
+                  <li><a class="dropdown-item" href="#" onclick="talepIptal({{ t.id }}, {{ t.miktar or 1 }}); return false;">İptal Et</a></li>
+                  <li><a class="dropdown-item" href="#" onclick="talepKapat({{ t.id }}, {{ t.miktar or 1 }}); return false;">Stok Gir</a></li>
+                </ul>
+              </div>
+            </td>
+            {% endif %}
           </tr>
         {% endfor %}
         {% if rows|length == 0 %}
         <tr>
-          <td colspan="11" class="text-center text-muted">{{ empty_msg }}</td>
+          <td colspan="{{ 12 if show_actions else 11 }}" class="text-center text-muted">{{ empty_msg }}</td>
         </tr>
         {% endif %}
       </tbody>
@@ -72,7 +83,7 @@
 
   <div class="tab-content mt-3" id="talepTabsContent">
     <div class="tab-pane fade show active" id="aktif" role="tabpanel" aria-labelledby="aktif-tab">
-      {{ render_table(aktif, "Aktif talep bulunamadı.") }}
+      {{ render_table(aktif, "Aktif talep bulunamadı.", True) }}
     </div>
     <div class="tab-pane fade" id="kapali" role="tabpanel" aria-labelledby="kapali-tab">
       {{ render_table(kapali, "Kapalı talep bulunamadı.") }}
@@ -129,6 +140,41 @@
         </div>
       </form>
     </div>
+  </div>
+</div>
+
+<!-- Talep Kapat Modal -->
+<div class="modal fade" id="talepKapatModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="talepKapatForm" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Stok Girişi</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" id="tkTalepId">
+        <div class="mb-3">
+          <label class="form-label">Miktar</label>
+          <input type="number" id="tkAdet" class="form-control" min="1" value="1">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Marka</label>
+          <select id="tkMarka" class="form-select"></select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Model</label>
+          <select id="tkModel" class="form-select"></select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Not (opsiyonel)</label>
+          <input type="text" id="tkAciklama" class="form-control">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
+        <button type="submit" class="btn btn-primary">Kaydet</button>
+      </div>
+    </form>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- group requests by IFS number in list view
- show request action menu with stock entry option
- add modal for entering stock information

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c00ad4833c832badd6428ce18f12cd