### PR TITLE
refactor: centralize request user name helper

### DIFF
--- a/routers/license.py
+++ b/routers/license.py
@@ -16,6 +16,7 @@ from database import get_db
 from models import Inventory, License, LicenseLog, LicenseName, StockTotal
 from security import current_user
 from utils.faults import FAULT_STATUS_SCRAP, resolve_fault
+from utils.http import get_request_user_name
 from utils.stock_log import create_stock_log
 
 router = APIRouter(prefix="/lisans", tags=["Lisans"])
@@ -85,16 +86,6 @@ def _logla(db: Session, lic: License, islem: str, detay: str, islem_yapan: str):
     db.add(
         LicenseLog(license_id=lic.id, islem=islem, detay=detay, islem_yapan=islem_yapan)
     )
-
-
-def get_current_user_name(request: Request) -> str:
-    return (
-        request.session.get("full_name")
-        or getattr(request.scope.get("user"), "full_name", None)
-        or "Bilinmeyen Kullanıcı"
-    )
-
-
 @router.get("/new", response_class=HTMLResponse, name="license.new")
 def new_license_form(request: Request, db: Session = Depends(get_db)):
     envanterler = db.query(Inventory).order_by(Inventory.no).all()
@@ -176,7 +167,7 @@ def create_license(
         mail_adresi=mail_adresi,
         ifs_no=ifs_no,
         tarih=datetime.utcnow(),
-        islem_yapan=get_current_user_name(request),
+        islem_yapan=get_request_user_name(request),
     )
     db.add(lic)
     db.commit()

--- a/routers/printers.py
+++ b/routers/printers.py
@@ -25,6 +25,7 @@ from models import (
 )
 from security import current_user
 from utils.faults import FAULT_STATUS_SCRAP, resolve_fault
+from utils.http import get_request_user_name
 from utils.stock_log import create_stock_log
 
 templates = Jinja2Templates(directory="templates")
@@ -102,16 +103,6 @@ async def export_printers(db: Session = Depends(get_db)):
 @router.post("/import", response_class=PlainTextResponse)
 async def import_printers(file: UploadFile = File(...)):
     return f"Received {file.filename}, but import is not implemented."
-
-
-def get_current_user_name(request: Request) -> str:
-    return (
-        request.session.get("full_name")
-        or getattr(getattr(request, "user", None), "full_name", None)
-        or "Bilinmeyen Kullanıcı"
-    )
-
-
 def build_changes(old: Printer, new_vals: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     out: Dict[str, Dict[str, Any]] = {}
     for k, v in new_vals.items():
@@ -273,7 +264,7 @@ def create_printer_simple(
         hostname=hostname,
         ifs_no=ifs_no,
         tarih=datetime.utcnow(),
-        islem_yapan=get_current_user_name(request),
+        islem_yapan=get_request_user_name(request),
     )
     db.add(prn)
     db.commit()


### PR DESCRIPTION
## Summary
- add a reusable helper that safely resolves the current request's display name from session or scope
- use the shared helper in the inventory, license and printer routers to remove duplicate logic and keep fallbacks consistent

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3da6ca9bc832bbef075b382608888