### PR TITLE
Remove unused sqlalchemy import from db bootstrap

### DIFF
--- a/db_bootstrap.py
+++ b/db_bootstrap.py
@@ -1,4 +1,3 @@
-from sqlalchemy import text
 from models import engine
 
 


### PR DESCRIPTION
## Summary
- remove the unused `text` import in `db_bootstrap.py`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c94e842204832bb28293ba38551ee4