### PR TITLE
Refactor scrap view to a single searchable table

### DIFF
--- a/templates/hurdalar.html
+++ b/templates/hurdalar.html
@@ -1,138 +1,77 @@
 {% extends "base.html" %}
-{% from "components/tabs.html" import tabs %}
-{% set active_key = request.query_params.get("tur") or "envanter" %}
 {% block title %}Hurdalar{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
-  <div class="tabs-wrap">
-    {{ tabs(
-      items=[
-        {"label":"Envanter Hurda","href": url_for('inventory.hurdalar') ~ "?tur=envanter","key":"envanter"},
-        {"label":"Lisans","href": url_for('inventory.hurdalar') ~ "?tur=lisans","key":"lisans"},
-        {"label":"Yazıcı","href": url_for('inventory.hurdalar') ~ "?tur=yazici","key":"yazici"},
-      ],
-      active_key=active_key
-    ) }}
+  <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3">
+    <h2 class="h4 mb-0">Hurdalar</h2>
+    <div class="d-flex flex-column flex-sm-row gap-2 w-100 w-lg-auto ms-lg-auto">
+      <div class="input-group">
+        <span class="input-group-text"><i class="bi bi-search"></i></span>
+        <input type="search" id="scrapSearch" class="form-control" placeholder="Ara...">
+      </div>
+      <select id="scrapTypeFilter" class="form-select">
+        <option value="all">Tümü</option>
+        <option value="envanter">Envanter</option>
+        <option value="lisans">Lisans</option>
+        <option value="yazici">Yazıcı</option>
+      </select>
+    </div>
   </div>
-  <div class="page-section">
-    {% if active_key == "envanter" %}
-    <div id="envanter">
-      <div class="table-responsive">
-        <table class="table table-striped table-hover table-sm align-middle">
-        <thead>
-          <tr>
-            <th>Envanter No</th>
-            <th>Marka</th>
-            <th>Model</th>
-            <th>Seri No</th>
-            <th>Departman</th>
-            <th>Tarih</th>
-            <th>Loglar</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for item in hurdalar %}
-          <tr>
-            <td>{{ item.no }}</td>
-            <td>{{ item.marka }}</td>
-            <td>{{ item.model }}</td>
-            <td>{{ item.seri_no }}</td>
-            <td>{{ item.departman }}</td>
-            <td>{{ item.tarih }}</td>
-            <td>
-              <ul class="mb-0 small">
-                {% for log in logs_map[item.id] %}
+
+  <div class="table-responsive">
+    <table class="table table-striped table-hover table-sm align-middle" id="scrapTable">
+      <thead class="table-light">
+        <tr>
+          <th scope="col">Tip</th>
+          <th scope="col">Başlık</th>
+          <th scope="col">Detaylar</th>
+          <th scope="col" class="text-nowrap">Tarih</th>
+          <th scope="col" class="text-end"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% set badge_map = {'envanter': 'text-bg-primary', 'lisans': 'text-bg-success', 'yazici': 'text-bg-warning'} %}
+        {% for item in combined_scraps %}
+        <tr data-type="{{ item.type }}" data-search="{{ item.search|e }}">
+          <td>
+            <span class="badge {{ badge_map.get(item.type, 'text-bg-secondary') }}">{{ item.type_label }}</span>
+          </td>
+          <td>
+            <div class="fw-semibold">{{ item.title }}</div>
+            <div class="text-muted small">{{ item.subtitle }}</div>
+          </td>
+          <td>
+            <ul class="list-unstyled mb-0 small">
+              {% for detail in item.details %}
+              <li><span class="text-muted">{{ detail.label }}:</span> {{ detail.value }}</li>
+              {% endfor %}
+            </ul>
+            {% if item.type == 'envanter' %}
+            <div class="mt-2">
+              <div class="text-muted small fw-semibold">Loglar</div>
+              <ul class="mb-0 small ps-3">
+                {% for log in item.logs %}
                 <li>{{ log|humanize_log }}</li>
                 {% else %}
                 <li class="text-muted">Log yok</li>
                 {% endfor %}
               </ul>
-            </td>
-            <td class="text-nowrap">
-              <button class="btn btn-outline-secondary btn-sm view-btn" data-id="{{ item.id }}" title="Detayı Göster">
-                <i class="bi bi-eye"></i>
-              </button>
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-        </table>
-      </div>
-    </div>
-    {% elif active_key == "lisans" %}
-    <div id="lisans">
-      <div class="table-responsive">
-        <table class="table table-striped table-hover table-sm align-middle">
-        <thead>
-          <tr><th>No</th><th>Lisans Adı</th><th>Key</th><th>Sorumlu</th><th>Bağlı Envanter</th><th>Not</th><th></th></tr>
-        </thead>
-        <tbody>
-          {% for row in license_scraps %}
-          <tr>
-            <td>{{ row.id }}</td>
-            <td>{{ row.lisans_adi }}</td>
-            <td class="text-truncate" style="max-width:220px;">{{ row.lisans_key }}</td>
-            <td>{{ row.sorumlu_personel or '-' }}</td>
-            <td>{{ row.bagli_envanter_no or '-' }}</td>
-            <td>{{ row.notlar or '-' }}</td>
-            <td class="text-nowrap">
-              <button class="btn btn-outline-secondary btn-sm view-btn" data-id="{{ row.id }}" title="Detayı Göster">
-                <i class="bi bi-eye"></i>
-              </button>
-            </td>
-          </tr>
-          {% else %}
-          <tr><td colspan="7" class="text-muted">Kayıt yok.</td></tr>
-          {% endfor %}
-        </tbody>
-        </table>
-      </div>
-    </div>
-    {% else %}
-    <div id="yazici">
-      <div class="table-responsive">
-        <table class="table table-striped table-hover table-sm align-middle">
-          <thead class="table-light">
-            <tr>
-              <th>ID</th>
-              <th>Marka/Model</th>
-              <th>Seri</th>
-              <th>Fabrika</th>
-              <th>Kullanım Alanı</th>
-              <th>Sorumlu</th>
-              <th>Bağlı Env.</th>
-              <th>Not</th>
-              <th>Tarih</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for r in printer_scraps %}
-            <tr>
-              <td>#{{ r.printer_id }}</td>
-              <td>{{ r.snapshot.marka }} {{ r.snapshot.model }}</td>
-              <td>{{ r.snapshot.seri_no }}</td>
-              <td>{{ r.snapshot.fabrika or '-' }}</td>
-              <td>{{ r.snapshot.kullanim_alani or '-' }}</td>
-              <td>{{ r.snapshot.sorumlu_personel or '-' }}</td>
-              <td>{{ r.snapshot.bagli_envanter_no or '-' }}</td>
-              <td>{{ r.reason or '-' }}</td>
-              <td>{{ r.created_at.strftime("%d.%m.%Y %H:%M") }}</td>
-              <td>
-                <button class="btn btn-outline-secondary btn-sm view-btn" data-id="{{ r.printer_id }}" title="Detayı Göster">
-                  <i class="bi bi-eye"></i>
-                </button>
-              </td>
-            </tr>
-            {% else %}
-            <tr><td colspan="9" class="text-muted">Kayıt yok.</td></tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-    {% endif %}
+            </div>
+            {% endif %}
+          </td>
+          <td class="text-nowrap">{{ item.display_date }}</td>
+          <td class="text-end">
+            <button class="btn btn-outline-secondary btn-sm view-btn" data-url="{{ item.detail_url }}" title="Detayı Göster">
+              <i class="bi bi-eye"></i>
+            </button>
+          </td>
+        </tr>
+        {% endfor %}
+        <tr id="scrapTableEmpty" class="d-none">
+          <td colspan="5" class="text-center text-muted py-3">Kayıt bulunamadı.</td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 
@@ -148,30 +87,43 @@
 </div>
 
 <script>
-document.querySelectorAll('#envanter .view-btn').forEach(b=>{
-  b.addEventListener('click', async ()=>{
-    const id = b.dataset.id;
-    const r = await fetch('/scrap/inventory/'+id);
-    const h = await r.text();
-    document.getElementById('hurdaDetayBody').innerHTML = h;
-    new bootstrap.Modal(document.getElementById('hurdaDetayModal')).show();
-  });
-});
+const rows = Array.from(document.querySelectorAll('#scrapTable tbody tr[data-type]'));
+const emptyRow = document.getElementById('scrapTableEmpty');
+const searchInput = document.getElementById('scrapSearch');
+const typeFilter = document.getElementById('scrapTypeFilter');
 
-document.querySelectorAll('#lisans .view-btn').forEach(b=>{
-  b.addEventListener('click', async ()=>{
-    const id = b.dataset.id;
-    const r = await fetch('/lisans/detail/'+id);
-    const h = await r.text();
-    document.getElementById('hurdaDetayBody').innerHTML = h;
-    new bootstrap.Modal(document.getElementById('hurdaDetayModal')).show();
-  });
-});
+function applyFilters() {
+  const term = searchInput.value.trim().toLowerCase();
+  const type = typeFilter.value;
+  let visibleCount = 0;
 
-document.querySelectorAll('#yazici .view-btn').forEach(b=>{
-  b.addEventListener('click', async ()=>{
-    const id = b.dataset.id;
-    const r = await fetch('/printers/'+id);
+  rows.forEach(row => {
+    const matchesType = type === 'all' || row.dataset.type === type;
+    const content = row.dataset.search || '';
+    const matchesTerm = !term || content.includes(term);
+    const shouldShow = matchesType && matchesTerm;
+    row.classList.toggle('d-none', !shouldShow);
+    if (shouldShow) {
+      visibleCount += 1;
+    }
+  });
+
+  if (emptyRow) {
+    emptyRow.classList.toggle('d-none', visibleCount !== 0);
+  }
+}
+
+if (searchInput && typeFilter) {
+  searchInput.addEventListener('input', applyFilters);
+  typeFilter.addEventListener('change', applyFilters);
+  applyFilters();
+}
+
+document.querySelectorAll('.view-btn').forEach(b => {
+  b.addEventListener('click', async () => {
+    const url = b.dataset.url;
+    if (!url) return;
+    const r = await fetch(url);
     const h = await r.text();
     document.getElementById('hurdaDetayBody').innerHTML = h;
     new bootstrap.Modal(document.getElementById('hurdaDetayModal')).show();


### PR DESCRIPTION
## Summary
- combine inventory, license, and printer scrap queries into a unified payload for the template and keep detail metadata handy for display
- redesign the scrap listing template to show a single table with badges, detail lists, and a modal trigger while adding search and type filtering controls

## Testing
- pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68caa6caf3c8832b8384b11e7f20a3be