### PR TITLE
Style tabs and sections with theme variables

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -204,6 +204,70 @@ small, .text-muted { color: var(--color-muted) !important; }
 }
 
 /* -------------------------------------------------------------------------- */
+/* Tabs & page sections                                                       */
+/* -------------------------------------------------------------------------- */
+.tabs-wrap .nav.nav-tabs,
+.tabs-wrap .nav.nav-pills {
+  border-bottom: 0 !important;
+  gap: var(--space-2xs);
+}
+
+.tabs-wrap .nav .nav-link {
+  border: 1px solid var(--color-border) !important;
+  border-bottom: 0 !important;
+  background: var(--color-surface-elevated) !important;
+  color: var(--color-heading) !important;
+  text-decoration: none !important;
+  border-radius: 0.9rem 0.9rem 0 0 !important;
+  padding: 0.5rem 0.9rem !important;
+  margin-bottom: 0 !important;
+  line-height: 1.2 !important;
+  box-shadow: none !important;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.tabs-wrap .nav .nav-link:hover {
+  background: var(--color-surface) !important;
+  color: var(--color-heading) !important;
+}
+
+.tabs-wrap .nav .nav-link.active {
+  background: var(--color-surface) !important;
+  color: var(--color-heading) !important;
+  position: relative !important;
+  z-index: 2 !important;
+  border-color: var(--color-border) var(--color-border) var(--color-surface) !important;
+}
+
+.page-section {
+  background: var(--color-surface) !important;
+  border: 1px solid var(--color-border) !important;
+  border-radius: 0 0.9rem 0.9rem 0.9rem !important;
+  padding: var(--space-md) !important;
+  margin-top: -1px !important;
+  color: var(--color-body);
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.page-section .table {
+  margin-bottom: 0 !important;
+}
+
+.page-section .table td,
+.page-section .table th {
+  vertical-align: middle !important;
+}
+
+.page-section .table thead th {
+  white-space: nowrap !important;
+}
+
+.page-section .table-responsive {
+  overflow-x: auto !important;
+  overflow-y: visible !important;
+}
+
+/* -------------------------------------------------------------------------- */
 /* Stat cards                                                                 */
 /* -------------------------------------------------------------------------- */
 .stat-grid {

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,48 +19,6 @@
     nav.navbar { z-index:1; }
   </style>
   <title>{% block title %}{% endblock %}</title>
-  <style>
-/* SEKME + TABLO BİRLEŞTİRME — ÇAKIŞMA KESİN DÜZELTME */
-.tabs-wrap .nav.nav-tabs,
-.tabs-wrap .nav.nav-pills { border-bottom: 0 !important; gap: .25rem; }
-
-/* Tüm sekmeler (tabs/pills) aynı görünüm */
-.tabs-wrap .nav .nav-link{
-  border: 1px solid #dee2e6 !important;
-  border-bottom: 0 !important;
-  background: #f3f4f6 !important;
-  color: #444 !important;
-  text-decoration: none !important;
-  border-radius: .9rem .9rem 0 0 !important; /* pill değil, sekme */
-  padding: .5rem .9rem !important;
-  margin-bottom: 0 !important;
-  line-height: 1.2 !important;
-}
-.tabs-wrap .nav .nav-link:hover{ background:#e9ecef !important; color:#222 !important; }
-
-/* Aktif sekme: alt sınırı kes ve üstte kalsın */
-.tabs-wrap .nav .nav-link.active{
-  background:#fff !important; color:#111 !important;
-  position: relative !important; z-index: 2 !important;
-  border-color:#dee2e6 #dee2e6 #fff !important;
-}
-
-/* Sekme altı kutu */
-.page-section{
-  background:#fff !important; border:1px solid #dee2e6 !important;
-  border-radius:0 .9rem .9rem .9rem !important;
-  padding:1rem !important; margin-top:-1px !important;
-}
-
-/* Bootstrap tablo iyileştirme */
-.page-section .table{ margin-bottom:0 !important; }
-.page-section .table td, .page-section .table th{ vertical-align:middle !important; }
-.page-section .table thead th{ white-space:nowrap !important; }
-.page-section .table-responsive{ overflow-x:auto !important; overflow-y:visible !important; }
-
-/* Olası global pill stili/tema müdahalesini sıfırla */
-.tabs-wrap .nav .nav-link{ box-shadow:none !important; }
-  </style>
 </head>
 <body class="theme-{{ request.session.get('user_theme', 'default') }} anim-{{ request.session.get('user_anim', 'none') }}">
   <nav class="navbar navbar-light bg-transparent p-3 pb-0">


### PR DESCRIPTION
## Summary
- move the tab and page-section styling from the base template into the shared custom stylesheet
- restyle tab backgrounds, borders, and text to reference the theme color variables for better dark/custom theme support
- keep page-section table refinements alongside the new component styles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d13fec67e0832b985803c46ecd41eb