### PR TITLE
Align assignment modals layout across lists

### DIFF
--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -257,7 +257,7 @@ content %}
 
 <!-- ATAMA MODALI -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
     <form method="post" id="assignForm">
       <div class="modal-content">
         <div class="modal-header">
@@ -274,29 +274,31 @@ content %}
             name="islem_yapan"
             value="{{ current_user.full_name if current_user else 'system' }}"
           />
-          <div class="mb-2">
-            <label class="form-label">Sorumlu Personel</label>
-            <select
-              name="sorumlu_personel"
-              class="form-select"
-              id="selPersonel"
-            >
-              <option value="">Seçiniz</option>
-              {% for u in users %}
-              <option value="{{ u }}">{{ u }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="mb-2">
-            <label class="form-label">Bağlı Olduğu Envanter No</label>
-            <select name="bagli_envanter_no" class="form-select" id="selBagli">
-              <option value="">Seçiniz</option>
-              {% for inv in envanterler %}
-              <option value="{{ inv.no }}">
-                {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
-              </option>
-              {% endfor %}
-            </select>
+          <div class="row g-3">
+            <div class="col-12 col-md-6 col-xl-3">
+              <label class="form-label">Sorumlu Personel</label>
+              <select
+                name="sorumlu_personel"
+                class="form-select"
+                id="selPersonel"
+              >
+                <option value="">Seçiniz</option>
+                {% for u in users %}
+                <option value="{{ u }}">{{ u }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col-12 col-md-6 col-xl-3">
+              <label class="form-label">Bağlı Olduğu Envanter No</label>
+              <select name="bagli_envanter_no" class="form-select" id="selBagli">
+                <option value="">Seçiniz</option>
+                {% for inv in envanterler %}
+                <option value="{{ inv.no }}">
+                  {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
+                </option>
+                {% endfor %}
+              </select>
+            </div>
           </div>
           <small class="text-muted"
             >Bu işlem lisansın geçmiş kayıtlarına eklenecek.</small

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -294,7 +294,7 @@ content %}
 
 <!-- ATAMA MODAL -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-scrollable">
+  <div class="modal-dialog modal-dialog-scrollable modal-lg">
     <form class="modal-content" id="assignForm">
       <div class="modal-header">
         <h6 class="modal-title">
@@ -309,44 +309,46 @@ content %}
       <div class="modal-body">
         <input type="hidden" id="assignPrinterId" name="printer_id" />
 
-        <div class="mb-2">
-          <label class="form-label">Fabrika</label>
-          <select id="selFabrika" name="fabrika" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for f in factories %}
-            <option value="{{ f }}">{{ f }}</option>
-            {% endfor %}
-          </select>
-        </div>
+        <div class="row g-3">
+          <div class="col-12 col-md-6 col-xl-3">
+            <label class="form-label">Fabrika</label>
+            <select id="selFabrika" name="fabrika" class="form-select">
+              <option value="">Seçiniz</option>
+              {% for f in factories %}
+              <option value="{{ f }}">{{ f }}</option>
+              {% endfor %}
+            </select>
+          </div>
 
-        <div class="mb-2">
-          <label class="form-label">Kullanım Alanı</label>
-          <select id="selKullanim" name="kullanim_alani" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for a in areas %}
-            <option value="{{ a }}">{{ a }}</option>
-            {% endfor %}
-          </select>
-        </div>
+          <div class="col-12 col-md-6 col-xl-3">
+            <label class="form-label">Kullanım Alanı</label>
+            <select id="selKullanim" name="kullanim_alani" class="form-select">
+              <option value="">Seçiniz</option>
+              {% for a in areas %}
+              <option value="{{ a }}">{{ a }}</option>
+              {% endfor %}
+            </select>
+          </div>
 
-        <div class="mb-2">
-          <label class="form-label">Sorumlu Personel</label>
-          <select id="selPersonel" name="sorumlu_personel" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for u in users %}
-            <option value="{{ u }}">{{ u }}</option>
-            {% endfor %}
-          </select>
-        </div>
+          <div class="col-12 col-md-6 col-xl-3">
+            <label class="form-label">Sorumlu Personel</label>
+            <select id="selPersonel" name="sorumlu_personel" class="form-select">
+              <option value="">Seçiniz</option>
+              {% for u in users %}
+              <option value="{{ u }}">{{ u }}</option>
+              {% endfor %}
+            </select>
+          </div>
 
-        <div class="mb-2">
-          <label class="form-label">Bağlı Olduğu Envanter</label>
-          <select id="selBagliEnv" name="bagli_envanter_no" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for inv in inventory_nos %}
-            <option value="{{ inv }}">{{ inv }}</option>
-            {% endfor %}
-          </select>
+          <div class="col-12 col-md-6 col-xl-3">
+            <label class="form-label">Bağlı Olduğu Envanter</label>
+            <select id="selBagliEnv" name="bagli_envanter_no" class="form-select">
+              <option value="">Seçiniz</option>
+              {% for inv in inventory_nos %}
+              <option value="{{ inv }}">{{ inv }}</option>
+              {% endfor %}
+            </select>
+          </div>
         </div>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
## Summary
- match the printer assignment modal layout with the inventory modal by switching to a four-column grid and widening the dialog
- apply the same responsive row-and-column structure to the license assignment modal for consistent appearance across modules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3f3a09348832bbc5510a882780cf4