### PR TITLE
Remove redundant stock selection from assignment modal

### DIFF
--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -249,10 +249,10 @@
         <form id="stockAssignForm" class="vstack gap-3">
           <!-- 1) STOK SEÇ (Stok Durumu'ndan) -->
           <div>
-            <label class="form-label fw-semibold">Stok Seç</label>
-            <select id="sa_stock" class="form-select" required>
-              <option value="">Seçiniz...</option>
-            </select>
+            <p class="form-label fw-semibold mb-2">Seçilen Stok</p>
+            <div id="sa_stock_alert" class="alert alert-warning py-2 px-3 small mb-0" role="alert">
+              Atama yapmak için stok durumu tablosundaki <strong>Atama</strong> düğmesini kullanınız.
+            </div>
             <div id="sa_stock_meta" class="mt-2 d-none">
               <div class="border rounded p-2 small bg-light-subtle">
                 <div class="d-flex flex-wrap gap-3 align-items-center mb-1">


### PR DESCRIPTION
## Summary
- remove the manual "Stok Seç" dropdown from the stock assignment modal and show an informational alert instead
- rework the assignment workflow in `static/js/stock.js` to track the selected stock programmatically and disable submission until one is provided
- refresh auto-filled fields and metadata when opening/closing the modal so existing stock information is re-used without asking the user again

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d114a029e8832bb9cea9e20c1aad49