### PR TITLE
Add bilgi knowledge center with categories and pin support

### DIFF
--- a/app/web/router.py
+++ b/app/web/router.py
@@ -14,6 +14,7 @@ from app.core.security import verify_password
 from routers import (
     catalog as catalog_router,
     home as home_router,
+    bilgiler as bilgiler_router,
     inventory as inventory_router,
     license as license_router,
     panel as panel_router,
@@ -196,6 +197,9 @@ router.include_router(
 )
 router.include_router(
     inventory_router.router, dependencies=[Depends(current_user)]
+)
+router.include_router(
+    bilgiler_router.router, dependencies=[Depends(current_user)]
 )
 router.include_router(
     license_router.router, dependencies=[Depends(current_user)]

--- a/routers/bilgiler.py
+++ b/routers/bilgiler.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Request,
+    UploadFile,
+    status,
+)
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from database import get_db
+from models import Bilgi, BilgiKategori, UserPinLimit
+from security import SessionUser, current_user
+from utils.template_filters import register_filters
+
+router = APIRouter(prefix="/bilgiler", tags=["Bilgiler"])
+templates = register_filters(Jinja2Templates(directory="templates"))
+
+UPLOAD_DIR = Path("static/uploads/bilgiler")
+ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif"}
+MAX_UPLOAD_SIZE = 5 * 1024 * 1024  # 5MB
+
+
+class PinPayload(BaseModel):
+    pin: bool
+
+
+def _serialize_bilgi_list(
+    items: list[Bilgi],
+    current_user_id: int,
+) -> tuple[list[Bilgi], list[Bilgi]]:
+    pinned = []
+    others = []
+    for item in items:
+        if item.is_pinned and item.pinned_by == current_user_id:
+            pinned.append(item)
+        else:
+            others.append(item)
+    return pinned, others
+
+
+def _save_photo_path(filename: str) -> Path:
+    ext = Path(filename).suffix.lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Desteklenmeyen dosya formatı")
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    unique_name = f"{uuid4().hex}{ext}"
+    return UPLOAD_DIR / unique_name
+
+
+async def _store_photo(file: UploadFile) -> str:
+    if not file.filename:
+        return ""
+
+    ext = Path(file.filename).suffix.lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Sadece jpg, jpeg, png veya gif yükleyebilirsiniz")
+
+    data = await file.read()
+    if len(data) > MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=400, detail="Dosya boyutu 5MB'ı geçemez")
+
+    if file.content_type and not file.content_type.startswith("image/"):
+        raise HTTPException(status_code=400, detail="Sadece görsel dosyaları yükleyebilirsiniz")
+
+    target = _save_photo_path(file.filename)
+    target.write_bytes(data)
+    return str(target.relative_to(Path("static")))
+
+
+def _remove_photo(path_str: str | None) -> None:
+    if not path_str:
+        return
+    candidate = Path("static") / path_str
+    if candidate.exists() and candidate.is_file():
+        try:
+            candidate.unlink()
+        except OSError:
+            pass
+
+
+@router.get("", response_class=HTMLResponse)
+def bilgi_index(
+    request: Request,
+    kategori: int | None = None,
+    q: str | None = None,
+    db: Session = Depends(get_db),
+    user: SessionUser = Depends(current_user),
+):
+    query = (
+        db.query(Bilgi)
+        .options(joinedload(Bilgi.kategori), joinedload(Bilgi.author))
+        .order_by(Bilgi.created_at.desc())
+    )
+
+    if kategori:
+        query = query.filter(Bilgi.kategori_id == kategori)
+    if q:
+        like = f"%{q.strip()}%"
+        query = query.filter(
+            or_(Bilgi.baslik.ilike(like), Bilgi.icerik.ilike(like))
+        )
+
+    items = query.all()
+    pinned_items, other_items = _serialize_bilgi_list(items, user.id)
+
+    categories = db.query(BilgiKategori).order_by(BilgiKategori.ad.asc()).all()
+
+    return templates.TemplateResponse(
+        "bilgiler/index.html",
+        {
+            "request": request,
+            "categories": categories,
+            "pinned_items": pinned_items,
+            "other_items": other_items,
+            "selected_category": kategori or "",
+            "search_query": q or "",
+            "session_user": user,
+        },
+    )
+
+
+@router.post("/ekle")
+async def bilgi_create(
+    request: Request,
+    baslik: str = Form(...),
+    kategori_id: int | None = Form(None),
+    icerik: str = Form(""),
+    foto: UploadFile | None = File(None),
+    db: Session = Depends(get_db),
+    user: SessionUser = Depends(current_user),
+):
+    title = baslik.strip()
+    if not title:
+        raise HTTPException(status_code=400, detail="Başlık zorunludur")
+
+    content = (icerik or "").strip()
+    if not content:
+        raise HTTPException(status_code=400, detail="İçerik zorunludur")
+
+    kategori_ref = None
+    if kategori_id:
+        kategori_ref = db.get(BilgiKategori, kategori_id)
+        if not kategori_ref:
+            raise HTTPException(status_code=400, detail="Geçersiz kategori seçimi")
+
+    photo_path = None
+    if foto and foto.filename:
+        photo_path = await _store_photo(foto)
+
+    now = datetime.utcnow()
+    bilgi = Bilgi(
+        baslik=title,
+        kategori_id=kategori_ref.id if kategori_ref else None,
+        icerik=content,
+        foto_yolu=photo_path,
+        kullanici_id=user.id,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(bilgi)
+    db.commit()
+    db.refresh(bilgi)
+
+    return JSONResponse({"ok": True, "id": bilgi.id}, status_code=status.HTTP_201_CREATED)
+
+
+@router.put("/{bilgi_id}/pin")
+def bilgi_pin(
+    bilgi_id: int,
+    payload: PinPayload,
+    db: Session = Depends(get_db),
+    user: SessionUser = Depends(current_user),
+):
+    bilgi = db.get(Bilgi, bilgi_id)
+    if not bilgi:
+        raise HTTPException(status_code=404, detail="Bilgi bulunamadı")
+
+    if bilgi.kullanici_id != user.id:
+        raise HTTPException(status_code=403, detail="Sadece kendi kayıtlarınızı sabitleyebilirsiniz")
+
+    limit = db.get(UserPinLimit, user.id)
+    if not limit:
+        limit = UserPinLimit(user_id=user.id, pin_count=0)
+
+    if payload.pin:
+        if bilgi.is_pinned and bilgi.pinned_by == user.id:
+            return {"pinned": True, "pin_count": limit.pin_count}
+        if limit.pin_count >= 3:
+            raise HTTPException(status_code=400, detail="En fazla 3 bilgi sabitleyebilirsiniz")
+        bilgi.is_pinned = True
+        bilgi.pinned_by = user.id
+        bilgi.pinned_at = datetime.utcnow()
+        limit.pin_count += 1
+    else:
+        if bilgi.is_pinned and limit.pin_count > 0:
+            limit.pin_count -= 1
+        bilgi.is_pinned = False
+        bilgi.pinned_by = None
+        bilgi.pinned_at = None
+
+    bilgi.updated_at = datetime.utcnow()
+    db.add_all([bilgi, limit])
+    db.commit()
+    db.refresh(limit)
+
+    return {"pinned": bilgi.is_pinned, "pin_count": limit.pin_count}
+
+
+@router.delete("/{bilgi_id}")
+def bilgi_delete(
+    bilgi_id: int,
+    db: Session = Depends(get_db),
+    user: SessionUser = Depends(current_user),
+):
+    bilgi = db.get(Bilgi, bilgi_id)
+    if not bilgi:
+        raise HTTPException(status_code=404, detail="Bilgi bulunamadı")
+
+    is_owner = bilgi.kullanici_id == user.id
+    if not (is_owner or user.role == "admin"):
+        raise HTTPException(status_code=403, detail="Silme yetkiniz yok")
+
+    photo_path = bilgi.foto_yolu
+    was_pinned_by_owner = bilgi.is_pinned and bilgi.pinned_by == bilgi.kullanici_id
+
+    if was_pinned_by_owner:
+        limit = db.get(UserPinLimit, bilgi.kullanici_id)
+        if limit and limit.pin_count > 0:
+            limit.pin_count -= 1
+            db.add(limit)
+
+    db.delete(bilgi)
+    db.commit()
+
+    _remove_photo(photo_path)
+    return {"ok": True}

--- a/routers/lookup.py
+++ b/routers/lookup.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import text
 
 from database import get_db  # projedeki mevcut get_db
-from models import Lookup, Model as ModelTbl, Brand, HardwareType
+from models import Lookup, Model as ModelTbl, Brand, HardwareType, BilgiKategori
 
 router = APIRouter(prefix="/api/lookup", tags=["lookup"])
 
@@ -21,6 +21,12 @@ def lookup_marka(db: Session = Depends(get_db)):
     rows = db.query(Brand).order_by(Brand.name.asc()).all()
     # İstemcilerin beklediği alan adı `name` olduğundan bu alanı döndür
     return [{"id": r.id, "name": r.name} for r in rows]
+
+
+@router.get("/bilgi_kategorileri")
+def lookup_bilgi_kategorileri(db: Session = Depends(get_db)):
+    rows = db.query(BilgiKategori).order_by(BilgiKategori.ad.asc()).all()
+    return [{"id": r.id, "name": r.ad} for r in rows]
 
 
 @router.get("/model")
@@ -71,6 +77,8 @@ ENTITY_TABLE = {
     "donanim_tipi": "hardware_types",
     "lisans-adi": "license_names",
     "lisans_adi": "license_names",
+    "bilgi-kategori": "bilgi_kategorileri",
+    "bilgi_kategorileri": "bilgi_kategorileri",
 }
 
 # Kolon/lookup bulunmadığında dönecek güvenli değerler

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -706,3 +706,21 @@ tr[data-href] > td:first-child {
 .inline-gap-sm { gap: var(--space-sm); }
 .inline-gap-md { gap: var(--space-md); }
 
+
+/* -------------------------------------------------------------------------- */
+/* Bilgi kartları                                                             */
+/* -------------------------------------------------------------------------- */
+.bilgi-card .card {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.bilgi-card .bilgi-content {
+  white-space: normal;
+}
+
+.bilgi-card .bilgi-photo {
+  max-height: 240px;
+  width: 100%;
+  object-fit: cover;
+}

--- a/static/js/bilgiler.js
+++ b/static/js/bilgiler.js
@@ -1,0 +1,281 @@
+(function () {
+  const MAX_PIN = 3;
+  const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+  function parseErrorMessage(response, fallback) {
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json().then((data) => {
+        if (data && typeof data.detail === 'string') {
+          return data.detail;
+        }
+        if (data && data.detail && data.detail.message) {
+          return data.detail.message;
+        }
+        return fallback;
+      });
+    }
+    return response.text().then((text) => text || fallback);
+  }
+
+  function ensurePinnedSection() {
+    let section = document.getElementById('pinnedBilgiler');
+    if (section) {
+      return section;
+    }
+    const generalSection = document.getElementById('bilgiList')?.closest('section');
+    if (!generalSection) {
+      return null;
+    }
+    section = document.createElement('section');
+    section.id = 'pinnedBilgiler';
+    section.className = 'mb-5';
+    section.innerHTML = `
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <span class="text-uppercase text-muted fw-semibold small">Sabitlenen Bilgiler</span>
+        <span class="badge bg-warning text-dark">0/${MAX_PIN}</span>
+      </div>
+      <div class="row g-3"></div>
+    `;
+    generalSection.parentElement.insertBefore(section, generalSection);
+    return section;
+  }
+
+  function updatePinnedBadge(section, countOverride) {
+    if (!section) return;
+    const badge = section.querySelector('.badge');
+    if (!badge) return;
+    if (typeof countOverride === 'number') {
+      badge.textContent = `${countOverride}/${MAX_PIN}`;
+      return;
+    }
+    const total = section.querySelectorAll('.bilgi-card').length;
+    badge.textContent = `${total}/${MAX_PIN}`;
+  }
+
+  function moveCardToPinned(card, pinCount) {
+    const section = ensurePinnedSection();
+    if (!section) return;
+    const row = section.querySelector('.row');
+    if (!row) return;
+    row.prepend(card);
+    updatePinnedBadge(section, pinCount);
+  }
+
+  function moveCardToGeneral(card, pinCount) {
+    const list = document.getElementById('bilgiList');
+    if (list) {
+      list.prepend(card);
+    }
+    const section = document.getElementById('pinnedBilgiler');
+    if (section) {
+      const row = section.querySelector('.row');
+      if (!row || !row.querySelector('.bilgi-card')) {
+        section.remove();
+      } else {
+        updatePinnedBadge(section, pinCount);
+      }
+    }
+  }
+
+  function applyFilters(filterEl, searchEl) {
+    const category = filterEl ? filterEl.value : '';
+    const query = searchEl ? searchEl.value.trim().toLowerCase() : '';
+    document.querySelectorAll('.bilgi-card').forEach((card) => {
+      const cardCategory = card.dataset.category || '';
+      const haystack = (card.dataset.search || '').toLowerCase();
+      const categoryMatch = !category || cardCategory === category;
+      const searchMatch = !query || haystack.includes(query);
+      card.classList.toggle('d-none', !(categoryMatch && searchMatch));
+    });
+  }
+
+  async function handlePin(button) {
+    const card = button.closest('.bilgi-card');
+    if (!card) return;
+    const id = button.dataset.id;
+    if (!id) return;
+    const pinned = button.dataset.pinned === 'true';
+
+    try {
+      const response = await fetch(`/bilgiler/${id}/pin`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pin: !pinned }),
+      });
+      if (!response.ok) {
+        const message = await parseErrorMessage(response, 'İşlem tamamlanamadı');
+        throw new Error(message);
+      }
+      const data = await response.json();
+      button.dataset.pinned = data.pinned ? 'true' : 'false';
+      const icon = button.querySelector('i');
+      const label = button.querySelector('span');
+      if (data.pinned) {
+        if (icon) icon.classList.add('bi-pin-angle-fill');
+        if (icon) icon.classList.remove('bi-pin-angle');
+        if (label) label.textContent = 'Tutturmayı Kaldır';
+        moveCardToPinned(card, data.pin_count);
+      } else {
+        if (icon) icon.classList.remove('bi-pin-angle-fill');
+        if (icon) icon.classList.add('bi-pin-angle');
+        if (label) label.textContent = 'Tuttur';
+        moveCardToGeneral(card, data.pin_count);
+      }
+    } catch (err) {
+      alert(err.message || 'İşlem tamamlanamadı');
+    }
+  }
+
+  async function handleDelete(button) {
+    const card = button.closest('.bilgi-card');
+    if (!card) return;
+    const id = button.dataset.id;
+    if (!id) return;
+    if (!confirm('Bu bilgiyi silmek istediğinizden emin misiniz?')) return;
+
+    try {
+      const response = await fetch(`/bilgiler/${id}`, { method: 'DELETE' });
+      if (!response.ok) {
+        const message = await parseErrorMessage(response, 'Silme işlemi başarısız');
+        throw new Error(message);
+      }
+      card.remove();
+      const generalList = document.getElementById('bilgiList');
+      if (generalList && !generalList.querySelector('.bilgi-card')) {
+        const empty = document.createElement('div');
+        empty.className = 'col-12';
+        empty.innerHTML = '<div class="alert alert-info mb-0">Listede bilgi bulunmuyor.</div>';
+        generalList.appendChild(empty);
+      }
+      const pinnedSection = document.getElementById('pinnedBilgiler');
+      if (pinnedSection) {
+        const hasCard = pinnedSection.querySelector('.bilgi-card');
+        if (!hasCard) {
+          pinnedSection.remove();
+        } else {
+          updatePinnedBadge(pinnedSection);
+        }
+      }
+    } catch (err) {
+      alert(err.message || 'Silme işlemi başarısız');
+    }
+  }
+
+  function handlePhotoPreview(input, previewWrapper, previewImg, errorBox) {
+    const file = input.files && input.files[0];
+    if (!file) {
+      if (previewWrapper) previewWrapper.classList.add('d-none');
+      if (previewImg) previewImg.src = '';
+      return;
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      if (errorBox) {
+        errorBox.textContent = 'Dosya boyutu 5MB sınırını aşıyor.';
+        errorBox.classList.remove('d-none');
+      } else {
+        alert('Dosya boyutu 5MB sınırını aşıyor.');
+      }
+      input.value = '';
+      return;
+    }
+    const allowed = ['image/jpeg', 'image/png', 'image/gif'];
+    if (file.type && !allowed.includes(file.type)) {
+      if (errorBox) {
+        errorBox.textContent = 'Sadece JPG, PNG veya GIF dosyaları yükleyebilirsiniz.';
+        errorBox.classList.remove('d-none');
+      } else {
+        alert('Sadece JPG, PNG veya GIF dosyaları yükleyebilirsiniz.');
+      }
+      input.value = '';
+      return;
+    }
+    if (errorBox) errorBox.classList.add('d-none');
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      if (previewImg) previewImg.src = ev.target.result;
+      if (previewWrapper) previewWrapper.classList.remove('d-none');
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function bindForm(form, errorBox, previewWrapper, previewImg) {
+    if (!form) return;
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      if (errorBox) {
+        errorBox.classList.add('d-none');
+        errorBox.textContent = '';
+      }
+      const formData = new FormData(form);
+      try {
+        const response = await fetch('/bilgiler/ekle', {
+          method: 'POST',
+          body: formData,
+        });
+        if (!response.ok) {
+          const message = await parseErrorMessage(response, 'Kaydetme sırasında bir hata oluştu');
+          throw new Error(message);
+        }
+        const modalEl = document.getElementById('bilgiModal');
+        if (modalEl && window.bootstrap) {
+          const modal = window.bootstrap.Modal.getOrCreateInstance(modalEl);
+          modal.hide();
+        }
+        form.reset();
+        if (previewWrapper) previewWrapper.classList.add('d-none');
+        if (previewImg) previewImg.src = '';
+        window.location.reload();
+      } catch (err) {
+        if (errorBox) {
+          errorBox.textContent = err.message || 'Kaydetme sırasında bir hata oluştu';
+          errorBox.classList.remove('d-none');
+        } else {
+          alert(err.message || 'Kaydetme sırasında bir hata oluştu');
+        }
+      }
+    });
+  }
+
+  window.initBilgiPage = function initBilgiPage(options = {}) {
+    const filterEl = document.getElementById('kategoriFilter');
+    const searchEl = document.getElementById('bilgiSearch');
+    const form = document.getElementById('bilgiForm');
+    const formError = document.getElementById('bilgiFormError');
+    const photoInput = document.getElementById('bilgiPhotoInput');
+    const previewWrapper = document.getElementById('bilgiPhotoPreviewWrapper');
+    const previewImg = document.getElementById('bilgiPhotoPreview');
+
+    if (filterEl) {
+      filterEl.value = options.kategori || '';
+      filterEl.addEventListener('change', () => applyFilters(filterEl, searchEl));
+    }
+    if (searchEl) {
+      searchEl.value = options.search || '';
+      searchEl.addEventListener('input', () => applyFilters(filterEl, searchEl));
+    }
+    applyFilters(filterEl, searchEl);
+
+    if (photoInput) {
+      photoInput.addEventListener('change', () =>
+        handlePhotoPreview(photoInput, previewWrapper, previewImg, formError)
+      );
+    }
+
+    bindForm(form, formError, previewWrapper, previewImg);
+
+    document.addEventListener('click', (e) => {
+      const pinBtn = e.target.closest('.bilgi-pin-btn');
+      if (pinBtn) {
+        e.preventDefault();
+        handlePin(pinBtn).then(() => applyFilters(filterEl, searchEl));
+        return;
+      }
+      const deleteBtn = e.target.closest('.bilgi-delete-btn');
+      if (deleteBtn) {
+        e.preventDefault();
+        handleDelete(deleteBtn).then(() => applyFilters(filterEl, searchEl));
+      }
+    });
+  };
+})();

--- a/static/uploads/bilgiler/.gitignore
+++ b/static/uploads/bilgiler/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -58,6 +58,22 @@
         </div>
       </div>
 
+      <!-- Bilgi Kategorisi -->
+      <div class="col-lg-4 col-md-6">
+        <div class="card ref-card h-100" data-entity="bilgi-kategori">
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <span>Bilgi Kategorisi</span>
+          </div>
+          <div class="card-body d-flex flex-column">
+            <div class="input-group mb-2">
+              <input class="form-control ref-input" placeholder="Yeni kategori..." />
+              <button class="btn btn-success ref-add" type="button">Ekle</button>
+            </div>
+            <ul class="list-group small ref-list flex-grow-1 overflow-auto"></ul>
+          </div>
+        </div>
+      </div>
+
       <!-- Fabrika -->
       <div class="col-lg-4 col-md-6">
         <div class="card ref-card h-100" data-entity="fabrika">

--- a/templates/base.html
+++ b/templates/base.html
@@ -110,6 +110,10 @@
               <i class="bi bi-inboxes"></i>
               <span>Talep Takip</span>
             </a>
+            <a class="side-link" href="/bilgiler">
+              <i class="bi bi-journal-text"></i>
+              <span>Bilgiler</span>
+            </a>
             <a class="side-link" href="{{ url_for('inventory.hurdalar') }}">
               <i class="bi bi-recycle"></i>
               <span>Hurdalar</span>

--- a/templates/bilgiler/index.html
+++ b/templates/bilgiler/index.html
@@ -1,0 +1,130 @@
+{% extends "base.html" %}
+{% block title %}Bilgi Merkezi{% endblock %}
+{% block content %}
+<div class="container-fluid px-0">
+  <div class="d-flex flex-wrap gap-3 align-items-center justify-content-between mb-4">
+    <div>
+      <h1 class="h4 mb-1">Bilgi Merkezi</h1>
+      <p class="text-muted small mb-0">Ekip içerisinde paylaşılan önemli notlar ve yönergeler.</p>
+    </div>
+    <button class="btn btn-primary" type="button" data-bs-toggle="modal" data-bs-target="#bilgiModal">
+      <i class="bi bi-plus-circle me-1"></i>Yeni Bilgi Ekle
+    </button>
+  </div>
+
+  <div class="card shadow-sm border-0 mb-4">
+    <div class="card-body">
+      <div class="row g-3 align-items-end" id="bilgiFilters">
+        <div class="col-md-3">
+          <label for="kategoriFilter" class="form-label text-muted">Kategori</label>
+          <select id="kategoriFilter" class="form-select form-select-sm">
+            <option value="">Tümü</option>
+            {% for kategori in categories %}
+            <option value="{{ kategori.id }}">{{ kategori.ad }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="col-md-6">
+          <label for="bilgiSearch" class="form-label text-muted">Arama</label>
+          <input id="bilgiSearch" class="form-control form-control-sm" type="search" placeholder="Başlık veya içerik içinde ara..." value="{{ search_query }}">
+        </div>
+        <div class="col-md-3 text-md-end">
+          <small class="text-muted d-block">Toplam {{ (pinned_items|length + other_items|length) }} kayıt</small>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {% if pinned_items %}
+  <section class="mb-5" id="pinnedBilgiler">
+    <div class="d-flex align-items-center gap-2 mb-2">
+      <span class="text-uppercase text-muted fw-semibold small">Sabitlenen Bilgiler</span>
+      <span class="badge bg-warning text-dark">{{ pinned_items|length }}/3</span>
+    </div>
+    <div class="row g-3">
+      {% for bilgi in pinned_items %}
+        {% include "partials/bilgi_card.html" %}
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
+  <section>
+    <div class="d-flex align-items-center gap-2 mb-2">
+      <span class="text-uppercase text-muted fw-semibold small">Tüm Bilgiler</span>
+    </div>
+    <div class="row g-3" id="bilgiList">
+      {% if other_items %}
+        {% for bilgi in other_items %}
+          {% include "partials/bilgi_card.html" %}
+        {% endfor %}
+      {% else %}
+        <div class="col-12">
+          <div class="alert alert-info mb-0">Henüz paylaşılmış bilgi bulunmuyor. İlk bilgiyi siz ekleyin!</div>
+        </div>
+      {% endif %}
+    </div>
+  </section>
+</div>
+
+<div class="modal fade" id="bilgiModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Yeni Bilgi Ekle</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+      <form id="bilgiForm" enctype="multipart/form-data">
+        <div class="modal-body">
+          <div class="alert alert-danger d-none" id="bilgiFormError"></div>
+          <div class="mb-3">
+            <label class="form-label">Başlık <span class="text-danger">*</span></label>
+            <input name="baslik" class="form-control" required maxlength="200" placeholder="Bilgi başlığını girin">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Kategori</label>
+            <select name="kategori_id" class="form-select" id="bilgiKategoriSelect">
+              <option value="">(Genel)</option>
+              {% for kategori in categories %}
+              <option value="{{ kategori.id }}">{{ kategori.ad }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">İçerik <span class="text-danger">*</span></label>
+            <textarea name="icerik" class="form-control" rows="6" required placeholder="İçeriği yazın..."></textarea>
+            <div class="form-text">Satır sonu için Enter kullanın. HTML otomatik olarak güvenli biçimde gösterilir.</div>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Fotoğraf (opsiyonel)</label>
+            <input type="file" class="form-control" name="foto" id="bilgiPhotoInput" accept=".jpg,.jpeg,.png,.gif">
+            <div class="form-text">En fazla 5MB. Dosya türleri: JPG, PNG veya GIF.</div>
+            <div class="mt-3 d-none" id="bilgiPhotoPreviewWrapper">
+              <img src="" alt="Fotoğraf önizlemesi" class="img-fluid rounded shadow-sm" id="bilgiPhotoPreview">
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+          <button type="submit" class="btn btn-primary">Kaydet</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ url_for('static', path='js/bilgiler.js') }}"></script>
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      initBilgiPage({
+        kategori: "{{ selected_category }}",
+        search: "{{ search_query }}",
+        currentUserId: {{ session_user.id }},
+        isAdmin: {{ 'true' if session_user.role == 'admin' else 'false' }}
+      });
+    });
+  </script>
+{% endblock %}

--- a/templates/partials/bilgi_card.html
+++ b/templates/partials/bilgi_card.html
@@ -1,0 +1,50 @@
+{% set owner = session_user.id == bilgi.kullanici_id %}
+{% set pinned = bilgi.is_pinned and bilgi.pinned_by == session_user.id %}
+<div class="col-12 col-md-6 col-xl-4 bilgi-card" data-category="{{ bilgi.kategori_id or '' }}" data-search="{{ (bilgi.baslik ~ ' ' ~ (bilgi.icerik or ''))|lower|replace('\n', ' ')|e }}">
+  <div class="card h-100 shadow-sm border-0">
+    <div class="card-body d-flex flex-column">
+      <div class="d-flex justify-content-between align-items-start mb-3 gap-2">
+        <div class="flex-grow-1">
+          <h3 class="h5 mb-1">{{ bilgi.baslik }}</h3>
+          <span class="badge text-bg-light text-muted border">
+            {{ bilgi.kategori.ad if bilgi.kategori else 'Genel' }}
+          </span>
+        </div>
+        <div class="btn-group btn-group-sm">
+          {% if owner %}
+          <button class="btn btn-outline-warning bilgi-pin-btn" data-id="{{ bilgi.id }}" data-pinned="{{ 'true' if pinned else 'false' }}">
+            <i class="bi bi-pin-angle{{ '-fill' if pinned else '' }}"></i>
+            <span class="ms-1">{{ 'Tutturmayı Kaldır' if pinned else 'Tuttur' }}</span>
+          </button>
+          {% endif %}
+          {% if owner or session_user.role == 'admin' %}
+          <button class="btn btn-outline-danger bilgi-delete-btn" data-id="{{ bilgi.id }}" title="Sil">
+            <i class="bi bi-trash"></i>
+          </button>
+          {% endif %}
+        </div>
+      </div>
+      <div class="text-muted small mb-3">
+        {% set author_name = bilgi.author.full_name if bilgi.author and bilgi.author.full_name else bilgi.author.username if bilgi.author else 'Bilinmiyor' %}
+        <span>{{ author_name }}</span>
+        <span class="mx-1">•</span>
+        <time datetime="{{ bilgi.created_at.isoformat() }}">{{ bilgi.created_at.strftime('%d.%m.%Y %H:%M') }}</time>
+      </div>
+      <div class="mt-auto">
+        <button class="btn btn-link px-0 text-decoration-none bilgi-toggle" type="button" data-bs-toggle="collapse" data-bs-target="#bilgi-{{ bilgi.id }}-icerik" aria-expanded="false">
+          Detayları Gör
+        </button>
+        <div class="collapse" id="bilgi-{{ bilgi.id }}-icerik">
+          <div class="border rounded bg-light-subtle p-3 small bilgi-content">
+            {{ bilgi.icerik|e|replace('\n', '<br>')|safe }}
+            {% if bilgi.foto_yolu %}
+            <div class="mt-3">
+              <img src="{{ url_for('static', path=bilgi.foto_yolu) }}" alt="{{ bilgi.baslik }} görseli" class="img-fluid rounded shadow-sm bilgi-photo">
+            </div>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- introduce BilgiKategori, Bilgi and UserPinLimit models plus REST endpoints and web UI for a knowledge center
- add a Bilgiler page with filtering, modal creation form, photo upload preview and AJAX pin/delete controls
- extend admin reference data and lookup APIs to manage knowledge categories and expose them in the lookup service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d12deb8a60832b83b3c4b11f71dcbf