### PR TITLE
Add stock state endpoints and page

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,7 @@ from routes.admin import router as admin_router
 from routes.scrap import router as scrap_router
 from routes.talepler import router as talepler_router
 from routes.stock import router as stock_router
+from routes.pages_stock import pages as stock_pages
 from routers.talep import router as talep_router
 from utils.template_filters import register_filters
 from security import current_user, require_roles
@@ -131,6 +132,7 @@ app.include_router(reqs.router, prefix="/requests", tags=["Requests"], dependenc
 app.include_router(stock.router, dependencies=[Depends(current_user)])
 app.include_router(stock.api_router, dependencies=[Depends(current_user)])
 app.include_router(stock_router, dependencies=[Depends(current_user)])
+app.include_router(stock_pages)
 app.include_router(scrap_router, dependencies=[Depends(current_user)])
 app.include_router(talepler_router, dependencies=[Depends(current_user)])
 app.include_router(trash.router, prefix="/trash", tags=["Trash"], dependencies=[Depends(current_user)])

--- a/routes/pages_stock.py
+++ b/routes/pages_stock.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Depends, Request
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from database import get_db
+from routes.stock import stock_query
+
+templates = Jinja2Templates(directory="templates")
+pages = APIRouter()
+
+
+@pages.get("/stock")
+def stock_page(request: Request, db: Session = Depends(get_db)):
+    rows = stock_query(db).all()
+    items = [
+        {
+            "donanim_tipi": r.donanim_tipi,
+            "stok": int(r.stok or 0),
+            "hurda": int(r.hurda or 0),
+        }
+        for r in rows
+    ]
+    return templates.TemplateResponse(
+        "stock/index.html",
+        {
+            "request": request,
+            "stock_items": items,
+        },
+    )
+

--- a/routes/stock.py
+++ b/routes/stock.py
@@ -3,13 +3,12 @@ from sqlalchemy import case, func
 from sqlalchemy.orm import Session
 
 from database import get_db
-from models import StockTransaction
+from models import HardwareType, StockTransaction
 
 router = APIRouter(prefix="/api/stock", tags=["stock"])
 
 
-@router.get("/state")
-def get_stock_state(db: Session = Depends(get_db)):
+def stock_query(db: Session):
     net_expr = func.sum(
         case(
             (StockTransaction.islem == "girdi", StockTransaction.miktar),
@@ -23,15 +22,31 @@ def get_stock_state(db: Session = Depends(get_db)):
     ).label("hurda")
 
     q = (
-        db.query(StockTransaction.donanim_tipi.label("donanim_tipi"), net_expr, hurda_expr)
-        .group_by(StockTransaction.donanim_tipi)
-        .order_by(StockTransaction.donanim_tipi.asc())
+        db.query(
+            HardwareType.id.label("donanim_tipi_id"),
+            func.coalesce(HardwareType.name, StockTransaction.donanim_tipi).label(
+                "donanim_tipi"
+            ),
+            net_expr,
+            hurda_expr,
+        )
+        .select_from(StockTransaction)
+        .outerjoin(HardwareType, HardwareType.name == StockTransaction.donanim_tipi)
+        .group_by(
+            HardwareType.id, HardwareType.name, StockTransaction.donanim_tipi
+        )
+        .order_by(func.coalesce(HardwareType.name, StockTransaction.donanim_tipi).asc())
     )
-    rows = q.all()
+    return q
 
+
+@router.get("/state")
+def get_stock_state(db: Session = Depends(get_db)):
+    rows = stock_query(db).all()
     return {
         "items": [
             {
+                "donanim_tipi_id": r.donanim_tipi_id,
                 "donanim_tipi": r.donanim_tipi,
                 "stok": int(r.stok or 0),
                 "hurda": int(r.hurda or 0),
@@ -39,3 +54,27 @@ def get_stock_state(db: Session = Depends(get_db)):
             for r in rows
         ]
     }
+
+
+@router.get("/state/debug")
+def get_stock_state_debug(db: Session = Depends(get_db)):
+    counts = (
+        db.query(
+            StockTransaction.islem,
+            func.count(1).label("adet"),
+            func.coalesce(func.sum(StockTransaction.miktar), 0).label("toplam"),
+        )
+        .group_by(StockTransaction.islem)
+        .all()
+    )
+    return {
+        "hareket_ozet": [
+            {
+                "islem": c.islem,
+                "adet": int(c.adet),
+                "toplam": int(c.toplam or 0),
+            }
+            for c in counts
+        ]
+    }
+

--- a/templates/stock/index.html
+++ b/templates/stock/index.html
@@ -1,6 +1,5 @@
-{% extends "base.html" %}{% block title %}Stok Durumu{% endblock %}
-{% block content %}
-<table id="stokTable" class="table table-striped">
+<h2>Stok Takibi</h2>
+<table class="table table-striped">
   <thead>
     <tr>
       <th>Donanım Tipi</th>
@@ -9,38 +8,19 @@
     </tr>
   </thead>
   <tbody>
-    <tr><td colspan="3" class="text-center text-muted">Yükleniyor…</td></tr>
+    {% if stock_items and stock_items|length > 0 %}
+      {% for r in stock_items %}
+        <tr>
+          <td>{{ r.donanim_tipi or '-' }}</td>
+          <td>{{ r.stok }}</td>
+          <td>{{ r.hurda }}</td>
+        </tr>
+      {% endfor %}
+    {% else %}
+      <tr>
+        <td colspan="3" class="text-center text-muted">Stok bulunamadı</td>
+      </tr>
+    {% endif %}
   </tbody>
 </table>
 
-<script>
-async function loadStockState(){
-  const tbody = document.querySelector('#stokTable tbody');
-  try{
-    const res = await fetch('/api/stock/state');
-    if(!res.ok) throw new Error('HTTP ' + res.status);
-    const data = await res.json();
-
-    tbody.innerHTML = '';
-    if(!data.items || data.items.length === 0){
-      tbody.innerHTML = '<tr><td colspan="3" class="text-center text-muted">Stok bulunamadı</td></tr>';
-      return;
-    }
-
-    for(const row of data.items){
-      const tr = document.createElement('tr');
-      tr.innerHTML = `
-        <td>${row.donanim_tipi ?? '-'}</td>
-        <td>${row.stok ?? 0}</td>
-        <td>${row.hurda ?? 0}</td>
-      `;
-      tbody.appendChild(tr);
-    }
-  }catch(e){
-    console.error(e);
-    tbody.innerHTML = '<tr><td colspan="3" class="text-danger text-center">Stok verisi alınamadı</td></tr>';
-  }
-}
-document.addEventListener('DOMContentLoaded', loadStockState);
-</script>
-{% endblock %}


### PR DESCRIPTION
## Summary
- expose stock state and debug endpoints
- add HTML page to display current stock
- wire new stock routes into application

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3e486c7f0832ba20e3915c822f23a