### PR TITLE
Improve stock add form error handling

### DIFF
--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -51,7 +51,33 @@ document.addEventListener('DOMContentLoaded', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       });
-      const j = await res.json();
+
+      if (!res.ok) {
+        let errMsg = `HTTP ${res.status}`;
+        if (res.statusText) {
+          errMsg += ` ${res.statusText}`;
+        }
+        try {
+          const bodyText = await res.text();
+          if (bodyText) {
+            errMsg += `\n${bodyText}`;
+          }
+        } catch (bodyErr) {
+          console.error('stock add response read failed', bodyErr);
+        }
+        alert(`Kayıt başarısız: ${errMsg}`);
+        return;
+      }
+
+      let j;
+      try {
+        j = await res.json();
+      } catch (jsonErr) {
+        console.error('stock add response parse failed', jsonErr);
+        alert('Sunucudan geçerli JSON alınamadı.');
+        return;
+      }
+
       if (j.ok) {
         location.reload();
       } else {


### PR DESCRIPTION
## Summary
- ensure the stock add form checks `res.ok` before parsing the response and shows HTTP error details to the user
- wrap the JSON parsing in a try/catch so non-JSON responses are handled gracefully

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9417bb2e4832b8296a68d89ae7e85