### PR TITLE
Add note logging to stock assignments

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -252,6 +252,7 @@ def stock_log_create(
     islem: str,
     ifs_no: str | None = None,
     islem_yapan: str | None = None,
+    aciklama: str | None = None,
     db: Session = Depends(get_db),
 ):
     if islem not in ("girdi", "cikti", "hurda"):
@@ -269,6 +270,7 @@ def stock_log_create(
         islem=islem,
         ifs_no=ifs_no,
         actor=islem_yapan,
+        aciklama=aciklama,
     )
     db.add(log)
     total.toplam = total.toplam + miktar if islem == "girdi" else total.toplam - miktar
@@ -287,6 +289,7 @@ def stock_assign(
     sorumlu_personel: str | None = None,
     kullanim_alani: str | None = None,
     islem_yapan: str | None = None,
+    aciklama: str | None = None,
     db: Session = Depends(get_db),
 ):
     if hedef_tur not in ("envanter", "lisans", "yazici"):
@@ -313,6 +316,7 @@ def stock_assign(
         "cikti",
         ifs_no=ifs_no,
         islem_yapan=islem_yapan,
+        aciklama=aciklama,
         db=db,
     )
     assign = models.StockAssignment(

--- a/routers/stock.py
+++ b/routers/stock.py
@@ -376,6 +376,7 @@ def stock_assign(payload: AssignPayload, db: Session = Depends(get_db)):
                 ifs_no=ifs_no,
                 islem="cikti",
                 actor=personel,
+                aciklama=payload.notlar,
                 source_type=payload.atama_turu,
                 source_id=(
                     payload.hedef_envanter_id

--- a/tests/test_stock_assign.py
+++ b/tests/test_stock_assign.py
@@ -41,6 +41,7 @@ def test_stock_assign_updates_license(db_session):
         ifs_no="IFS1",
         hedef_envanter_no="INV001",
         sorumlu_personel="Ali",
+        aciklama="Test notu",
         db=db,
     )
 
@@ -52,6 +53,7 @@ def test_stock_assign_updates_license(db_session):
     assert log.miktar == 1
     assert log.ifs_no == "IFS1"
     assert log.islem == "cikti"
+    assert log.aciklama == "Test notu"
     assign = db.query(models.StockAssignment).first()
     assert assign.hedef_envanter_no == "INV001"
 


### PR DESCRIPTION
## Summary
- allow passing `aciklama` (note) when creating stock logs
- propagate notes through stock assignment endpoint
- test that assignment notes are stored

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3fd04e09c832b9afa77ef2ea4ab63