### PR TITLE
Track source records for stock entries

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -472,6 +472,8 @@ def stock_entry(
             model=item.model,
             islem="girdi",
             actor=actor,
+            source_type="envanter",
+            source_id=item.id,
         )
     )
     db.add(

--- a/routers/license.py
+++ b/routers/license.py
@@ -278,6 +278,8 @@ def stock_license(lic_id: int, db: Session = Depends(get_db), user=Depends(curre
         mail_adresi=lic.mail_adresi,
         islem="girdi",
         actor=actor,
+        source_type="lisans",
+        source_id=lic.id,
     )
     db.add(log)
 

--- a/routers/printers.py
+++ b/routers/printers.py
@@ -363,6 +363,8 @@ def stock_printer(printer_id: int, db: Session = Depends(get_db), user=Depends(c
             model=p.model,
             islem="girdi",
             actor=actor,
+            source_type="yazici",
+            source_id=p.id,
         )
     )
     db.add(

--- a/routers/stock.py
+++ b/routers/stock.py
@@ -199,6 +199,7 @@ def stock_status(db: Session = Depends(get_db)):
                 "net_miktar": r.get("net"),
                 "son_islem_ts": r.get("last_tarih"),
                 "source_type": r.get("source_type"),
+                "source_id": r.get("source_id"),
             }
         )
     return items

--- a/templates/stock.html
+++ b/templates/stock.html
@@ -60,6 +60,18 @@ function detailFormatter(value, row) {
 
 function showStockDetail(encoded) {
   const row = JSON.parse(decodeURIComponent(encoded));
+  let url = '';
+  if (row.source_type === 'envanter' && row.source_id) {
+    url = `/inventory/${row.source_id}`;
+  } else if (row.source_type === 'lisans' && row.source_id) {
+    url = `/lisans/${row.source_id}`;
+  } else if (row.source_type === 'yazici' && row.source_id) {
+    url = `/printers/${row.source_id}`;
+  }
+  if (url) {
+    window.open(url, '_blank');
+    return;
+  }
   const lines = [
     `Donanım Tipi: ${row.donanim_tipi ?? '-'}`,
     `Marka: ${row.marka ?? '-'}`,

--- a/tests/test_inventory_printer_stock.py
+++ b/tests/test_inventory_printer_stock.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import models
+from routers.inventory import stock_entry
+from routers.printers import stock_printer
+
+import pytest
+
+
+@pytest.fixture()
+def db_session():
+    models.Base.metadata.create_all(models.engine)
+    db = models.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        models.Base.metadata.drop_all(models.engine)
+
+
+def test_inventory_stock_source(db_session):
+    inv = models.Inventory(
+        no="E1",
+        donanim_tipi="Laptop",
+        marka="Dell",
+        model="X",
+        ifs_no="IFS1",
+    )
+    db_session.add(inv)
+    db_session.commit()
+
+    user = SimpleNamespace(username="tester")
+    stock_entry(inv.id, db=db_session, user=user)
+
+    log = db_session.query(models.StockLog).order_by(models.StockLog.id.desc()).first()
+    assert log.source_type == "envanter"
+    assert log.source_id == inv.id
+
+
+def test_printer_stock_source(db_session):
+    p = models.Printer(
+        marka="HP",
+        model="P100",
+        ifs_no="PRN1",
+    )
+    db_session.add(p)
+    db_session.commit()
+
+    user = SimpleNamespace(username="tester")
+    stock_printer(p.id, db=db_session, user=user)
+
+    log = db_session.query(models.StockLog).order_by(models.StockLog.id.desc()).first()
+    assert log.source_type == "yazici"
+    assert log.source_id == p.id
+

--- a/tests/test_license_stock.py
+++ b/tests/test_license_stock.py
@@ -45,3 +45,5 @@ def test_stock_license_updates_total(db_session):
     assert log.miktar == 1
     assert log.islem == "girdi"
     assert log.ifs_no == "IFS-L1"
+    assert log.source_type == "lisans"
+    assert log.source_id == lic.id


### PR DESCRIPTION
## Summary
- store `source_type` and `source_id` when inventory items, licenses, or printers are added to stock
- expose origin identifiers in stock status API and link to underlying records in the stock page
- add tests for tracking source info on stock entries

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `python3 -m pip install pytest` *(fails: No module named pip)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c40db9fd94832bbdab9594a813de08