### PR TITLE
Fix stock status API fields and UI bindings

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -243,8 +243,6 @@ def stock_status_detail(db: Session = Depends(get_db)):
     return {"totals": totals, "items": items}
 
 
-@router.get("/stock/status")
-
 @router.post("/stock/logs")
 def stock_log_create(
     donanim_tipi: str,

--- a/routers/stock.py
+++ b/routers/stock.py
@@ -182,11 +182,11 @@ def stock_status(db: Session = Depends(get_db)):
         elif donanim in license_map:
             donanim = license_map[donanim]
 
-        marka = r.get("marka")
+        marka = r.get("marka") or None
         if marka and marka in brand_map:
             marka = brand_map[marka]
 
-        model = r.get("model")
+        model = r.get("model") or None
         if model and model in model_map:
             model = model_map[model]
 
@@ -195,7 +195,7 @@ def stock_status(db: Session = Depends(get_db)):
                 "donanim_tipi": donanim,
                 "marka": marka,
                 "model": model,
-                "ifs_no": r.get("ifs_no"),
+                "ifs_no": r.get("ifs_no") or "",
                 "net_miktar": r.get("net"),
                 "son_islem_ts": r.get("last_tarih"),
                 "source_type": r.get("source_type"),

--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -275,7 +275,7 @@ function loadStockStatus() {
     .then(data => {
       const tbody = document.querySelector('#tblStockStatus tbody');
       if (!tbody) return;
-      const items = Array.isArray(data) ? data : data.rows;
+      const items = Array.isArray(data) ? data : (data.items || data.rows);
       if (!Array.isArray(items) || items.length === 0) {
         tbody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">Stok bulunamadı</td></tr>';
         return;
@@ -287,7 +287,7 @@ function loadStockStatus() {
           <td>${item.model || '-'}</td>
           <td>${item.ifs_no || '-'}</td>
           <td class="text-end">${item.net_miktar}</td>
-          <td>${item.son_islem_ts ? new Date(item.son_islem_ts).toLocaleString() : '-'}</td>
+          <td>${item.son_islem_ts ? new Date(item.son_islem_ts).toLocaleString('tr-TR', { day:'2-digit', month:'2-digit', year:'numeric', hour:'2-digit', minute:'2-digit', hour12:false }) : '-'}</td>
         </tr>`)
         .join('');
       tbody.innerHTML = rows;

--- a/templates/stock.html
+++ b/templates/stock.html
@@ -22,7 +22,7 @@
             <th data-field="model" data-formatter="emptyFormatter">Model</th>
             <th data-field="ifs_no" data-formatter="emptyFormatter">IFS No</th>
             <th data-field="net_miktar" data-align="right">Stok</th>
-            <th data-field="son_islem_ts" data-formatter="emptyFormatter">Son İşlem</th>
+            <th data-field="son_islem_ts" data-formatter="dateFormatter">Son İşlem</th>
             <th data-formatter="detailFormatter" data-align="center"></th>
           </tr>
         </thead>
@@ -36,7 +36,20 @@
 
 <script>
 function emptyFormatter(value) {
-  return value ?? '-';
+  return value === null || value === undefined || value === '' ? '-' : value;
+}
+
+function dateFormatter(value) {
+  if (!value) return '-';
+  const d = new Date(value);
+  return d.toLocaleString('tr-TR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
 }
 
 function detailFormatter(value, row) {
@@ -53,7 +66,7 @@ function showStockDetail(encoded) {
     `Model: ${row.model ?? '-'}`,
     `IFS No: ${row.ifs_no ?? '-'}`,
     `Stok: ${row.net_miktar}`,
-    `Son İşlem: ${row.son_islem_ts ?? '-'}`,
+    `Son İşlem: ${dateFormatter(row.son_islem_ts)}`,
   ];
   alert(lines.join('\n'));
 }

--- a/templates/stock_status.html
+++ b/templates/stock_status.html
@@ -56,7 +56,7 @@ async function loadStokDurumu() {
     tbody.innerHTML = data.map(item => `
       <tr>
         <td>${item.donanim_tipi || '-'}</td>
-        <td class="text-end">${item.stok}</td>
+        <td class="text-end">${item.net_miktar}</td>
       </tr>
     `).join('');
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure `/api/stock/status` only maps to stock log creation once and returns labelled fields
- normalize API output and format stock status dates
- update stock status pages to use new contract

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c40b0ba3cc832b8b16a402529c1fc5