### PR TITLE
Deduplicate logs query in logs_home

### DIFF
--- a/routers/logs.py
+++ b/routers/logs.py
@@ -13,13 +13,7 @@ templates = Jinja2Templates(directory="templates")
 
 @router.get("/", response_class=HTMLResponse, name="logs_page")
 def logs_home(request: Request, tab: str = "kullanici", db: Session = Depends(get_db)):
-    user_logs = (
-        db.query(InventoryLog, Inventory.no.label("inv_no"))
-        .join(Inventory, Inventory.id == InventoryLog.inventory_id)
-        .order_by(InventoryLog.created_at.desc())
-        .all()
-    )
-    inventory_logs = (
+    logs = (
         db.query(InventoryLog, Inventory.no.label("inv_no"))
         .join(Inventory, Inventory.id == InventoryLog.inventory_id)
         .order_by(InventoryLog.created_at.desc())
@@ -31,8 +25,8 @@ def logs_home(request: Request, tab: str = "kullanici", db: Session = Depends(ge
         "logs/index.html",
         {
             "request": request,
-            "user_logs": user_logs,
-            "inventory_logs": inventory_logs,
+            "user_logs": logs,
+            "inventory_logs": logs,
             "users": users,
             "inventory_numbers": inventory_numbers,
             "tab": tab,


### PR DESCRIPTION
## Summary
- reuse a single logs query in `logs_home` and supply it for both context keys to avoid duplicate database work

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1391829f0832bb213e134ce8674c2