### PR TITLE
Enhance stock assignment flow with dynamic forms

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -200,6 +200,8 @@ def stock_status_detail(db: Session = Depends(get_db)):
             models.StockLog.ifs_no,
             models.StockLog.source_type,
             models.StockLog.source_id,
+            models.StockLog.lisans_anahtari,
+            models.StockLog.mail_adresi,
             models.StockLog.tarih,
             models.StockLog.id,
         )
@@ -214,12 +216,18 @@ def stock_status_detail(db: Session = Depends(get_db)):
     ).all()
 
     last_source: dict[
-        tuple[str, str | None, str | None, str | None], tuple[str | None, int | None]
+        tuple[str, str | None, str | None, str | None],
+        dict[str, str | int | None],
     ] = {}
     for r in last_logs:
         key = (r.donanim_tipi, r.marka, r.model, r.ifs_no)
         if key not in last_source:
-            last_source[key] = (r.source_type, r.source_id)
+            last_source[key] = {
+                "source_type": r.source_type,
+                "source_id": r.source_id,
+                "lisans_anahtari": r.lisans_anahtari,
+                "mail_adresi": r.mail_adresi,
+            }
 
     items: list[dict] = []
     totals_calc: dict[str, int] = {}
@@ -229,7 +237,7 @@ def stock_status_detail(db: Session = Depends(get_db)):
         if qty <= 0:
             continue
         key = (r.donanim_tipi, r.marka, r.model, r.ifs_no)
-        src = last_source.get(key, (None, None))
+        src = last_source.get(key, {})
         items.append(
             {
                 "donanim_tipi": r.donanim_tipi,
@@ -238,8 +246,10 @@ def stock_status_detail(db: Session = Depends(get_db)):
                 "ifs_no": r.ifs_no,
                 "net": qty,
                 "last_tarih": r.last_tarih,
-                "source_type": src[0],
-                "source_id": src[1],
+                "source_type": src.get("source_type"),
+                "source_id": src.get("source_id"),
+                "lisans_anahtari": src.get("lisans_anahtari"),
+                "mail_adresi": src.get("mail_adresi"),
             }
         )
         totals_calc[r.donanim_tipi] = totals_calc.get(r.donanim_tipi, 0) + qty

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -257,54 +257,144 @@
             <div class="tab-content border border-top-0 p-3 rounded-bottom">
               <!-- LISANS -->
               <div class="tab-pane fade show active" id="sa_tab_lisans" role="tabpanel">
-                <div class="row g-3">
-                  <div class="col-md-6">
-                    <label class="form-label">Lisans</label>
-                    <select id="sa_lisans" class="form-select">
-                      <option value="">Seçiniz...</option>
-                    </select>
+                <div class="row g-3" id="sa_license_form">
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">Lisans Adı</label>
+                    <input id="sa_license_name" class="form-control" data-auto-key="donanim_tipi" placeholder="Lisans adı" required>
+                  </div>
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">Lisans Anahtarı</label>
+                    <input id="sa_license_key" class="form-control" data-auto-key="lisans_anahtari" placeholder="Lisans anahtarı">
                   </div>
                   <div class="col-md-6">
                     <label class="form-label">Sorumlu Personel</label>
-                    <select id="sa_user" class="form-select">
+                    <select id="sa_license_person" class="form-select" data-no-search>
                       <option value="">Seçiniz...</option>
                     </select>
                   </div>
                   <div class="col-md-6">
                     <label class="form-label">Bağlı Envanter (opsiyonel)</label>
-                    <select id="sa_envanter_for_lic" class="form-select">
+                    <select id="sa_license_inventory" class="form-select" data-no-search>
                       <option value="">Seçiniz...</option>
                     </select>
+                  </div>
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">IFS No</label>
+                    <input id="sa_license_ifs" class="form-control" data-auto-key="ifs_no" placeholder="IFS No">
+                  </div>
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">Mail Adresi</label>
+                    <input id="sa_license_mail" type="email" class="form-control" data-auto-key="mail_adresi" placeholder="ornek@firma.com">
                   </div>
                 </div>
               </div>
 
               <!-- ENVANTER -->
               <div class="tab-pane fade" id="sa_tab_envanter" role="tabpanel">
-                <div class="row g-3">
+                <div class="row g-3" id="sa_inventory_form">
                   <div class="col-md-6">
-                    <label class="form-label">Hedef Envanter</label>
-                    <select id="sa_envanter" class="form-select">
+                    <label class="form-label">Envanter No</label>
+                    <input id="sa_inv_no" class="form-control" placeholder="ENV-000123" required>
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Bilgisayar Adı</label>
+                    <input id="sa_inv_pc" class="form-control" placeholder="PC-OFIS-01">
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Fabrika</label>
+                    <select id="sa_inv_factory" class="form-select" data-no-search>
                       <option value="">Seçiniz...</option>
                     </select>
                   </div>
                   <div class="col-md-6">
-                    <label class="form-label">Sorumlu Personel (opsiyonel)</label>
-                    <select id="sa_user2" class="form-select">
+                    <label class="form-label">Departman</label>
+                    <select id="sa_inv_department" class="form-select" data-no-search>
                       <option value="">Seçiniz...</option>
                     </select>
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Kullanım Alanı</label>
+                    <select id="sa_inv_usage" class="form-select" data-no-search>
+                      <option value="">Seçiniz...</option>
+                    </select>
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Sorumlu Personel</label>
+                    <select id="sa_inv_person" class="form-select" data-no-search>
+                      <option value="">Seçiniz...</option>
+                    </select>
+                  </div>
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">Donanım Tipi</label>
+                    <input id="sa_inv_hardware" class="form-control" data-auto-key="donanim_tipi" placeholder="Donanım tipi">
+                  </div>
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">Marka</label>
+                    <input id="sa_inv_brand" class="form-control" data-auto-key="marka" placeholder="Marka">
+                  </div>
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">Model</label>
+                    <input id="sa_inv_model" class="form-control" data-auto-key="model" placeholder="Model">
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Seri No</label>
+                    <input id="sa_inv_serial" class="form-control" placeholder="Seri no">
+                  </div>
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">IFS No</label>
+                    <input id="sa_inv_ifs" class="form-control" data-auto-key="ifs_no" placeholder="IFS No">
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Bağlı Makina No</label>
+                    <input id="sa_inv_machine" class="form-control" placeholder="Makina no">
+                  </div>
+                  <div class="col-12">
+                    <label class="form-label">Notlar (opsiyonel)</label>
+                    <textarea id="sa_inv_note" class="form-control" rows="2" placeholder="Ek bilgi"></textarea>
                   </div>
                 </div>
               </div>
 
               <!-- YAZICI -->
               <div class="tab-pane fade" id="sa_tab_yazici" role="tabpanel">
-                <div class="row g-3">
+                <div class="row g-3" id="sa_printer_form">
                   <div class="col-md-6">
-                    <label class="form-label">Hedef Yazıcı</label>
-                    <select id="sa_yazici" class="form-select">
+                    <label class="form-label">Envanter No</label>
+                    <input id="sa_prn_no" class="form-control" placeholder="PRN-000123" required>
+                  </div>
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">Marka</label>
+                    <input id="sa_prn_brand" class="form-control" data-auto-key="marka" placeholder="Marka">
+                  </div>
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">Model</label>
+                    <input id="sa_prn_model" class="form-control" data-auto-key="model" placeholder="Model">
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Kullanım Alanı</label>
+                    <select id="sa_prn_usage" class="form-select" data-no-search>
                       <option value="">Seçiniz...</option>
                     </select>
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">IP Adresi</label>
+                    <input id="sa_prn_ip" class="form-control" placeholder="192.168.x.x">
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">MAC</label>
+                    <input id="sa_prn_mac" class="form-control" placeholder="AA:BB:CC:DD:EE:FF">
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Hostname</label>
+                    <input id="sa_prn_host" class="form-control" placeholder="Yazıcı adı">
+                  </div>
+                  <div class="col-md-6" data-auto-field>
+                    <label class="form-label">IFS No</label>
+                    <input id="sa_prn_ifs" class="form-control" data-auto-key="ifs_no" placeholder="IFS No">
+                  </div>
+                  <div class="col-12">
+                    <label class="form-label">Notlar (opsiyonel)</label>
+                    <textarea id="sa_prn_note" class="form-control" rows="2" placeholder="Ek bilgi"></textarea>
                   </div>
                 </div>
               </div>
@@ -315,7 +405,8 @@
           <div class="row g-3">
             <div class="col-md-4">
               <label class="form-label">Miktar</label>
-              <input id="sa_miktar" type="number" class="form-control" value="1" min="1">
+              <input id="sa_miktar" type="number" class="form-control" value="1" min="1" readonly>
+              <div class="form-text">Atamalar tekil kayıt oluşturur.</div>
             </div>
             <div class="col-md-8">
               <label class="form-label">Notlar (opsiyonel)</label>


### PR DESCRIPTION
## Summary
- expose license key and mail metadata from the stock detail API so assignment options know what information can be auto-filled
- rework the `/stock/assign` endpoint to accept nested form payloads, create inventory/license/printer records, normalize log payloads and persist stock assignment entries
- rebuild the stock assignment modal and client script to display target-specific forms, auto-hide populated fields, and submit the new payload structure
- cover the new behaviour with unit tests for creation scenarios and concurrent access

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca9fb515c8832bbc32e7330c93372e