### PR TITLE
Fix assignment actions and hide options for faulty records

### DIFF
--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -45,7 +45,13 @@
     </thead>
     <tbody>
       {% for row in items %}
-      <tr data-id="{{ row.id }}" class="inv-row{% if row.durum == 'arızalı' %} table-warning{% endif %}">
+      <tr
+        data-id="{{ row.id }}"
+        data-fabrika="{{ row.fabrika or '' }}"
+        data-departman="{{ row.departman or '' }}"
+        data-sorumlu="{{ row.sorumlu_personel or '' }}"
+        data-bagli="{{ row.bagli_envanter_no or '' }}"
+        class="inv-row{% if row.durum == 'arızalı' %} table-warning{% endif %}">
         <td>
           {{ row.no }}
           {% if row.durum == 'arızalı' %}
@@ -420,13 +426,30 @@ document.addEventListener('DOMContentLoaded', () => {
   // İşlem seçimi
   document.querySelectorAll('.action-select').forEach(sel => {
     sel.addEventListener('change', async (e) => {
-      e.stopImmediatePropagation();
-      const id = e.target.dataset.id;
       const val = e.target.value;
       if (!val) return;
+      const id = e.target.dataset.id;
+      if (!id) return;
+
+      if (val === 'assign') {
+        e.stopImmediatePropagation();
+        const tr = e.target.closest('tr');
+        document.getElementById('assign_item_id').value = id;
+        await preloadAssignDropdowns(id);
+        if (tr) {
+          setSelectValue('selFabrika', tr.dataset.fabrika);
+          setSelectValue('selDepartman', tr.dataset.departman);
+          setSelectValue('selPersonel', tr.dataset.sorumlu);
+          setSelectValue('selBagli', tr.dataset.bagli);
+        }
+        assignModal.show();
+        e.target.value = '';
+        return;
+      }
 
       if (val === 'fault') {
         if (window.Faults) {
+          e.stopImmediatePropagation();
           window.Faults.openMarkModal('inventory', {
             entityId: Number(id),
             entityKey: e.target.dataset.entityKey || e.target.dataset.device || id,
@@ -434,19 +457,29 @@ document.addEventListener('DOMContentLoaded', () => {
             title: e.target.dataset.title || '',
           });
         }
-      } else if (val === 'repair') {
+        e.target.value = '';
+        return;
+      }
+
+      if (val === 'repair') {
         if (window.Faults) {
+          e.stopImmediatePropagation();
           window.Faults.openRepairModal('inventory', {
             entityId: Number(id),
             entityKey: e.target.dataset.entityKey || e.target.dataset.device || id,
             deviceNo: e.target.dataset.device || '',
           });
         }
-      } else if (val === 'scrap') {
+        e.target.value = '';
+        return;
+      }
+
+      if (val === 'scrap') {
+        e.stopImmediatePropagation();
         document.getElementById('scrap_item_id').value = id;
         scrapModal.show();
+        e.target.value = '';
       }
-      e.target.value = '';
     });
   });
 
@@ -466,6 +499,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const el = document.getElementById(id);
     el.innerHTML = '<option value="">Seçiniz</option>' + arr.map(x =>
       `<option value="${x.id}">${x.text}</option>`).join('');
+  }
+
+  function setSelectValue(selectId, value) {
+    const el = document.getElementById(selectId);
+    if (!el) return;
+    const val = value || '';
+    if (val && !Array.from(el.options).some(opt => opt.value === val)) {
+      const opt = document.createElement('option');
+      opt.value = val;
+      opt.textContent = val;
+      el.appendChild(opt);
+    }
+    el.value = val;
   }
 
   // Atama submit

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -44,7 +44,11 @@
       </thead>
       <tbody>
         {% for row in items %}
-        <tr>
+        <tr
+          data-id="{{ row.id }}"
+          data-personel="{{ row.sorumlu_personel or '' }}"
+          data-bagli="{{ row.bagli_envanter_no or '' }}"
+          data-durum="{{ row.durum or '' }}">
           <td>{{ row.id }}</td>
           <td>{{ row.lisans_adi }}</td>
           <td class="text-truncate" style="max-width:180px;">{{ row.lisans_key }}</td>
@@ -63,6 +67,7 @@
           <td class="actions">
             {% set entity = 'lisans' %}
             {% set row_id = row.id %}
+            {% set fault_status = row.durum %}
             {% include 'partials/_actions_menu.html' %}
           </td>
         </tr>
@@ -325,19 +330,37 @@
     // Mevcut atama/hurda işlemleri
     const assignModal = new bootstrap.Modal(document.getElementById('assignModal'));
     const assignForm  = document.getElementById('assignForm');
+    const selAssignPersonel = document.getElementById('selPersonel');
+    const selAssignBagli = document.getElementById('selBagli');
     const scrapModal  = new bootstrap.Modal(document.getElementById('scrapModal'));
     const scrapForm   = document.getElementById('scrapForm');
     let scrapId = null;
+    let personelChoices = null;
+    let bagliChoices = null;
 
     document.querySelectorAll('#licensesTable .action-select').forEach(sel => {
       sel.addEventListener('change', (e) => {
-        e.stopImmediatePropagation();
-        const id = e.target.dataset.id;
         const val = e.target.value;
         if (!val) return;
+        const id = e.target.dataset.id;
+        if (!id) return;
+
+        if (val === 'assign') {
+          e.stopImmediatePropagation();
+          assignForm.setAttribute('action', `/lisans/${id}/assign`);
+          const tr = e.target.closest('tr');
+          if (tr) {
+            setSelectValue(selAssignPersonel, tr.dataset.personel, personelChoices);
+            setSelectValue(selAssignBagli, tr.dataset.bagli, bagliChoices);
+          }
+          assignModal.show();
+          e.target.value = '';
+          return;
+        }
 
         if (val === 'fault') {
           if (window.Faults) {
+            e.stopImmediatePropagation();
             window.Faults.openMarkModal('license', {
               entityId: Number(id),
               entityKey: e.target.dataset.entityKey || id,
@@ -345,21 +368,40 @@
               title: e.target.dataset.title || '',
             });
           }
-        } else if (val === 'repair') {
+          e.target.value = '';
+          return;
+        }
+
+        if (val === 'repair') {
           if (window.Faults) {
+            e.stopImmediatePropagation();
             window.Faults.openRepairModal('license', {
               entityId: Number(id),
               entityKey: e.target.dataset.entityKey || id,
               deviceNo: e.target.dataset.device || '',
             });
           }
-        } else if (val === 'scrap') {
-          scrapId = id;
-          scrapModal.show();
+          e.target.value = '';
+          return;
         }
 
-        e.target.value = '';
+        if (val === 'scrap') {
+          e.stopImmediatePropagation();
+          scrapId = id;
+          scrapModal.show();
+          e.target.value = '';
+        }
       });
+    });
+
+    assignForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const actionUrl = assignForm.getAttribute('action');
+      if (!actionUrl) return;
+      const fd = new FormData(assignForm);
+      const res = await fetch(actionUrl, { method: 'POST', body: fd });
+      if(res.ok){ assignModal.hide(); location.reload(); }
+      else { alert('Atama kaydedilemedi'); }
     });
 
     scrapForm.addEventListener('submit', async (e) => {
@@ -370,11 +412,32 @@
       else { alert('Hurdaya ayırma başarısız'); }
     });
 
+    function setSelectValue(selectEl, value, choicesInstance) {
+      if (!selectEl) return;
+      const val = value || '';
+      if (val && !Array.from(selectEl.options).some(opt => opt.value === val)) {
+        const opt = document.createElement('option');
+        opt.value = val;
+        opt.textContent = val;
+        selectEl.appendChild(opt);
+        if (choicesInstance) {
+          choicesInstance.setChoices([{ value: val, label: val }], 'value', 'label', false);
+        }
+      }
+      if (choicesInstance) {
+        choicesInstance.removeActiveItems();
+        if (val) {
+          choicesInstance.setChoiceByValue(val);
+        }
+      }
+      selectEl.value = val;
+    }
+
     if (window.Choices) {
       new Choices('#selLisansAdi',   { searchEnabled: true, shouldSort: false });
       new Choices('#selPersonelAdd', { searchEnabled: true, shouldSort: false });
-      new Choices('#selPersonel',    { searchEnabled: true, shouldSort: false });
-      new Choices('#selBagli',       { searchEnabled: true, shouldSort: false });
+      personelChoices = new Choices('#selPersonel', { searchEnabled: true, shouldSort: false });
+      bagliChoices = new Choices('#selBagli',       { searchEnabled: true, shouldSort: false });
     }
   });
 </script>

--- a/templates/partials/_actions_menu.html
+++ b/templates/partials/_actions_menu.html
@@ -7,8 +7,8 @@
     ('scrap', 'Hurdaya Ayır')
   ] %}
 {% endif %}
+{% set fault_status_value = fault_status|default('')|lower %}
 {% if fault_mode %}
-  {% set fault_status_value = fault_status|default('')|lower %}
   {% set fault_actions = [
     ('fault', 'Arızalı İşaretle')
   ] %}
@@ -18,6 +18,16 @@
     ] %}
   {% endif %}
   {% set actions = fault_actions + actions %}
+{% endif %}
+
+{% if fault_status_value == 'arızalı' or fault_status_value == 'arizali' %}
+  {% set filtered_actions = [] %}
+  {% for value, label in actions %}
+    {% if value not in ['assign', 'edit', 'stock'] %}
+      {% set filtered_actions = filtered_actions + [(value, label)] %}
+    {% endif %}
+  {% endfor %}
+  {% set actions = filtered_actions %}
 {% endif %}
 
 <div class="d-flex align-items-center">

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -51,7 +51,14 @@
       </thead>
       <tbody>
         {% for p in printers %}
-        <tr data-id="{{ p.id }}"{% if p.durum == 'arızalı' %} class="table-warning"{% endif %}>
+        <tr
+          data-id="{{ p.id }}"
+          data-label="{{ p.hostname or p.envanter_no or ('Yazıcı #' ~ p.id) }}"
+          data-fabrika="{{ p.fabrika or '' }}"
+          data-kullanim="{{ p.kullanim_alani or '' }}"
+          data-personel="{{ p.sorumlu_personel or '' }}"
+          data-bagli="{{ p.bagli_envanter_no or '' }}"
+          {% if p.durum == 'arızalı' %}class="table-warning"{% endif %}>
           <td>#{{ p.id }}</td>
           <td>{{ p.marka or '-' }}</td>
           <td>{{ p.model or '-' }}</td>
@@ -404,14 +411,28 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.querySelectorAll('.action-select').forEach(sel => {
     sel.addEventListener('change', (e) => {
-      e.stopImmediatePropagation();
-      const tr = e.target.closest('tr');
-      const printerId = tr.dataset.id;
       const val = e.target.value;
       if(!val) return;
+      const tr = e.target.closest('tr');
+      const printerId = tr?.dataset.id;
+      if(!printerId) return;
+
+      if(val === 'assign'){
+        e.stopImmediatePropagation();
+        document.getElementById('assignPrinterId').value = printerId;
+        document.getElementById('assignPrinterLabel').textContent = tr.dataset.label || `#${printerId}`;
+        setSelectValue('selFabrika', tr.dataset.fabrika);
+        setSelectValue('selKullanim', tr.dataset.kullanim);
+        setSelectValue('selPersonel', tr.dataset.personel);
+        setSelectValue('selBagliEnv', tr.dataset.bagli);
+        assignModal.show();
+        e.target.value = '';
+        return;
+      }
 
       if(val === 'fault'){
         if(window.Faults){
+          e.stopImmediatePropagation();
           window.Faults.openMarkModal('printer', {
             entityId: Number(printerId),
             entityKey: e.target.dataset.entityKey || printerId,
@@ -419,22 +440,44 @@ document.addEventListener('DOMContentLoaded', () => {
             title: e.target.dataset.title || '',
           });
         }
-      } else if(val === 'repair'){
+        e.target.value = '';
+        return;
+      }
+
+      if(val === 'repair'){
         if(window.Faults){
+          e.stopImmediatePropagation();
           window.Faults.openRepairModal('printer', {
             entityId: Number(printerId),
             entityKey: e.target.dataset.entityKey || printerId,
             deviceNo: e.target.dataset.device || '',
           });
         }
-      } else if(val === 'scrap'){
-        document.getElementById('scrapPrinterId').value = printerId;
-        scrapModal.show();
+        e.target.value = '';
+        return;
       }
 
-      e.target.value = '';
+      if(val === 'scrap'){
+        e.stopImmediatePropagation();
+        document.getElementById('scrapPrinterId').value = printerId;
+        scrapModal.show();
+        e.target.value = '';
+      }
     });
   });
+
+  function setSelectValue(selectId, value){
+    const el = document.getElementById(selectId);
+    if(!el) return;
+    const val = value || '';
+    if(val && !Array.from(el.options).some(opt => opt.value === val)){
+      const opt = document.createElement('option');
+      opt.value = val;
+      opt.textContent = val;
+      el.appendChild(opt);
+    }
+    el.value = val;
+  }
 
   scrapForm.addEventListener('submit', function(e){
     e.preventDefault();


### PR DESCRIPTION
## Summary
- prevent assignment, edit and stock options from showing on faulty items by filtering the shared action menu
- make the inventory, printer and license lists populate assignment modals and allow global handlers to run for other actions
- ensure assignment modals preload and select the current record data for a smoother workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1545560d0832bb790793fa9174750