### PR TITLE
Handle missing stock type input

### DIFF
--- a/routers/stock.py
+++ b/routers/stock.py
@@ -227,7 +227,13 @@ def stock_add(payload: dict = Body(...), db: Session = Depends(get_db)):
     # UI yeni adla `is_lisans` gönderiyor; eski `is_license` ile de uyumlu
     # kalmak için her ikisini de kontrol ediyoruz.
     is_license = payload.get("is_lisans") or payload.get("is_license")
-    donanim_tipi = payload.get("donanim_tipi")
+
+    # Donanım tipi zorunlu; boş veya None gelirse 500 yerine anlamlı hata döndür.
+    donanim_tipi_raw = payload.get("donanim_tipi")
+    if donanim_tipi_raw is None:
+        donanim_tipi_raw = ""
+    donanim_tipi = str(donanim_tipi_raw).strip()
+
     if donanim_tipi and donanim_tipi.isdigit():
         ht = db.get(HardwareType, int(donanim_tipi))
         if ht:
@@ -236,6 +242,9 @@ def stock_add(payload: dict = Body(...), db: Session = Depends(get_db)):
             ln = db.get(LicenseName, int(donanim_tipi))
             if ln:
                 donanim_tipi = ln.name
+
+    if not donanim_tipi:
+        return {"ok": False, "error": "Donanım tipi seçiniz"}
 
     marka = None if is_license else payload.get("marka")
     if marka and marka.isdigit():

--- a/tests/test_stock_add.py
+++ b/tests/test_stock_add.py
@@ -42,3 +42,9 @@ def test_stock_add_negative_amount(db_session):
     }
     result = stock_add(payload, db_session)
     assert result == {"ok": False, "error": "Miktar 0'dan büyük olmalı"}
+
+
+def test_stock_add_requires_type(db_session):
+    payload = {"is_lisans": False, "miktar": 1, "islem_yapan": "tester"}
+    result = stock_add(payload, db_session)
+    assert result == {"ok": False, "error": "Donanım tipi seçiniz"}


### PR DESCRIPTION
## Summary
- guard stock additions against missing or blank hardware type values
- normalize the incoming value before converting ids to names and return a clear error when absent
- add a regression test that verifies the new validation path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cab891b2e8832babd88e6d3a7022f9