### PR TITLE
Improve fault summary details and disable license faults

### DIFF
--- a/static/js/faults.js
+++ b/static/js/faults.js
@@ -67,13 +67,43 @@
     }
     const content = items
       .map((item) => {
-        const title = item.device_no || item.title || '-';
+        const title = item.title || item.device_no || item.entity_key || '-';
         const reason = item.reason || '-';
         const destination = item.destination || '';
         const created = formatDate(item.created_at);
+        const meta = item.meta && typeof item.meta === 'object' ? item.meta : null;
+
+        const detailParts = [];
+        const addDetail = (label, value) => {
+          if (!value) return;
+          const text = `${label}: ${value}`;
+          if (!detailParts.includes(text)) detailParts.push(text);
+        };
+
+        if (item.entity_key && item.entity_key !== title) {
+          addDetail('Kayıt', item.entity_key);
+        }
+        if (item.device_no && item.device_no !== title) {
+          addDetail('Cihaz No', item.device_no);
+        }
+        if (meta && typeof meta === 'object') {
+          const lineValue = meta.line || meta.row || meta.satir || meta.line_no;
+          const deviceName =
+            meta.device_name || meta.deviceName || meta.device_label || meta.device || meta.cihaz_adi;
+          if (lineValue) addDetail('Satır', lineValue);
+          if (deviceName && deviceName !== item.device_no) {
+            addDetail('Cihaz', deviceName);
+          }
+        }
+
+        const details = detailParts.length
+          ? `<div class="small text-muted">${detailParts.join(' • ')}</div>`
+          : '';
+
         return `
           <div class="fault-summary-item">
             <h6 class="mb-1">${title}</h6>
+            ${details}
             <div class="small">${reason}</div>
             ${destination ? `<div class="small text-muted">Gönderildiği: ${destination}</div>` : ''}
             ${created ? `<div class="text-muted small">${created}</div>` : ''}

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -9,9 +9,6 @@
         <i class="bi bi-plus-lg"></i>
         <span>Ekle</span>
       </a>
-      {% with fault_entity='license', fault_prefix='license', fault_label='Lisans Arızalı Durum' %}
-        {% include 'partials/_fault_controls.html' %}
-      {% endwith %}
       <div class="dropdown">
         <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
           Excel
@@ -66,11 +63,6 @@
           <td class="actions">
             {% set entity = 'lisans' %}
             {% set row_id = row.id %}
-            {% set fault_mode = True %}
-            {% set fault_device = row.lisans_key or ('Lisans #' ~ row.id) %}
-            {% set fault_title = row.lisans_adi %}
-            {% set fault_entity_key = row.id %}
-            {% set fault_status = row.durum %}
             {% include 'partials/_actions_menu.html' %}
           </td>
         </tr>


### PR DESCRIPTION
## Summary
- enrich the fault summary popover with record, device and meta details so faulty devices are easier to identify
- remove fault summary/action controls from the license list to disable marking licenses as faulty

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d14a1c2114832b8815766cac7bd209