### PR TITLE
Restore actions menu options and conditionally show repair action

### DIFF
--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -63,6 +63,7 @@
           {% set fault_device = row.no %}
           {% set fault_title = (row.marka ~ ' ' ~ row.model)|trim %}
           {% set fault_entity_key = row.no %}
+          {% set fault_status = row.durum %}
           {% include 'partials/_actions_menu.html' %}
         </td>
       </tr>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -70,6 +70,7 @@
             {% set fault_device = row.lisans_key or ('Lisans #' ~ row.id) %}
             {% set fault_title = row.lisans_adi %}
             {% set fault_entity_key = row.id %}
+            {% set fault_status = row.durum %}
             {% include 'partials/_actions_menu.html' %}
           </td>
         </tr>

--- a/templates/partials/_actions_menu.html
+++ b/templates/partials/_actions_menu.html
@@ -1,19 +1,23 @@
 {% set actions = action_options %}
 {% if not actions %}
-  {% if fault_mode %}
-    {% set actions = [
-      ('fault', 'Arızalı İşaretle'),
-      ('repair', 'Tamir Edildi'),
-      ('scrap', 'Hurdaya Ayır')
-    ] %}
-  {% else %}
-    {% set actions = [
-      ('assign', 'Atama Yap'),
-      ('edit', 'Düzenle'),
-      ('stock', 'Stok Girişi'),
-      ('scrap', 'Hurdaya Ayır')
+  {% set actions = [
+    ('assign', 'Atama Yap'),
+    ('edit', 'Düzenle'),
+    ('stock', 'Stok Girişi'),
+    ('scrap', 'Hurdaya Ayır')
+  ] %}
+{% endif %}
+{% if fault_mode %}
+  {% set fault_status_value = fault_status|default('')|lower %}
+  {% set fault_actions = [
+    ('fault', 'Arızalı İşaretle')
+  ] %}
+  {% if fault_status_value == 'arızalı' or fault_status_value == 'arizali' %}
+    {% set fault_actions = fault_actions + [
+      ('repair', 'Tamir Edildi')
     ] %}
   {% endif %}
+  {% set actions = fault_actions + actions %}
 {% endif %}
 
 <div class="d-flex align-items-center">

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -76,6 +76,7 @@
             {% set fault_device = p.envanter_no or ('Yazıcı #' ~ p.id) %}
             {% set fault_title = (p.marka ~ ' ' ~ p.model)|trim %}
             {% set fault_entity_key = p.envanter_no or p.id %}
+            {% set fault_status = p.durum %}
             {% include 'partials/_actions_menu.html' %}
           </td>
         </tr>


### PR DESCRIPTION
## Summary
- restore default assign/edit/stock options in the actions menu while keeping the fault controls
- only expose the "Tamir Edildi" action when the related record is currently marked arızalı
- propagate each row's current status to the shared actions partial for correct option rendering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1489e4170832bb411596d7383b360