### PR TITLE
Remove unused pytest import from theme migration test

### DIFF
--- a/tests/test_theme_migration.py
+++ b/tests/test_theme_migration.py
@@ -3,7 +3,6 @@ import sys
 import importlib
 from pathlib import Path
 
-import pytest
 from sqlalchemy import inspect
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- remove the unused pytest import from the theme migration test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c95958eb7c832bb2be91f560cd51cb