### PR TITLE
Enable brand-based model filtering in admin panel

### DIFF
--- a/templates/admin/taxonomies.html
+++ b/templates/admin/taxonomies.html
@@ -16,6 +16,7 @@
             <input class="form-control ref-input" placeholder="Yeni kullanım alanı..." />
             <button class="btn btn-success ref-add">Ekle</button>
           </div>
+          <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>
@@ -31,6 +32,7 @@
             <input class="form-control ref-input" placeholder="Yeni lisans adı..." />
             <button class="btn btn-success ref-add">Ekle</button>
           </div>
+          <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>
@@ -46,6 +48,7 @@
             <input class="form-control ref-input" placeholder="Yeni fabrika..." />
             <button class="btn btn-success ref-add">Ekle</button>
           </div>
+          <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>
@@ -61,6 +64,7 @@
             <input class="form-control ref-input" placeholder="Yeni donanım tipi..." />
             <button class="btn btn-success ref-add">Ekle</button>
           </div>
+          <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>
@@ -76,6 +80,7 @@
             <input class="form-control ref-input" placeholder="Yeni marka..." />
             <button class="btn btn-success ref-add">Ekle</button>
           </div>
+          <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>
@@ -99,6 +104,7 @@
               </div>
             </div>
           </div>
+          <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
         </div>
       </div>
     </div>

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -37,6 +37,7 @@
               <input class="form-control ref-input" placeholder="Yeni kullanım alanı..." />
               <button class="btn btn-success ref-add" type="button">Ekle</button>
             </div>
+            <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -52,6 +53,7 @@
               <input class="form-control ref-input" placeholder="Yeni lisans adı..." />
               <button class="btn btn-success ref-add" type="button">Ekle</button>
             </div>
+            <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -67,6 +69,7 @@
               <input class="form-control ref-input" placeholder="Yeni fabrika..." />
               <button class="btn btn-success ref-add" type="button">Ekle</button>
             </div>
+            <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -82,6 +85,7 @@
               <input class="form-control ref-input" placeholder="Yeni donanım tipi..." />
               <button class="btn btn-success ref-add" type="button">Ekle</button>
             </div>
+            <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -97,6 +101,7 @@
               <input class="form-control ref-input" placeholder="Yeni marka..." />
               <button class="btn btn-success ref-add" type="button">Ekle</button>
             </div>
+            <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -120,6 +125,7 @@
                 </div>
               </div>
             </div>
+            <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
           </div>
         </div>
       </div>
@@ -261,14 +267,25 @@
           </table>
         </div>
 
+        </div>
       </div>
-    </div>
-  </div>
-
-</div>
+    </div> <!-- collapse -->
 
 
-</div>
+    </div> <!-- tab-pane: kullanıcılar -->
+  </div> <!-- tab-content -->
+  </div> <!-- page-section -->
+</div> <!-- container-fluid -->
+
+<link href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+<script defer src="/static/js/refdata.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    if (window.initRefAdmin) window.initRefAdmin();
+  });
+</script>
+
 <style>
   .nav-tabs .nav-link.active { font-weight:600; }
   .nav-pills .nav-link { padding:.25rem .75rem; }


### PR DESCRIPTION
## Summary
- show reference data lists and load brand selection in admin templates
- filter model entries by chosen brand like request form

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0218fad60832b9654c337dd2669c2