### PR TITLE
Replace ambiguous l variables with clearer names

### DIFF
--- a/routers/catalog.py
+++ b/routers/catalog.py
@@ -37,7 +37,7 @@ def list_factories(db: Session = Depends(get_db)):
 @router.get("/license-names")
 def list_license_names(db: Session = Depends(get_db)):
     items = db.query(LicenseName).order_by(LicenseName.name.asc()).all()
-    return [{"id": l.id, "name": l.name} for l in items]
+    return [{"id": license_name.id, "name": license_name.name} for license_name in items]
 
 
 @router.get("/hardware-types")
@@ -115,10 +115,10 @@ def create_license_name(name: str, db: Session = Depends(get_db)):
     exists = db.query(LicenseName).filter(LicenseName.name.ilike(name)).first()
     if exists:
         return {"ok": True, "id": exists.id}
-    l = LicenseName(name=name)
-    db.add(l)
+    license_name = LicenseName(name=name)
+    db.add(license_name)
     db.commit()
-    return {"ok": True, "id": l.id}
+    return {"ok": True, "id": license_name.id}
 
 
 @router.post("/hardware-types")

--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -149,37 +149,37 @@ async function sa_loadStocks(){
 }
 
 async function sa_loadSources(){
-  const fill = (id, arr, v="id", l="ad")=>{
+  const fill = (id, arr, valueKey="id", labelKey="ad")=>{
     const el = $(id); if(!el) return;
     el.innerHTML = `<option value="">Seçiniz...</option>`;
     (arr||[]).forEach(x=>{
       const o = document.createElement("option");
-      o.value = x[v]; o.textContent = x[l] ?? x[v];
+      o.value = x[valueKey]; o.textContent = x[labelKey] ?? x[valueKey];
       el.appendChild(o);
     });
   };
 
   try{
-    const [u,l,e,y] = await Promise.all([
+    const [userResponse, licenseResponse, inventoryResponse, printerResponse] = await Promise.all([
       fetch(`${URL_ASSIGN_SOURCES}?type=users`),
       fetch(`${URL_ASSIGN_SOURCES}?type=licenses`),
       fetch(`${URL_ASSIGN_SOURCES}?type=envanter`),
       fetch(`${URL_ASSIGN_SOURCES}?type=yazici`)
     ]);
-    if(!u.ok||!l.ok||!e.ok||!y.ok){
-      showBanner("Atama kaynakları alınamadı. URL prefix doğru mu?"); 
+    if(!userResponse.ok||!licenseResponse.ok||!inventoryResponse.ok||!printerResponse.ok){
+      showBanner("Atama kaynakları alınamadı. URL prefix doğru mu?");
     }
-    const users = u.ok? await u.json():[];
-    const lic   = l.ok? await l.json():[];
-    const env   = e.ok? await e.json():[];
-    const yaz   = y.ok? await y.json():[];
+    const users       = userResponse.ok? await userResponse.json():[];
+    const licenses    = licenseResponse.ok? await licenseResponse.json():[];
+    const inventories = inventoryResponse.ok? await inventoryResponse.json():[];
+    const printers    = printerResponse.ok? await printerResponse.json():[];
 
     fill("#sa_user", users, "id", "ad");
     fill("#sa_user2", users, "id", "ad");
-    fill("#sa_lisans", lic, "id", "lisans_adi");
-    fill("#sa_envanter", env, "id", "envanter_no");
-    fill("#sa_envanter_for_lic", env, "id", "envanter_no");
-    fill("#sa_yazici", yaz, "id", "model");
+    fill("#sa_lisans", licenses, "id", "lisans_adi");
+    fill("#sa_envanter", inventories, "id", "envanter_no");
+    fill("#sa_envanter_for_lic", inventories, "id", "envanter_no");
+    fill("#sa_yazici", printers, "id", "model");
   }catch(e){
     showBanner("Atama kaynakları yüklenemedi. Konsolu kontrol edin."); console.error(e);
   }

--- a/templates/inventory_detail.html
+++ b/templates/inventory_detail.html
@@ -101,12 +101,12 @@
   <h6 class="mt-4">Bağlı Lisanslar</h6>
   <ul class="list-group">
     {% if lisanslar and lisanslar|length %}
-      {% for l in lisanslar %}
+      {% for license_obj in lisanslar %}
       <li class="list-group-item d-flex justify-content-between align-items-center">
-        <span>{{ l.lisans_adi }}{% if l.lisans_anahtari %} - {{ l.lisans_anahtari }}{% endif %}</span>
+        <span>{{ license_obj.lisans_adi }}{% if license_obj.lisans_anahtari %} - {{ license_obj.lisans_anahtari }}{% endif %}</span>
         <div class="d-flex align-items-center gap-2">
-          <span class="text-muted">{{ l.durum or 'Aktif' }}</span>
-          <button class="btn btn-sm btn-outline-secondary license-detail-btn" data-id="{{ l.id }}" title="Detayları Göster">
+          <span class="text-muted">{{ license_obj.durum or 'Aktif' }}</span>
+          <button class="btn btn-sm btn-outline-secondary license-detail-btn" data-id="{{ license_obj.id }}" title="Detayları Göster">
             <i class="bi bi-eye"></i>
           </button>
         </div>


### PR DESCRIPTION
## Summary
- rename ambiguous single-letter license variables in the catalog router and inventory detail template
- update stock assignment helper to use descriptive parameter and response names

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c95cc171e8832ba144767e74fe8c1b