### PR TITLE
Fix printer modal brand/model initialization

### DIFF
--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -280,37 +280,36 @@ document.addEventListener('DOMContentLoaded', () => {
     .map((th, idx) => ({ idx, name: th.textContent.trim(), field: th.dataset.field }))
     .filter(c => c.field);
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const markaSel = document.getElementById('selYaziciMarka');
-    const modelSel = document.getElementById('selYaziciModel');
-    if (markaSel && modelSel) {
-      if (window.Choices) {
-        new Choices(markaSel, { searchEnabled: true, shouldSort: false });
-        new Choices(modelSel, { searchEnabled: true, shouldSort: false });
-      }
-      const loadModels = async () => {
-        const marka = markaSel.value;
-        modelSel.innerHTML = '<option value="">Seçiniz...</option>';
-        modelSel.disabled = !marka;
-        if (!marka) return;
-        try {
-          const resp = await fetch(`/api/printers/models?brand=${encodeURIComponent(marka)}`);
-          if (resp.ok) {
-            const data = await resp.json();
-            data.forEach(m => {
-              const opt = document.createElement('option');
-              opt.value = m;
-              opt.textContent = m;
-              modelSel.appendChild(opt);
-            });
-          }
-        } catch (e) {
-          console.error(e);
-        }
-      };
-      markaSel.addEventListener('change', loadModels);
+  const markaSel = document.getElementById('selYaziciMarka');
+  const modelSel = document.getElementById('selYaziciModel');
+  if (markaSel && modelSel) {
+    if (window.Choices) {
+      new Choices(markaSel, { searchEnabled: true, shouldSort: false });
+      new Choices(modelSel, { searchEnabled: true, shouldSort: false });
     }
-  });
+    const loadModels = async () => {
+      const marka = markaSel.value;
+      modelSel.innerHTML = '<option value="">Seçiniz...</option>';
+      modelSel.disabled = !marka;
+      if (!marka) return;
+      try {
+        const resp = await fetch(`/api/printers/models?brand=${encodeURIComponent(marka)}`);
+        if (resp.ok) {
+          const data = await resp.json();
+          data.forEach(m => {
+            const opt = document.createElement('option');
+            opt.value = m;
+            opt.textContent = m;
+            modelSel.appendChild(opt);
+          });
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    markaSel.addEventListener('change', loadModels);
+    loadModels();
+  }
 
   // Modal tetikleyici attribute ile handle ediliyor; ek JS gerekmez.
 


### PR DESCRIPTION
## Summary
- move the printer marka/model initialization logic into the main DOMContentLoaded handler
- keep the Choices setup and model loading helper accessible without nested listeners

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d15d896c08832bb8337bcc16a5303a