### PR TITLE
Fix stock logging compatibility

### DIFF
--- a/routers/inventory.py
+++ b/routers/inventory.py
@@ -27,10 +27,10 @@ from models import (
     License,
     LicenseLog,
     ScrapPrinter,
-    StockLog,
     StockTotal,
 )
 from security import current_user
+from utils.stock_log import create_stock_log
 
 templates = register_filters(Jinja2Templates(directory="templates"))
 
@@ -472,18 +472,17 @@ def stock_entry(
     item.fabrika = "Baylan 3"
     item.departman = "Bilgi İşlem"
 
-    db.add(
-        StockLog(
-            donanim_tipi=donanim_tipi,
-            miktar=1,
-            ifs_no=item.ifs_no,
-            marka=item.marka,
-            model=item.model,
-            islem="girdi",
-            actor=actor,
-            source_type="envanter",
-            source_id=item.id,
-        )
+    create_stock_log(
+        db,
+        donanim_tipi=donanim_tipi,
+        miktar=1,
+        ifs_no=item.ifs_no,
+        marka=item.marka,
+        model=item.model,
+        islem="girdi",
+        actor=actor,
+        source_type="envanter",
+        source_id=item.id,
     )
 
     total = db.get(StockTotal, donanim_tipi) or StockTotal(

--- a/routers/printers.py
+++ b/routers/printers.py
@@ -20,10 +20,10 @@ from models import (
     Brand,
     Model,
     UsageArea,
-    StockLog,
     StockTotal,
 )
 from sqlalchemy import text
+from utils.stock_log import create_stock_log
 
 templates = Jinja2Templates(directory="templates")
 router = APIRouter(prefix="/printers", tags=["Printers"])
@@ -370,18 +370,17 @@ def stock_printer(printer_id: int, db: Session = Depends(get_db), user=Depends(c
     p.bagli_envanter_no = None
     p.fabrika = "Baylan 3"
 
-    db.add(
-        StockLog(
-            donanim_tipi=donanim_tipi,
-            miktar=1,
-            ifs_no=p.ifs_no,
-            marka=p.marka,
-            model=p.model,
-            islem="girdi",
-            actor=actor,
-            source_type="yazici",
-            source_id=p.id,
-        )
+    create_stock_log(
+        db,
+        donanim_tipi=donanim_tipi,
+        miktar=1,
+        ifs_no=p.ifs_no,
+        marka=p.marka,
+        model=p.model,
+        islem="girdi",
+        actor=actor,
+        source_type="yazici",
+        source_id=p.id,
     )
 
     total = db.get(StockTotal, donanim_tipi) or StockTotal(

--- a/templates/stock_status.html
+++ b/templates/stock_status.html
@@ -46,7 +46,10 @@ async function loadStokDurumu() {
   if (!tbody) return;
   tbody.innerHTML = `<tr><td colspan="2">Yükleniyor…</td></tr>`;
   try {
-    const res = await fetch('/api/stock/status');
+    const res = await fetch('/api/stock/status', {
+      headers: { Accept: 'application/json' },
+      credentials: 'same-origin',
+    });
     if (!res.ok) throw new Error('API hata durumu: ' + res.status);
     const data = await res.json();
     if (!Array.isArray(data) || data.length === 0) {

--- a/tests/test_stock_add.py
+++ b/tests/test_stock_add.py
@@ -11,6 +11,20 @@ import models
 from routers.stock import stock_add
 
 
+def _make_payload(**overrides):
+    payload = {
+        "is_lisans": False,
+        "donanim_tipi": "Laptop",
+        "miktar": 1,
+        "islem_yapan": "tester",
+        "marka": "Dell",
+        "model": "X",
+        "ifs_no": "IFS-1",
+    }
+    payload.update(overrides)
+    return payload
+
+
 @pytest.fixture()
 def db_session():
     models.Base.metadata.create_all(models.engine)
@@ -48,3 +62,38 @@ def test_stock_add_requires_type(db_session):
     payload = {"is_lisans": False, "miktar": 1, "islem_yapan": "tester"}
     result = stock_add(payload, db_session)
     assert result == {"ok": False, "error": "Donanım tipi seçiniz"}
+
+
+def test_stock_add_normalizes_girdi(db_session):
+    payload = _make_payload(islem="Girdi")
+    result = stock_add(payload, db_session)
+    assert result["ok"] is True
+    log = db_session.query(models.StockLog).first()
+    assert log is not None
+    assert log.islem == "girdi"
+
+
+def test_stock_add_normalizes_cikti_variants(db_session):
+    db_session.add(models.StockTotal(donanim_tipi="Laptop", toplam=3))
+    db_session.commit()
+
+    payload = _make_payload(islem="Çıktı", miktar=2)
+    result = stock_add(payload, db_session)
+    assert result["ok"] is True
+
+    log = (
+        db_session.query(models.StockLog)
+        .order_by(models.StockLog.id.desc())
+        .first()
+    )
+    assert log is not None
+    assert log.islem == "cikti"
+
+    total = db_session.get(models.StockTotal, "Laptop")
+    assert total.toplam == 1
+
+
+def test_stock_add_rejects_unknown_islem(db_session):
+    payload = _make_payload(islem="Bilinmeyen")
+    result = stock_add(payload, db_session)
+    assert result == {"ok": False, "error": "Geçersiz işlem türü"}

--- a/utils/stock_log.py
+++ b/utils/stock_log.py
@@ -1,0 +1,147 @@
+"""Utility helpers for working with stock logs."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import inspect, insert, select, func
+from sqlalchemy.orm import Session
+
+from models import StockLog, SessionLocal
+
+
+_AVAILABLE_COLUMNS: set[str] | None = None
+_ISLEM_TRANSLATION = str.maketrans({"ç": "c", "ğ": "g", "ı": "i", "ö": "o", "ş": "s", "ü": "u"})
+_ISLEM_ALIASES = {
+    "girdi": "girdi",
+    "cikti": "cikti",
+    "cikis": "cikti",
+    "hurda": "hurda",
+    "atama": "atama",
+}
+
+
+def normalize_islem(value: Any, default: str = "girdi") -> tuple[str, bool]:
+    """Normalize a movement type value to canonical form.
+
+    Returns a tuple of ``(normalized, is_valid)``. ``is_valid`` indicates
+    whether the provided value was recognised. When ``value`` is falsy the
+    ``default`` is returned and considered valid.
+    """
+
+    if value is None:
+        return default, True
+
+    text = str(value).strip()
+    if not text:
+        return default, True
+
+    lowered = text.lower().translate(_ISLEM_TRANSLATION)
+    mapped = _ISLEM_ALIASES.get(lowered)
+    if mapped:
+        return mapped, True
+
+    return default, False
+
+
+def _load_available_columns() -> set[str]:
+    global _AVAILABLE_COLUMNS
+    if _AVAILABLE_COLUMNS is not None:
+        return _AVAILABLE_COLUMNS
+
+    session = None
+    try:
+        session = SessionLocal()
+        bind = session.get_bind()
+        if bind is None:
+            _AVAILABLE_COLUMNS = {col.name for col in StockLog.__table__.columns}
+        else:
+            try:
+                inspector = inspect(bind)
+                columns = inspector.get_columns("stock_logs")
+                if not columns:
+                    raise RuntimeError("no columns")
+                _AVAILABLE_COLUMNS = {col["name"] for col in columns}
+            except Exception:  # pragma: no cover
+                _AVAILABLE_COLUMNS = {col.name for col in StockLog.__table__.columns}
+    except Exception:  # pragma: no cover - session init failure
+        _AVAILABLE_COLUMNS = {col.name for col in StockLog.__table__.columns}
+    finally:
+        if session is not None:
+            session.close()
+
+    return _AVAILABLE_COLUMNS
+
+
+def _get_available_columns(db: Session) -> set[str]:
+    """Return the set of physical columns for the stock_logs table."""
+
+    if _AVAILABLE_COLUMNS is not None:
+        return _AVAILABLE_COLUMNS
+    return _load_available_columns()
+
+
+def create_stock_log(db: Session, *, return_id: bool = False, **fields: Any) -> int | None:
+    """Insert a row into ``stock_logs`` while tolerating legacy schemas.
+
+    Older deployments may not have all of the newer optional columns
+    (``marka``, ``model``, ``source_type`` ...).  Writing through the ORM
+    would fail in those environments because SQLAlchemy would still try to
+    reference the missing columns.  This helper inspects the real table
+    definition at runtime and only includes the columns that physically
+    exist before issuing a manual INSERT statement.
+
+    The function returns the inserted primary key when available so callers
+    that need to expose it (e.g. API responses) can continue to do so.
+    """
+
+    available = _get_available_columns(db)
+    model_columns = {col.name for col in StockLog.__table__.columns}
+    missing_columns = model_columns - available
+
+    if not missing_columns:
+        payload = {k: v for k, v in fields.items() if k in model_columns}
+        if "tarih" not in payload:
+            payload["tarih"] = datetime.utcnow()
+        log = StockLog(**payload)
+        db.add(log)
+        if return_id:
+            db.flush()
+            return getattr(log, "id", None)
+        return None
+
+    data: dict[str, Any] = {}
+    for key, value in fields.items():
+        if key in available:
+            data[key] = value
+
+    if "tarih" in available and "tarih" not in data:
+        data["tarih"] = datetime.utcnow()
+
+    stmt = insert(StockLog.__table__).values(**data)
+    result = db.execute(stmt)
+
+    if not return_id:
+        return None
+
+    inserted_pk = getattr(result, "inserted_primary_key", None)
+    if inserted_pk:
+        return int(inserted_pk[0])
+
+    if "id" in available:
+        try:
+            return int(result.scalar_one())  # type: ignore[arg-type]
+        except Exception:  # pragma: no cover - fallback for drivers w/out RETURNING
+            pk = db.execute(select(func.max(StockLog.id))).scalar()
+            return int(pk) if pk is not None else None
+
+    return None
+
+
+# Preload available columns when module is imported to avoid reflection
+# during transactional operations. Any failures simply fall back to the
+# model-defined columns and will be re-evaluated lazily if needed.
+try:  # pragma: no cover - defensive preload
+    _load_available_columns()
+except Exception:
+    _AVAILABLE_COLUMNS = None


### PR DESCRIPTION
## Summary
* Added helper `create_stock_log` that inspects the physical `stock_logs` columns and writes via ORM when possible, or falls back to direct inserts for legacy schemas while optionally returning the new ID
* Updated stock-related routers to rely on the helper instead of instantiating `StockLog` directly and adjusted the stock status template to send credentials when fetching data
* Stock status fetch calls now include credentials to work across deployments that require authentication
* Normalized stock movement inputs (e.g. UI provided "Girdi"/"Çıktı") to canonical values so new entries update totals correctly and covered the behavior with regression tests

## Testing
* pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd63bf1078832bb7a99f12b4c12dff