### PR TITLE
Fix talep cancellation auto-invocation

### DIFF
--- a/static/js/talep.js
+++ b/static/js/talep.js
@@ -176,7 +176,7 @@ window.talepIptal = async function(id, mevcut){
   }catch(err){
     console.error(err); alert('İşlem başarısız');
   }
-}
+};
 
 // Talep kapat ve stoğa aktar (modal ile)
 (() => {


### PR DESCRIPTION
## Summary
- Terminate `talepIptal` definition with a semicolon to prevent immediate invocation when the next IIFE runs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c015c26e14832b91da59e3e6736e37