### PR TITLE
Remove unused SQLAlchemy and_ import

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
 from database import get_db
 import models
-from sqlalchemy import func, case, and_, or_
+from sqlalchemy import func, case, or_
 from typing import List
 
 router = APIRouter(prefix="/api", tags=["API"])


### PR DESCRIPTION
## Summary
- remove the unused `and_` helper from the SQLAlchemy import in the API router

## Testing
- ruff check routers/api.py

------
https://chatgpt.com/codex/tasks/task_e_68c95262d7e4832bb899548de97304aa