### PR TITLE
Remove unused TalepDurum import

### DIFF
--- a/routers/talep.py
+++ b/routers/talep.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, conint
 from typing import List, Optional
 
 from database import get_db
-from models import Talep, TalepTuru, HardwareType, Brand, Model, TalepDurum
+from models import Talep, TalepTuru, HardwareType, Brand, Model
 
 router = APIRouter(prefix="/api/talep", tags=["Talep"])
 


### PR DESCRIPTION
## Summary
- remove the unused `TalepDurum` import from the talep router module.

## Testing
- ruff check routers/talep.py

------
https://chatgpt.com/codex/tasks/task_e_68c95681f1b8832bbf6f17005fb920b5