### PR TITLE
Fix stock assignment quantities and clean up stock toolbar

### DIFF
--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -390,10 +390,15 @@
     function normaliseStockMeta(meta) {
       if (!meta) return null;
       const normalised = { ...meta };
-      if (normalised.net !== undefined && normalised.mevcut_miktar === undefined) {
-        normalised.mevcut_miktar = normalised.net;
+      if (normalised.mevcut_miktar === undefined) {
+        if (normalised.net_miktar !== undefined) {
+          normalised.mevcut_miktar = normalised.net_miktar;
+        } else if (normalised.net !== undefined) {
+          normalised.mevcut_miktar = normalised.net;
+        }
       }
-      normalised.mevcut_miktar = Number(normalised.mevcut_miktar ?? 0);
+      const numericQty = Number(normalised.mevcut_miktar ?? 0);
+      normalised.mevcut_miktar = Number.isNaN(numericQty) ? 0 : numericQty;
       return normalised;
     }
 
@@ -757,7 +762,7 @@
         const item = JSON.parse(decodeURIComponent(encoded));
         setSelectedStock({
           ...item,
-          mevcut_miktar: item.mevcut_miktar ?? item.net,
+          mevcut_miktar: item.mevcut_miktar ?? item.net_miktar ?? item.net,
         });
         const modalEl = document.getElementById('stokAtamaModal');
         if (modalEl) {

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -27,7 +27,6 @@
           </li>
         </ul>
       </div>
-      <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#stokAtamaModal">Atama</button>
       <input type="text" id="stockSearch" class="form-control form-control-sm" placeholder="Ara" style="width:200px">
     </div>
   </div>


### PR DESCRIPTION
## Summary
- ensure the stock assignment modal reads the correct remaining quantity from stock status entries
- fall back safely when the API only provides net_miktar values for assignment calculations
- remove the redundant top-right assignment button from the stock tracking page toolbar

## Testing
- pytest tests/test_stock_assign.py

------
https://chatgpt.com/codex/tasks/task_e_68d28d396904832b85306ab88cc0f838