### PR TITLE
Fix tab spacing in admin panel

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -252,6 +252,13 @@ small,
 .tabs-wrap .nav.nav-tabs,
 .tabs-wrap .nav.nav-pills {
   border-bottom: 0 !important;
+}
+
+.tabs-wrap .nav.nav-tabs {
+  gap: 0;
+}
+
+.tabs-wrap .nav.nav-pills {
   gap: var(--space-2xs);
 }
 


### PR DESCRIPTION
## Summary
- remove the spacing between adjacent admin panel tabs so they visually connect

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3f2d85dcc832bbac9d211529c8500