### PR TITLE
Fix stock entry navigation and stabilize stock status fetch

### DIFF
--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -130,6 +130,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // --- Yeni stok atama modali -------------------------------------------------
 /* ================== AYAR ================== */
+function getMetaApiRoot() {
+  if (typeof document === 'undefined') return '/api';
+  const meta = document.querySelector('meta[name="api-root"]');
+  if (!meta) return '/api';
+  const content = (meta.getAttribute('content') || '').trim();
+  return content ? content.replace(/\/$/, '') : '/api';
+}
+
+const API_ROOT_META = getMetaApiRoot();
+const STOCK_STATUS_URL = `${API_ROOT_META}/stock/status`;
+
 const API_PREFIX = ""; // Örn: "/api"
 const URL_STOCK_OPTIONS = `${API_PREFIX}/stock/options`;
 const URL_ASSIGN_SOURCES = `${API_PREFIX}/inventory/assign/sources`;
@@ -672,7 +683,10 @@ function loadStockStatus() {
   setStockStatusMessage(document.querySelector('#tblStockStatusInventory tbody'), 'Yükleniyor…');
   setStockStatusMessage(document.querySelector('#tblStockStatusLicense tbody'), 'Yükleniyor…');
 
-  fetch('/api/stock/status', { headers: { Accept: 'application/json' } })
+  fetch(STOCK_STATUS_URL, {
+    headers: { Accept: 'application/json' },
+    credentials: 'same-origin',
+  })
     .then(r => {
       if (!r.ok) throw new Error('HTTP ' + r.status);
       return r.json();

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -56,7 +56,7 @@
             {% else %}<span class="badge bg-success">Aktif</span>{% endif %}
           </td>
           <td class="actions">
-            {% set entity = 'licenses' %}
+            {% set entity = 'lisans' %}
             {% set row_id = row.id %}
             {% include 'partials/_actions_menu.html' %}
           </td>

--- a/templates/stock.html
+++ b/templates/stock.html
@@ -142,10 +142,21 @@ function renderStockTable(items) {
   tbody.innerHTML = rows;
 }
 
+function getApiRoot() {
+  const meta = document.querySelector('meta[name="api-root"]');
+  const content = meta ? (meta.getAttribute('content') || '').trim() : '';
+  return content ? content.replace(/\/$/, '') : '/api';
+}
+
+const STOCK_STATUS_URL = `${getApiRoot()}/stock/status`;
+
 async function loadStockStatusTable() {
   setStockTableMessage('Yükleniyor…');
   try {
-    const res = await fetch('/api/stock/status', { headers: { Accept: 'application/json' } });
+    const res = await fetch(STOCK_STATUS_URL, {
+      headers: { Accept: 'application/json' },
+      credentials: 'same-origin',
+    });
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
     }


### PR DESCRIPTION
## Summary
- point the license list action menu to the /lisans routes so stock entry opens correctly
- read the configured API root when loading stock status data and send cookies with the request to keep the tables populated

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd449385d8832b912ba543f9d17490