### PR TITLE
Fix fault workflow menus and stock status actions

### DIFF
--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -927,16 +927,42 @@
       const detailButton = hasDetail
         ? `<button type="button" class="btn btn-sm btn-outline-secondary" data-stock-detail="${encoded}" title="Detay"><span aria-hidden="true">&#9776;</span><span class="visually-hidden">Detay</span></button>`
         : '';
+      const key = buildFaultKey(item);
+      const hasFault =
+        typeof window !== 'undefined'
+        && window.Faults
+        && typeof window.Faults.hasOpenFault === 'function'
+        ? window.Faults.hasOpenFault('stock', key)
+        : false;
+      const availableQty = Number(item?.net_miktar) || 0;
+      const menuItems = [];
+      if (availableQty > 0) {
+        menuItems.push(
+          `<li><button class="dropdown-item" type="button" onclick="assignFromStatus('${encoded}')">Atama Yap</button></li>`
+        );
+      }
+      if (hasFault) {
+        menuItems.push(
+          `<li><button class="dropdown-item" type="button" onclick="repairFromStatus('${encoded}')">Aktif Et</button></li>`
+        );
+      } else {
+        menuItems.push(
+          `<li><button class="dropdown-item" type="button" onclick="markFaultFromStatus('${encoded}')">Arızalı</button></li>`
+        );
+      }
+      if (menuItems.length) {
+        menuItems.push('<li><hr class="dropdown-divider"></li>');
+      }
+      menuItems.push(
+        `<li><button class="dropdown-item text-danger" type="button" onclick="scrapFromStatus('${encoded}')">Hurda</button></li>`
+      );
       const actionsMenu = `
     <div class="btn-group">
       <button class="btn btn-sm btn-outline-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
         İşlemler
       </button>
       <ul class="dropdown-menu dropdown-menu-end">
-        <li><button class="dropdown-item" type="button" onclick="markFaultFromStatus('${encoded}')">Arızalı</button></li>
-        <li><button class="dropdown-item" type="button" onclick="repairFromStatus('${encoded}')">Tamir Edildi</button></li>
-        <li><hr class="dropdown-divider"></li>
-        <li><button class="dropdown-item text-danger" type="button" onclick="scrapFromStatus('${encoded}')">Hurda</button></li>
+        ${menuItems.join('')}
       </ul>
     </div>`;
       const lastOp = item.son_islem_ts
@@ -1245,4 +1271,5 @@
   window.markFaultFromStatus = (encoded) => StockAssign.markFaultFromStatus(encoded);
   window.repairFromStatus = (encoded) => StockAssign.repairFromStatus(encoded);
   window.loadStockStatus = () => StockAssign.refreshStockStatus();
+  window.onStockFaultsUpdated = () => StockAssign.refreshStockStatus();
 })();

--- a/templates/partials/_actions_menu.html
+++ b/templates/partials/_actions_menu.html
@@ -7,14 +7,16 @@
     ('scrap', 'Hurdaya Ayır')
   ] %}
 {% endif %}
-{% set fault_status_value = fault_status|default('')|lower %}
+{% set fault_status_value = fault_status|default('')|lower|trim %}
 {% if fault_mode %}
-  {% set fault_actions = [
-    ('fault', 'Arızalı İşaretle')
-  ] %}
+  {% set fault_actions = [] %}
   {% if fault_status_value == 'arızalı' or fault_status_value == 'arizali' %}
     {% set fault_actions = fault_actions + [
-      ('repair', 'Tamir Edildi')
+      ('repair', 'Aktif Et')
+    ] %}
+  {% else %}
+    {% set fault_actions = fault_actions + [
+      ('fault', 'Arızalı İşaretle')
     ] %}
   {% endif %}
   {% set actions = fault_actions + actions %}
@@ -23,7 +25,7 @@
 {% if fault_status_value == 'arızalı' or fault_status_value == 'arizali' %}
   {% set filtered_actions = [] %}
   {% for value, label in actions %}
-    {% if value not in ['assign', 'edit', 'stock'] %}
+    {% if value not in ['assign', 'edit', 'stock', 'fault'] %}
       {% set filtered_actions = filtered_actions + [(value, label)] %}
     {% endif %}
   {% endfor %}

--- a/templates/partials/_fault_controls.html
+++ b/templates/partials/_fault_controls.html
@@ -61,7 +61,7 @@
   <div class="modal-dialog modal-dialog-centered modal-sm">
     <form class="modal-content" data-fault-repair-form>
       <div class="modal-header">
-        <h5 class="modal-title">Tamir Edildi</h5>
+        <h5 class="modal-title">Aktif Et</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
       </div>
       <div class="modal-body">
@@ -77,7 +77,7 @@
           <label class="form-label">Not</label>
           <textarea class="form-control form-control-sm" name="note" rows="2" placeholder="Opsiyonel"></textarea>
         </div>
-        <p class="small mb-0">Bu kayıt tamir edildi olarak işaretlenecek.</p>
+        <p class="small mb-0">Bu kayıt aktif hale getirilecek ve arıza kapatılacak.</p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">İptal</button>


### PR DESCRIPTION
## Summary
- hide arıza seçenekleri that no longer apply by showing **Aktif Et** instead of Arızalı İşaretle when a kayıt already has an açık arıza and by keeping Hurdaya Ayır in the işlem listesi
- align the arıza modal wording with the new **Aktif Et** action and reuse the same flow across modüller
- teach the fault helper to normalise entity adları, cache açık arıza kayıtları, and notify stok durum tables so that the stok sekmesi can add Atama Yap, show Aktif Et only when a fault exists, and refresh after arıza işlemleri

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2875b4ad0832b876a054f8280c62a