### PR TITLE
Fix action options for faulty items

### DIFF
--- a/templates/partials/_actions_menu.html
+++ b/templates/partials/_actions_menu.html
@@ -23,13 +23,13 @@
 {% endif %}
 
 {% if fault_status_value == 'arızalı' or fault_status_value == 'arizali' %}
-  {% set filtered_actions = [] %}
+  {% set filtered_actions = namespace(values=[]) %}
   {% for value, label in actions %}
     {% if value not in ['assign', 'edit', 'stock', 'fault'] %}
-      {% set filtered_actions = filtered_actions + [(value, label)] %}
+      {% set filtered_actions.values = filtered_actions.values + [(value, label)] %}
     {% endif %}
   {% endfor %}
-  {% set actions = filtered_actions %}
+  {% set actions = filtered_actions.values %}
 {% endif %}
 
 <div class="d-flex align-items-center">


### PR DESCRIPTION
## Summary
- keep the repair and scrap options visible for arızalı entries by correctly building the filtered action list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d28adf69cc832b91d9d009aa7538c7