### PR TITLE
Add stock state endpoint and index page

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,7 @@ from routers.api import router as api_router
 from routes.admin import router as admin_router
 from routes.scrap import router as scrap_router
 from routes.talepler import router as talepler_router
+from routes.stock import router as stock_router
 from routers.talep import router as talep_router
 from utils.template_filters import register_filters
 from security import current_user, require_roles
@@ -129,6 +130,7 @@ app.include_router(catalog_router.router, dependencies=[Depends(current_user)])
 app.include_router(reqs.router, prefix="/requests", tags=["Requests"], dependencies=[Depends(current_user)])
 app.include_router(stock.router, dependencies=[Depends(current_user)])
 app.include_router(stock.api_router, dependencies=[Depends(current_user)])
+app.include_router(stock_router, dependencies=[Depends(current_user)])
 app.include_router(scrap_router, dependencies=[Depends(current_user)])
 app.include_router(talepler_router, dependencies=[Depends(current_user)])
 app.include_router(trash.router, prefix="/trash", tags=["Trash"], dependencies=[Depends(current_user)])

--- a/routes/stock.py
+++ b/routes/stock.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import StockTransaction
+
+router = APIRouter(prefix="/api/stock", tags=["stock"])
+
+
+@router.get("/state")
+def get_stock_state(db: Session = Depends(get_db)):
+    net_expr = func.sum(
+        case(
+            (StockTransaction.islem == "girdi", StockTransaction.miktar),
+            (StockTransaction.islem == "cikti", -StockTransaction.miktar),
+            else_=0,
+        )
+    ).label("stok")
+
+    hurda_expr = func.sum(
+        case((StockTransaction.islem == "hurda", StockTransaction.miktar), else_=0)
+    ).label("hurda")
+
+    q = (
+        db.query(StockTransaction.donanim_tipi.label("donanim_tipi"), net_expr, hurda_expr)
+        .group_by(StockTransaction.donanim_tipi)
+        .order_by(StockTransaction.donanim_tipi.asc())
+    )
+    rows = q.all()
+
+    return {
+        "items": [
+            {
+                "donanim_tipi": r.donanim_tipi,
+                "stok": int(r.stok or 0),
+                "hurda": int(r.hurda or 0),
+            }
+            for r in rows
+        ]
+    }

--- a/templates/stock/index.html
+++ b/templates/stock/index.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}{% block title %}Stok Durumu{% endblock %}
+{% block content %}
+<table id="stokTable" class="table table-striped">
+  <thead>
+    <tr>
+      <th>Donanım Tipi</th>
+      <th>Stok</th>
+      <th>Hurda</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td colspan="3" class="text-center text-muted">Yükleniyor…</td></tr>
+  </tbody>
+</table>
+
+<script>
+async function loadStockState(){
+  const tbody = document.querySelector('#stokTable tbody');
+  try{
+    const res = await fetch('/api/stock/state');
+    if(!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+
+    tbody.innerHTML = '';
+    if(!data.items || data.items.length === 0){
+      tbody.innerHTML = '<tr><td colspan="3" class="text-center text-muted">Stok bulunamadı</td></tr>';
+      return;
+    }
+
+    for(const row of data.items){
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${row.donanim_tipi ?? '-'}</td>
+        <td>${row.stok ?? 0}</td>
+        <td>${row.hurda ?? 0}</td>
+      `;
+      tbody.appendChild(tr);
+    }
+  }catch(e){
+    console.error(e);
+    tbody.innerHTML = '<tr><td colspan="3" class="text-danger text-center">Stok verisi alınamadı</td></tr>';
+  }
+}
+document.addEventListener('DOMContentLoaded', loadStockState);
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/api/stock/state` endpoint to report stock and scrap totals
- register new stock route in app
- render simple stock state table with client-side fetch

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3e20dfc58832b82a9307429d411fa