### PR TITLE
Handle SQLite connect args for engines

### DIFF
--- a/tests/test_stock_assign_concurrent.py
+++ b/tests/test_stock_assign_concurrent.py
@@ -15,10 +15,11 @@ from fastapi import HTTPException
 
 
 def _setup_engine():
+    database_url = "sqlite://"
     engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
+        database_url,
         poolclass=StaticPool,
+        **models.engine_kwargs_for_url(database_url),
     )
     TestingSession = sessionmaker(bind=engine, autocommit=False, autoflush=False)
     models.Base.metadata.create_all(engine)


### PR DESCRIPTION
## Summary
- parse the database URL to detect SQLite connections and automatically supply `check_same_thread=False`
- expose a reusable helper for engine keyword arguments and apply it when building test engines

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc01fea8b8832b9925eb067c6359c1