### PR TITLE
Refactor layout to show navigation as left sidebar

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -123,6 +123,46 @@ small, .text-muted { color: var(--color-muted) !important; }
 /* -------------------------------------------------------------------------- */
 /* Sidebar                                                                    */
 /* -------------------------------------------------------------------------- */
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+@media (min-width: 992px) {
+  .app-shell {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}
+
+.app-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  width: 100%;
+}
+
+@media (min-width: 992px) {
+  .app-sidebar {
+    flex: 0 0 280px;
+    max-width: 280px;
+    position: sticky;
+    top: var(--space-md);
+    align-self: flex-start;
+  }
+}
+
+.app-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
+}
+
+.side-group {
+  border-radius: var(--radius-md);
+}
+
 .side-title {
   font-size: var(--font-size-xs);
   font-weight: 600;

--- a/templates/base.html
+++ b/templates/base.html
@@ -76,17 +76,16 @@
   </nav>
 
     <div class="container-fluid p-3">
-      <div class="row g-3">
-        {% if request.session.get('user_id') %}
-        <!-- Sol bloklar -->
-        <aside class="col-12 col-lg-2">
-          <div class="side-group soft-card p-3 mb-3 stack-sm">
+      {% if request.session.get('user_id') %}
+      <div class="app-shell">
+        <aside class="app-sidebar stack-sm">
+          <div class="side-group soft-card p-3 stack-sm">
             <a class="side-link" href="/dashboard">
               <i class="bi bi-speedometer2"></i>
               <span>Ana Sayfa</span>
             </a>
           </div>
-          <div class="side-group soft-card p-3 mb-3 stack-sm">
+          <div class="side-group soft-card p-3 stack-sm">
             <div class="side-title">ENVANTER</div>
             <a class="side-link" href="/inventory">
               <i class="bi bi-hdd-stack"></i>
@@ -105,43 +104,44 @@
               <span>Stok Takip</span>
             </a>
           </div>
-        </div>
-        <div class="side-group soft-card p-3 mb-3 stack-sm">
-          <div class="side-title">İŞLEMLER</div>
-          <a class="side-link" href="/talepler">
-            <i class="bi bi-inboxes"></i>
-            <span>Talep Takip</span>
-          </a>
-          <a class="side-link" href="{{ url_for('inventory.hurdalar') }}">
-            <i class="bi bi-recycle"></i>
-            <span>Hurdalar</span>
-          </a>
-        </div>
-        <div class="side-group soft-card p-3 stack-sm">
-          <div class="side-title">AYARLAR</div>
-          <a class="side-link" href="/profile">
-            <i class="bi bi-person-circle"></i>
-            <span>Profil</span>
-          </a>
-          {% if request.session.get('user_role') == 'admin' %}
-          <a class="side-link" href="/admin">
-            <i class="bi bi-gear-wide-connected"></i>
-            <span>Admin Paneli</span>
-          </a>
-          <a class="side-link" href="/logs">
-            <i class="bi bi-clock-history"></i>
-            <span>Kayıtlar</span>
-          </a>
-          {% endif %}
-        </div>
-      </aside>
-      <main class="col-12 col-lg-10">
+          <div class="side-group soft-card p-3 stack-sm">
+            <div class="side-title">İŞLEMLER</div>
+            <a class="side-link" href="/talepler">
+              <i class="bi bi-inboxes"></i>
+              <span>Talep Takip</span>
+            </a>
+            <a class="side-link" href="{{ url_for('inventory.hurdalar') }}">
+              <i class="bi bi-recycle"></i>
+              <span>Hurdalar</span>
+            </a>
+          </div>
+          <div class="side-group soft-card p-3 stack-sm">
+            <div class="side-title">AYARLAR</div>
+            <a class="side-link" href="/profile">
+              <i class="bi bi-person-circle"></i>
+              <span>Profil</span>
+            </a>
+            {% if request.session.get('user_role') == 'admin' %}
+            <a class="side-link" href="/admin">
+              <i class="bi bi-gear-wide-connected"></i>
+              <span>Admin Paneli</span>
+            </a>
+            <a class="side-link" href="/logs">
+              <i class="bi bi-clock-history"></i>
+              <span>Kayıtlar</span>
+            </a>
+            {% endif %}
+          </div>
+        </aside>
+        <main class="app-main">
       {% else %}
-      <main class="col-12">
+        <main class="app-main">
       {% endif %}
-        {% block content %}{% endblock %}
-      </main>
+          {% block content %}{% endblock %}
+        </main>
+      {% if request.session.get('user_id') %}
       </div>
+      {% endif %}
     </div>
 
     <!-- picker modal -->


### PR DESCRIPTION
## Summary
- refactor the base layout to render the navigation cards inside a dedicated sidebar container
- add responsive sidebar styles so the navigation stacks on mobile and stays sticky on desktop

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d108b8d81c832b89a4c85c0d53f213