### PR TITLE
Add aciklama column to stock_logs

### DIFF
--- a/alembic/versions/1e4c12f4b1b9_add_aciklama_to_stock_logs.py
+++ b/alembic/versions/1e4c12f4b1b9_add_aciklama_to_stock_logs.py
@@ -1,0 +1,23 @@
+"""add aciklama to stock_logs
+
+Revision ID: 1e4c12f4b1b9
+Revises: 9f3d8fa40c3b
+Create Date: 2025-02-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "1e4c12f4b1b9"
+down_revision = "9f3d8fa40c3b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("stock_logs", sa.Column("aciklama", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("stock_logs", "aciklama")

--- a/models.py
+++ b/models.py
@@ -709,5 +709,7 @@ def init_db():
             conn.execute(
                 text("ALTER TABLE stock_logs ADD COLUMN mail_adresi VARCHAR(200)")
             )
+        if "aciklama" not in cols:
+            conn.execute(text("ALTER TABLE stock_logs ADD COLUMN aciklama TEXT"))
         if "actor" not in cols:
             conn.execute(text("ALTER TABLE stock_logs ADD COLUMN actor VARCHAR(150)"))

--- a/sql/2025-08-25_stock.sql
+++ b/sql/2025-08-25_stock.sql
@@ -3,6 +3,11 @@ CREATE TABLE IF NOT EXISTS stock_logs (
   donanim_tipi TEXT NOT NULL,
   miktar INTEGER NOT NULL,
   ifs_no TEXT,
+  marka TEXT,
+  model TEXT,
+  lisans_anahtari TEXT,
+  mail_adresi TEXT,
+  aciklama TEXT,
   tarih TEXT,
   islem TEXT NOT NULL,
   actor TEXT

--- a/tests/test_stock_log_aciklama_migration.py
+++ b/tests/test_stock_log_aciklama_migration.py
@@ -1,0 +1,54 @@
+import sys
+import sqlite3
+import importlib
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_init_db_adds_aciklama_column(tmp_path, monkeypatch):
+    db_file = tmp_path / "app.db"
+    conn = sqlite3.connect(db_file)
+    conn.execute(
+        """
+        CREATE TABLE stock_logs (
+            id INTEGER PRIMARY KEY,
+            donanim_tipi TEXT NOT NULL,
+            miktar INTEGER NOT NULL,
+            ifs_no TEXT,
+            marka TEXT,
+            model TEXT,
+            lisans_anahtari TEXT,
+            mail_adresi TEXT,
+            tarih TEXT,
+            islem TEXT NOT NULL,
+            actor TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_file}")
+    sys.modules.pop("models", None)
+    import models
+    importlib.reload(models)
+
+    models.init_db()
+
+    from sqlalchemy import inspect
+
+    insp = inspect(models.engine)
+    cols = {c["name"] for c in insp.get_columns("stock_logs")}
+    assert "aciklama" in cols
+
+    db = models.SessionLocal()
+    log = models.StockLog(donanim_tipi="mouse", miktar=1, islem="girdi", aciklama="test")
+    db.add(log)
+    db.commit()
+    db.close()
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    sys.modules.pop("models", None)
+    import models as _cleanup
+    importlib.reload(_cleanup)


### PR DESCRIPTION
## Summary
- ensure stock_logs table includes aciklama by auto-migrating existing SQLite databases
- add Alembic migration for aciklama
- cover stock log migration with regression test

## Testing
- `pytest tests/test_stock_log_aciklama_migration.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c137ff0a14832ba120965496287d60