### PR TITLE
Align stock lookup and status handling

### DIFF
--- a/routes/talepler.py
+++ b/routes/talepler.py
@@ -186,7 +186,7 @@ def convert_request_to_stock(
         talep.aciklama = aciklama
 
     payload = {
-        "is_license": talep.tur == TalepTuru.LISANS,
+        "is_lisans": talep.tur == TalepTuru.LISANS,
         "donanim_tipi": talep.donanim_tipi,
         "miktar": adet,
         "marka": marka,

--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -36,9 +36,12 @@ document.getElementById('frmStockAdd')?.addEventListener('submit', async (e)=>{
   if(chkIsLicense?.checked){
     fd.set('miktar','1');
     fd.set('donanim_tipi', fd.get('lisans_adi')||'');
-    fd.set('is_license','1');
+    fd.set('is_lisans','1');
+    fd.delete('is_license');
   }
   const payload = Object.fromEntries(fd.entries());
+  const miktar = Number(payload.miktar);
+  if(!miktar || miktar <= 0){ alert('Miktar 0\'dan büyük olmalı'); return; }
   try{
     const res = await fetch('/stock/add', {
       method:'POST',
@@ -270,11 +273,18 @@ function loadStockStatus() {
       if (!tbody) return;
       const items = Array.isArray(data) ? data : data.rows;
       if (!Array.isArray(items) || items.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="3" class="text-center text-muted">Stok bulunamadı</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">Stok bulunamadı</td></tr>';
         return;
       }
       const rows = items
-        .map(item => `<tr><td>${item.donanim_tipi || '-'}</td><td>${item.stok}</td><td></td></tr>`)
+        .map(item => `<tr>
+          <td>${item.donanim_tipi || '-'}</td>
+          <td>${item.marka || '-'}</td>
+          <td>${item.model || '-'}</td>
+          <td>${item.ifs_no || '-'}</td>
+          <td class="text-end">${item.net_miktar}</td>
+          <td>${item.son_islem_ts ? new Date(item.son_islem_ts).toLocaleString() : '-'}</td>
+        </tr>`)
         .join('');
       tbody.innerHTML = rows;
     })
@@ -282,7 +292,7 @@ function loadStockStatus() {
       console.error('stock status load failed', err);
       const tbody = document.querySelector('#tblStockStatus tbody');
       if (tbody) {
-        tbody.innerHTML = '<tr><td colspan="3" class="text-center text-muted">Veri alınamadı</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">Veri alınamadı</td></tr>';
       }
     });
 }

--- a/templates/stock.html
+++ b/templates/stock.html
@@ -18,7 +18,11 @@
         <thead>
           <tr>
             <th data-field="donanim_tipi">Donanım Tipi</th>
-            <th data-field="stok" data-align="right">Stok</th>
+            <th data-field="marka">Marka</th>
+            <th data-field="model">Model</th>
+            <th data-field="ifs_no">IFS No</th>
+            <th data-field="net_miktar" data-align="right">Stok</th>
+            <th data-field="son_islem_ts">Son İşlem</th>
           </tr>
         </thead>
       </table>

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -80,8 +80,11 @@
             <thead class="table-light">
               <tr>
                 <th>Donanım Tipi</th>
-                <th>Stok</th>
-                <th></th>
+                <th>Marka</th>
+                <th>Model</th>
+                <th>IFS No</th>
+                <th class="text-end">Stok</th>
+                <th>Son İşlem</th>
               </tr>
             </thead>
             <tbody></tbody>
@@ -103,7 +106,7 @@
       <div class="modal-body row g-3">
         <div class="col-12">
           <div class="form-check">
-            <input class="form-check-input" type="checkbox" id="chkIsLicense" name="is_license">
+            <input class="form-check-input" type="checkbox" id="chkIsLicense" name="is_lisans">
             <label class="form-check-label" for="chkIsLicense">Lisans</label>
           </div>
         </div>

--- a/tests/test_lookup_model_alias.py
+++ b/tests/test_lookup_model_alias.py
@@ -1,0 +1,49 @@
+import os, sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+import models
+from routers.lookup import lookup_model
+
+
+@pytest.fixture()
+def db_session():
+    models.Base.metadata.create_all(models.engine)
+    db = models.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        models.Base.metadata.drop_all(models.engine)
+
+
+def _seed(db):
+    b = models.Brand(name='Asus')
+    db.add(b)
+    db.flush()
+    db.add(models.Model(name='A1', brand_id=b.id))
+    db.commit()
+    return b
+
+
+def test_lookup_model_alias_with_name(db_session):
+    b = _seed(db_session)
+    res = lookup_model(marka=b.name, db=db_session)
+    assert res and res[0]['name'] == 'A1'
+
+
+def test_lookup_model_alias_with_id(db_session):
+    b = _seed(db_session)
+    res = lookup_model(marka=str(b.id), db=db_session)
+    assert res and res[0]['name'] == 'A1'
+
+
+def test_lookup_model_requires_brand(db_session):
+    _seed(db_session)
+    with pytest.raises(HTTPException):
+        lookup_model(marka_id=None, marka=None, db=db_session)

--- a/tests/test_stock_add.py
+++ b/tests/test_stock_add.py
@@ -24,7 +24,7 @@ def db_session():
 
 def test_stock_add_zero_amount(db_session):
     payload = {
-        "is_license": False,
+        "is_lisans": False,
         "donanim_tipi": "cpu",
         "miktar": 0,
         "islem_yapan": "test",
@@ -35,7 +35,7 @@ def test_stock_add_zero_amount(db_session):
 
 def test_stock_add_negative_amount(db_session):
     payload = {
-        "is_license": False,
+        "is_lisans": False,
         "donanim_tipi": "cpu",
         "miktar": -5,
         "islem_yapan": "test",

--- a/tests/test_stock_status_api.py
+++ b/tests/test_stock_status_api.py
@@ -1,0 +1,39 @@
+import os, sys
+from pathlib import Path
+from datetime import datetime
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+import models
+from models import StockLog
+from routers.stock import stock_status
+
+
+@pytest.fixture()
+def db_session():
+    models.Base.metadata.create_all(models.engine)
+    db = models.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        models.Base.metadata.drop_all(models.engine)
+
+
+def test_stock_status_returns_rows(db_session):
+    db_session.add(StockLog(donanim_tipi='laptop', marka='asus', model='a110', ifs_no='ifs', miktar=2, islem='girdi', tarih=datetime.utcnow()))
+    db_session.add(StockLog(donanim_tipi='laptop', marka='asus', model='a110', ifs_no='ifs', miktar=1, islem='cikti', tarih=datetime.utcnow()))
+    db_session.commit()
+
+    rows = stock_status(db_session)
+    assert rows
+    row = rows[0]
+    assert row['donanim_tipi'] == 'laptop'
+    assert row['marka'] == 'asus'
+    assert row['model'] == 'a110'
+    assert row['ifs_no'] == 'ifs'
+    assert row['net_miktar'] == 1
+    assert row['son_islem_ts'] is not None


### PR DESCRIPTION
## Summary
- accept `marka` alias for `/api/lookup/model` and raise 422 when brand missing
- expose detailed fields on `/api/stock/status` and support `is_lisans` in stock operations
- update front-end selects and stock pages for new contract and validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4014bb5c0832bb8cc1bbd14ffa3eb