### PR TITLE
Improve stock status view

### DIFF
--- a/routers/stock.py
+++ b/routers/stock.py
@@ -142,14 +142,19 @@ def stock_list(request: Request, db: Session = Depends(get_db)):
 
 @router.get("/durum", response_class=HTMLResponse)
 def stock_status_page(request: Request, db: Session = Depends(get_db)):
-    rows = current_stock(db)
+    """Stok durumunu HTML olarak göster."""
+    data = stock_status(db)
     return templates.TemplateResponse(
-        "stock_status.html", {"request": request, "rows": rows}
+        "stock_status.html",
+        {"request": request, "totals": data["totals"], "detail": data["detail"]},
     )
+
 
 @router.get("/durum/json")
 def stock_status_json(db: Session = Depends(get_db)):
-    return JSONResponse({"ok": True, "rows": current_stock(db)})
+    """Stok durumunu JSON olarak döndür."""
+    data = stock_status(db)
+    return JSONResponse({"ok": True, "totals": data["totals"], "detail": data["detail"]})
 
 @router.post("/add")
 def stock_add(payload: dict = Body(...), db: Session = Depends(get_db)):

--- a/templates/stock_status.html
+++ b/templates/stock_status.html
@@ -1,31 +1,48 @@
-<!doctype html>
-<html lang="tr">
-<head>
-  <meta charset="utf-8">
-  <title>Stok Durumu</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="p-3">
-  <h5>Stok Durumu</h5>
-  <div class="table-responsive">
-    <table class="table table-sm">
-      <thead class="table-light">
-        <tr>
-          <th>Donanım Tipi</th>
-          <th>IFS No</th>
-          <th>Stok</th>
-        </tr>
-      </thead>
-      <tbody>
-      {% for r in rows %}
-        <tr>
-          <td>{{ r.donanim_tipi }}</td>
-          <td>{{ r.ifs_no or '-' }}</td>
-          <td>{{ r.stok }}</td>
-        </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-  </div>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Stok Durumu{% endblock %}
+
+{% block content %}
+<h5>Stok Durumu</h5>
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead class="table-light">
+      <tr>
+        <th>Donanım Tipi</th>
+        <th>Stok</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for dt, qty in totals.items() %}
+      <tr>
+        <td>{{ dt }}</td>
+        <td>{{ qty }}</td>
+        <td>
+          {% if detail.get(dt) %}
+          <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="collapse" data-bs-target="#det{{ loop.index }}">
+            <i class="bi bi-list"></i>
+          </button>
+          {% endif %}
+        </td>
+      </tr>
+      {% if detail.get(dt) %}
+      <tr id="det{{ loop.index }}" class="collapse">
+        <td colspan="3">
+          <table class="table table-sm mb-0">
+            <thead class="table-light">
+              <tr><th>IFS No</th><th>Stok</th></tr>
+            </thead>
+            <tbody>
+              {% for ifs, q in detail.get(dt).items() %}
+              <tr><td>{{ ifs }}</td><td>{{ q }}</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      {% endif %}
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Use API's stock totals for status endpoints
- Render stock status page using base layout with collapsible IFS detail

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c13e1ee858832ba97c30b35c84720c