### PR TITLE
Refactor talep handling utilities and modal templates

### DIFF
--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -1,0 +1,28 @@
+{% macro modal(id, title, dialog_class="", form_attrs=None, footer=None, content_class="") -%}
+<div class="modal fade" id="{{ id }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog {{ dialog_class }}">
+    {%- if form_attrs is not none %}
+    <form {{ form_attrs|xmlattr }} class="modal-content{% if content_class %} {{ content_class }}{% endif %}">
+    {%- else %}
+    <div class="modal-content{% if content_class %} {{ content_class }}{% endif %}">
+    {%- endif %}
+      <div class="modal-header">
+        <h5 class="modal-title">{{ title }}</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <div class="modal-body">
+        {{ caller() }}
+      </div>
+      {%- if footer %}
+      <div class="modal-footer">
+        {{ footer }}
+      </div>
+      {%- endif %}
+    {%- if form_attrs is not none %}
+    </form>
+    {%- else %}
+    </div>
+    {%- endif %}
+  </div>
+</div>
+{%- endmacro %}

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "components/modal.html" import modal %}
 {% block title %}Talep Takip{% endblock %}
 {% block content %}
 <div class="container-fluid p-3">
@@ -96,89 +97,75 @@
   </div>
 </div>
 <!-- Talep Aç Modal -->
-<div class="modal fade" id="talepModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-xl">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Talep Aç</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
-      </div>
-
-      <form id="talepForm" autocomplete="off">
-        <div class="modal-body">
-
-          <!-- IFS -->
-          <div class="mb-3">
-            <label class="form-label">IFS No</label>
-            <input id="ifs_no" name="ifs_no" class="form-control" placeholder="IFS No">
-          </div>
-
-          <!-- Kalemler tablosu -->
-          <div class="d-flex justify-content-between align-items-center mb-2">
-            <label class="form-label m-0">Kalemler</label>
-            <button type="button" id="btnAddRow" class="btn btn-outline-secondary btn-sm">Satır Ekle</button>
-          </div>
-
-          <div class="table-responsive">
-            <table class="table table-sm align-middle" id="rowsTable">
-              <thead>
-                <tr>
-                  <th style="width:20%">Donanım Tipi</th>
-                  <th style="width:8%">Miktar</th>
-                  <th style="width:18%">Marka</th>
-                  <th style="width:18%">Model</th>
-                  <th style="width:28%">Açıklama</th>
-                  <th style="width:8%"></th>
-                </tr>
-              </thead>
-              <tbody><!-- JS dolduracak --></tbody>
-            </table>
-          </div>
-
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-          <button type="submit" class="btn btn-primary">Gönder</button>
-        </div>
-      </form>
-    </div>
+{% set talep_modal_footer %}
+  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+  <button type="submit" class="btn btn-primary">Gönder</button>
+{% endset %}
+{% call modal(
+  "talepModal",
+  "Talep Aç",
+  dialog_class="modal-xl",
+  form_attrs={"id": "talepForm", "autocomplete": "off"},
+  footer=talep_modal_footer,
+) %}
+  <!-- IFS -->
+  <div class="mb-3">
+    <label class="form-label">IFS No</label>
+    <input id="ifs_no" name="ifs_no" class="form-control" placeholder="IFS No">
   </div>
-</div>
+
+  <!-- Kalemler tablosu -->
+  <div class="d-flex justify-content-between align-items-center mb-2">
+    <label class="form-label m-0">Kalemler</label>
+    <button type="button" id="btnAddRow" class="btn btn-outline-secondary btn-sm">Satır Ekle</button>
+  </div>
+
+  <div class="table-responsive">
+    <table class="table table-sm align-middle" id="rowsTable">
+      <thead>
+        <tr>
+          <th style="width:20%">Donanım Tipi</th>
+          <th style="width:8%">Miktar</th>
+          <th style="width:18%">Marka</th>
+          <th style="width:18%">Model</th>
+          <th style="width:28%">Açıklama</th>
+          <th style="width:8%"></th>
+        </tr>
+      </thead>
+      <tbody><!-- JS dolduracak --></tbody>
+    </table>
+  </div>
+{% endcall %}
 
 <!-- Talep Kapat Modal -->
-<div class="modal fade" id="talepKapatModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form id="talepKapatForm" class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Stok Girişi</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
-      </div>
-      <div class="modal-body">
-        <input type="hidden" id="tkTalepId">
-        <div class="mb-3">
-          <label class="form-label">Miktar</label>
-          <input type="number" id="tkAdet" class="form-control" min="1" value="1">
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Marka</label>
-          <select id="tkMarka" class="form-select"></select>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Model</label>
-          <select id="tkModel" class="form-select"></select>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Not (opsiyonel)</label>
-          <input type="text" id="tkAciklama" class="form-control">
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
-        <button type="submit" class="btn btn-primary">Kaydet</button>
-      </div>
-    </form>
+{% set talep_kapat_footer %}
+  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+{% endset %}
+{% call modal(
+  "talepKapatModal",
+  "Stok Girişi",
+  form_attrs={"id": "talepKapatForm"},
+  footer=talep_kapat_footer,
+) %}
+  <input type="hidden" id="tkTalepId">
+  <div class="mb-3">
+    <label class="form-label">Miktar</label>
+    <input type="number" id="tkAdet" class="form-control" min="1" value="1">
   </div>
-</div>
+  <div class="mb-3">
+    <label class="form-label">Marka</label>
+    <select id="tkMarka" class="form-select"></select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Model</label>
+    <select id="tkModel" class="form-select"></select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Not (opsiyonel)</label>
+    <input type="text" id="tkAciklama" class="form-control">
+  </div>
+{% endcall %}
 
 <script src="/static/js/talep.js"></script>
 {% endblock %}

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "components/tabs.html" import tabs %}
+{% from "components/modal.html" import modal %}
 {% set active_key = request.query_params.get("durum") or "acik" %}
 {% block title %}Talep Takip{% endblock %}
 {% block content %}
@@ -87,89 +88,75 @@
 </div>
 
 <!-- Talep Aç Modal -->
-<div class="modal fade" id="talepModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-xl">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Talep Aç</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
-      </div>
-
-      <form id="talepForm" autocomplete="off">
-        <div class="modal-body">
-
-          <!-- IFS -->
-          <div class="mb-3">
-            <label class="form-label">IFS No</label>
-            <input id="ifs_no" name="ifs_no" class="form-control" placeholder="IFS No">
-          </div>
-
-          <!-- Kalemler tablosu -->
-          <div class="d-flex justify-content-between align-items-center mb-2">
-            <label class="form-label m-0">Kalemler</label>
-            <button type="button" id="btnAddRow" class="btn btn-outline-secondary btn-sm">Satır Ekle</button>
-          </div>
-
-          <div class="table-responsive">
-            <table class="table table-sm align-middle" id="rowsTable">
-              <thead>
-                <tr>
-                  <th style="width:20%">Donanım Tipi</th>
-                  <th style="width:8%">Miktar</th>
-                  <th style="width:18%">Marka</th>
-                  <th style="width:18%">Model</th>
-                  <th style="width:28%">Açıklama</th>
-                  <th style="width:8%"></th>
-                </tr>
-              </thead>
-              <tbody><!-- JS dolduracak --></tbody>
-            </table>
-          </div>
-
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-          <button type="submit" class="btn btn-primary">Gönder</button>
-        </div>
-      </form>
-    </div>
+{% set talep_modal_footer %}
+  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+  <button type="submit" class="btn btn-primary">Gönder</button>
+{% endset %}
+{% call modal(
+  "talepModal",
+  "Talep Aç",
+  dialog_class="modal-xl",
+  form_attrs={"id": "talepForm", "autocomplete": "off"},
+  footer=talep_modal_footer,
+) %}
+  <!-- IFS -->
+  <div class="mb-3">
+    <label class="form-label">IFS No</label>
+    <input id="ifs_no" name="ifs_no" class="form-control" placeholder="IFS No">
   </div>
- </div>
+
+  <!-- Kalemler tablosu -->
+  <div class="d-flex justify-content-between align-items-center mb-2">
+    <label class="form-label m-0">Kalemler</label>
+    <button type="button" id="btnAddRow" class="btn btn-outline-secondary btn-sm">Satır Ekle</button>
+  </div>
+
+  <div class="table-responsive">
+    <table class="table table-sm align-middle" id="rowsTable">
+      <thead>
+        <tr>
+          <th style="width:20%">Donanım Tipi</th>
+          <th style="width:8%">Miktar</th>
+          <th style="width:18%">Marka</th>
+          <th style="width:18%">Model</th>
+          <th style="width:28%">Açıklama</th>
+          <th style="width:8%"></th>
+        </tr>
+      </thead>
+      <tbody><!-- JS dolduracak --></tbody>
+    </table>
+  </div>
+{% endcall %}
 
 <!-- Talep Kapat Modal -->
-<div class="modal fade" id="talepKapatModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form id="talepKapatForm" class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Stok Girişi</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
-      </div>
-      <div class="modal-body">
-        <input type="hidden" id="tkTalepId">
-        <div class="mb-3">
-          <label class="form-label">Miktar</label>
-          <input type="number" id="tkAdet" class="form-control" min="1" value="1">
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Marka</label>
-          <select id="tkMarka" class="form-select"></select>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Model</label>
-          <select id="tkModel" class="form-select"></select>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Not (opsiyonel)</label>
-          <input type="text" id="tkAciklama" class="form-control">
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
-        <button type="submit" class="btn btn-primary">Kaydet</button>
-      </div>
-    </form>
+{% set talep_kapat_footer %}
+  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+{% endset %}
+{% call modal(
+  "talepKapatModal",
+  "Stok Girişi",
+  form_attrs={"id": "talepKapatForm"},
+  footer=talep_kapat_footer,
+) %}
+  <input type="hidden" id="tkTalepId">
+  <div class="mb-3">
+    <label class="form-label">Miktar</label>
+    <input type="number" id="tkAdet" class="form-control" min="1" value="1">
   </div>
-</div>
+  <div class="mb-3">
+    <label class="form-label">Marka</label>
+    <select id="tkMarka" class="form-select"></select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Model</label>
+    <select id="tkModel" class="form-select"></select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Not (opsiyonel)</label>
+    <input type="text" id="tkAciklama" class="form-control">
+  </div>
+{% endcall %}
 
 {% endblock %}
 

--- a/tests/test_talep_adet_validation.py
+++ b/tests/test_talep_adet_validation.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"
@@ -33,23 +34,27 @@ def talep(db_session):
 
 
 def test_cancel_request_zero_adet(db_session, talep):
-    res = cancel_request(talep.id, adet=0, db=db_session)
-    assert res.status_code == 400
+    with pytest.raises(HTTPException) as exc:
+        cancel_request(talep.id, adet=0, db=db_session)
+    assert exc.value.status_code == 400
 
 
 def test_cancel_request_negative_adet(db_session, talep):
-    res = cancel_request(talep.id, adet=-1, db=db_session)
-    assert res.status_code == 400
+    with pytest.raises(HTTPException) as exc:
+        cancel_request(talep.id, adet=-1, db=db_session)
+    assert exc.value.status_code == 400
 
 
 def test_close_request_zero_adet(db_session, talep):
-    res = close_request(talep.id, adet=0, db=db_session)
-    assert res.status_code == 400
+    with pytest.raises(HTTPException) as exc:
+        close_request(talep.id, adet=0, db=db_session)
+    assert exc.value.status_code == 400
 
 
 def test_close_request_negative_adet(db_session, talep):
-    res = close_request(talep.id, adet=-3, db=db_session)
-    assert res.status_code == 400
+    with pytest.raises(HTTPException) as exc:
+        close_request(talep.id, adet=-3, db=db_session)
+    assert exc.value.status_code == 400
 
 
 def test_kapanma_tarihi_set_on_cancel(db_session, talep):

--- a/tests/test_talep_to_stock.py
+++ b/tests/test_talep_to_stock.py
@@ -10,7 +10,7 @@ os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 import models
 from routes.talepler import convert_request_to_stock
 from models import Talep, TalepTuru, TalepDurum, StockLog, StockTotal
-from fastapi.responses import JSONResponse
+from fastapi import HTTPException
 
 
 @pytest.fixture()
@@ -80,9 +80,9 @@ def test_convert_request_requires_brand_model(db_session):
     db_session.commit()
     db_session.refresh(talep)
 
-    res = convert_request_to_stock(talep.id, adet=1, db=db_session)
-    assert isinstance(res, JSONResponse)
-    assert res.status_code == 400
+    with pytest.raises(HTTPException) as exc:
+        convert_request_to_stock(talep.id, adet=1, db=db_session)
+    assert exc.value.status_code == 400
 
     res2 = convert_request_to_stock(
         talep.id,

--- a/utils/http.py
+++ b/utils/http.py
@@ -1,0 +1,16 @@
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+
+def validate_adet(adet: int) -> None:
+    """Ensure that the given quantity is a positive integer."""
+    if adet <= 0:
+        raise HTTPException(status_code=400, detail="Adet 0'dan büyük olmalı")
+
+
+def get_or_404(db: Session, model, id: int, message: str = "Kayıt bulunamadı"):
+    """Return the object with ``id`` from ``model`` or raise a 404 error."""
+    obj = db.get(model, id)
+    if not obj:
+        raise HTTPException(status_code=404, detail=message)
+    return obj


### PR DESCRIPTION
## Summary
- add reusable HTTP helpers and a shared talep processing routine to centralize validation
- refactor talep cancellation, closure, and stock conversion endpoints to use the shared helpers
- extract the repeated talep modal markup into a reusable component and update the relevant templates
- update talep-related tests to align with the new exception-based error handling

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d111daa54c832b9f4cf71d71a123cc