### PR TITLE
Revamp assignment forms with modern styling

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -744,6 +744,284 @@ tr[data-href] > td:first-child {
 }
 
 /* -------------------------------------------------------------------------- */
+/* Modern form surfaces                                                       */
+/* -------------------------------------------------------------------------- */
+.form-shell {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(
+    135deg,
+    rgba(99, 102, 241, 0.16),
+    rgba(129, 140, 248, 0.12) 42%,
+    rgba(236, 72, 153, 0.18)
+  );
+  border-radius: 26px;
+  padding: clamp(1.75rem, 1.2rem + 2vw, 3rem);
+  border: 1px solid rgba(124, 58, 237, 0.16);
+  box-shadow: var(--shadow-lg);
+  max-width: 1040px;
+  margin: 0 auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.form-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+      circle at top right,
+      rgba(248, 250, 252, 0.85),
+      transparent 56%
+    ),
+    radial-gradient(circle at bottom left, rgba(255, 255, 255, 0.75), transparent 60%);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.form-shell__header,
+.form-shell__form {
+  position: relative;
+  z-index: 1;
+}
+
+.form-shell__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.form-shell__title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.form-shell__subtitle {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-muted-strong);
+}
+
+.form-shell__header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.form-shell__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.form-shell__body {
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(18px);
+  border-radius: calc(var(--radius-lg) + 8px);
+  padding: clamp(1.5rem, 1.1rem + 1.6vw, 2.5rem);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.form-shell__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.form-shell__actions .btn {
+  min-width: 120px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-md) var(--space-lg);
+}
+
+.form-grid .grid-span-2,
+.form-grid .is-full {
+  grid-column: 1 / -1;
+}
+
+.form-hint {
+  margin: 0;
+  color: var(--color-muted-strong);
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 576px) {
+  .form-shell {
+    padding: var(--space-lg);
+  }
+
+  .form-shell__body {
+    padding: var(--space-lg);
+  }
+}
+
+body.theme-dark .form-shell {
+  background: linear-gradient(
+    135deg,
+    rgba(30, 64, 175, 0.55),
+    rgba(67, 56, 202, 0.5) 45%,
+    rgba(109, 40, 217, 0.6)
+  );
+  border-color: rgba(148, 163, 184, 0.28);
+}
+
+body.theme-dark .form-shell::before {
+  background: radial-gradient(
+      circle at top right,
+      rgba(148, 163, 184, 0.25),
+      transparent 62%
+    ),
+    radial-gradient(circle at bottom left, rgba(15, 23, 42, 0.4), transparent 60%);
+  opacity: 0.6;
+}
+
+body.theme-dark .form-shell__body {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+}
+
+body.theme-dark .form-shell__subtitle,
+body.theme-dark .form-hint {
+  color: rgba(226, 232, 240, 0.78);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Modern modals                                                              */
+/* -------------------------------------------------------------------------- */
+.modal-modern .modal-content {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(
+    135deg,
+    rgba(99, 102, 241, 0.2),
+    rgba(129, 140, 248, 0.16) 45%,
+    rgba(236, 72, 153, 0.22)
+  );
+  border: 1px solid rgba(124, 58, 237, 0.2);
+  border-radius: 28px;
+  padding: clamp(1.5rem, 1.1rem + 1.2vw, 2.25rem);
+  box-shadow: var(--shadow-lg);
+  color: inherit;
+}
+
+.modal-modern .modal-content::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+      circle at top right,
+      rgba(255, 255, 255, 0.85),
+      transparent 58%
+    ),
+    radial-gradient(circle at bottom left, rgba(255, 255, 255, 0.7), transparent 62%);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.modal-modern .modal-header,
+.modal-modern .modal-body,
+.modal-modern .modal-footer {
+  position: relative;
+  z-index: 1;
+}
+
+.modal-modern .modal-header,
+.modal-modern .modal-footer {
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.modal-modern .modal-header {
+  margin-bottom: var(--space-md);
+}
+
+.modal-modern .modal-title {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.modal-modern .modal-body {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: calc(var(--radius-lg) + 6px);
+  padding: clamp(1.25rem, 1rem + 1vw, 2rem);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.modal-modern .modal-footer {
+  margin-top: var(--space-md);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  justify-content: flex-end;
+}
+
+.modal-modern .modal-footer .btn {
+  min-width: 120px;
+}
+
+@media (max-width: 576px) {
+  .modal-modern .modal-content {
+    padding: var(--space-lg);
+  }
+
+  .modal-modern .modal-body {
+    padding: var(--space-lg);
+  }
+}
+
+body.theme-dark .modal-modern .modal-content {
+  background: linear-gradient(
+    135deg,
+    rgba(30, 64, 175, 0.58),
+    rgba(67, 56, 202, 0.54) 45%,
+    rgba(109, 40, 217, 0.62)
+  );
+  border-color: rgba(148, 163, 184, 0.32);
+}
+
+body.theme-dark .modal-modern .modal-content::before {
+  background: radial-gradient(
+      circle at top right,
+      rgba(148, 163, 184, 0.18),
+      transparent 60%
+    ),
+    radial-gradient(circle at bottom left, rgba(15, 23, 42, 0.45), transparent 62%);
+  opacity: 0.55;
+}
+
+body.theme-dark .modal-modern .modal-body {
+  background: rgba(15, 23, 42, 0.82);
+  border-color: rgba(148, 163, 184, 0.28);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.1);
+}
+
+body.theme-dark .modal-modern .modal-title {
+  color: #f8fafc;
+}
+
+/* -------------------------------------------------------------------------- */
 /* Buttons                                                                    */
 /* -------------------------------------------------------------------------- */
 .btn,

--- a/templates/_printer_form_fields.html
+++ b/templates/_printer_form_fields.html
@@ -1,9 +1,9 @@
-<div class="row g-3">
-  <div class="col-md-6">
+<div class="form-grid">
+  <div>
     <label class="form-label">Yazıcı Markası</label>
     <select id="selYaziciMarka" name="marka_id" class="form-select"></select>
   </div>
-  <div class="col-md-6">
+  <div>
     <label class="form-label">Yazıcı Modeli</label>
     <select
       id="selYaziciModel"
@@ -11,12 +11,12 @@
       class="form-select"
       disabled
     ></select>
-    <small class="text-muted"
-      >Not: Model listesi seçilen Markaya göre filtrelenir.</small
-    >
+  </div>
+  <div class="grid-span-2">
+    <p class="form-hint">Not: Model listesi seçilen markaya göre filtrelenir.</p>
   </div>
 
-  <div class="col-md-6">
+  <div>
     <label class="form-label">Kullanım Alanı</label>
     <select
       id="selYaziciKullanim"
@@ -25,27 +25,27 @@
     ></select>
   </div>
 
-  <div class="col-md-6">
+  <div>
     <label class="form-label">Envanter No</label>
     <input name="envanter_no" class="form-control" required />
   </div>
 
-  <div class="col-md-4">
+  <div>
     <label class="form-label">IP Adresi</label>
     <input name="ip_adresi" class="form-control" />
   </div>
 
-  <div class="col-md-4">
+  <div>
     <label class="form-label">MAC</label>
     <input name="mac" class="form-control" />
   </div>
 
-  <div class="col-md-4">
+  <div>
     <label class="form-label">Hostname</label>
     <input name="hostname" class="form-control" />
   </div>
 
-  <div class="col-md-4">
+  <div>
     <label class="form-label">IFS No</label>
     <input name="ifs_no" class="form-control" />
   </div>

--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -1,90 +1,105 @@
 {% extends "base.html" %}{% block title %}Envanter Düzenle{% endblock %} {%
 block content %}
 <div class="container-fluid p-3">
-  <h5 class="mb-3">Envanter Düzenle</h5>
-  <form method="post" action="{{ '?modal=1' if modal else '' }}">
-    <div class="row g-3">
-      <div class="col-md-3">
-        <label class="form-label">Fabrika</label>
-        <input
-          name="fabrika"
-          class="form-control"
-          value="{{ item.fabrika or '' }}"
-        />
+  <div class="form-shell">
+    <div class="form-shell__header">
+      <div>
+        <h2 class="form-shell__title">Envanter Düzenle</h2>
+        <p class="form-shell__subtitle">
+          Envanter bilgilerini güncelleyerek kayıtlarınızı güncel tutun.
+        </p>
       </div>
-      <div class="col-md-3">
-        <label class="form-label">Departman</label>
-        <input
-          name="departman"
-          class="form-control"
-          value="{{ item.departman or '' }}"
-        />
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Sorumlu Personel</label>
-        <input
-          name="sorumlu_personel"
-          class="form-control"
-          value="{{ item.sorumlu_personel or '' }}"
-        />
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Bağlı Envanter No</label>
-        <input
-          name="bagli_envanter_no"
-          class="form-control"
-          value="{{ item.bagli_envanter_no or '' }}"
-        />
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Marka</label>
-        <input
-          name="marka"
-          class="form-control"
-          value="{{ item.marka or '' }}"
-        />
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Model</label>
-        <input
-          name="model"
-          class="form-control"
-          value="{{ item.model or '' }}"
-        />
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">Kullanım Alanı</label>
-        <input
-          name="kullanim_alani"
-          class="form-control"
-          value="{{ item.kullanim_alani or '' }}"
-        />
-      </div>
-      <div class="col-md-3">
-        <label class="form-label">IFS No</label>
-        <input
-          name="ifs_no"
-          class="form-control"
-          value="{{ item.ifs_no or '' }}"
-        />
-      </div>
-      <div class="col-md-12">
-        <label class="form-label">Not</label>
-        <textarea name="not" class="form-control">
+    </div>
+    <form
+      method="post"
+      action="{{ '?modal=1' if modal else '' }}"
+      class="form-shell__form"
+    >
+      <div class="form-shell__body">
+        <div class="form-grid">
+          <div>
+            <label class="form-label">Fabrika</label>
+            <input
+              name="fabrika"
+              class="form-control"
+              value="{{ item.fabrika or '' }}"
+            />
+          </div>
+          <div>
+            <label class="form-label">Departman</label>
+            <input
+              name="departman"
+              class="form-control"
+              value="{{ item.departman or '' }}"
+            />
+          </div>
+          <div>
+            <label class="form-label">Sorumlu Personel</label>
+            <input
+              name="sorumlu_personel"
+              class="form-control"
+              value="{{ item.sorumlu_personel or '' }}"
+            />
+          </div>
+          <div>
+            <label class="form-label">Bağlı Envanter No</label>
+            <input
+              name="bagli_envanter_no"
+              class="form-control"
+              value="{{ item.bagli_envanter_no or '' }}"
+            />
+          </div>
+          <div>
+            <label class="form-label">Marka</label>
+            <input
+              name="marka"
+              class="form-control"
+              value="{{ item.marka or '' }}"
+            />
+          </div>
+          <div>
+            <label class="form-label">Model</label>
+            <input
+              name="model"
+              class="form-control"
+              value="{{ item.model or '' }}"
+            />
+          </div>
+          <div>
+            <label class="form-label">Kullanım Alanı</label>
+            <input
+              name="kullanim_alani"
+              class="form-control"
+              value="{{ item.kullanim_alani or '' }}"
+            />
+          </div>
+          <div>
+            <label class="form-label">IFS No</label>
+            <input
+              name="ifs_no"
+              class="form-control"
+              value="{{ item.ifs_no or '' }}"
+            />
+          </div>
+          <div class="grid-span-2">
+            <label class="form-label">Not</label>
+            <textarea name="not" class="form-control" rows="3">
 {{ item.not_ or '' }}</textarea
-        >
+            >
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="mt-3">
-      <button class="btn btn-primary btn-sm">Kaydet</button>
-      {% if not modal %}
-      <a
-        href="{{ url_for('inventory.list') }}"
-        class="btn btn-outline-secondary btn-sm"
-        >İptal</a
-      >
-      {% endif %}
-    </div>
-  </form>
+      <div class="form-shell__actions">
+        <button class="btn btn-primary" type="submit">Kaydet</button>
+        {% if not modal %}
+        <a
+          href="{{ url_for('inventory.list') }}"
+          class="btn btn-outline-secondary"
+          >İptal</a
+        >
+        {% endif %}
+      </div>
+    </form>
+  </div>
 </div>
 {% endblock %}

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -371,7 +371,7 @@ block content %}
 
 <!-- Atama Modal -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
+  <div class="modal-dialog modal-lg modal-modern">
     <form id="assignForm" class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Envanter Atama</h5>
@@ -381,35 +381,37 @@ block content %}
           data-bs-dismiss="modal"
         ></button>
       </div>
-      <div class="modal-body row g-3">
+      <div class="modal-body">
         <input type="hidden" name="item_id" id="assign_item_id" />
-        <div class="col-md-3">
-          <label class="form-label">Fabrika</label>
-          <select name="fabrika" id="selFabrika" class="form-select"></select>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Departman</label>
-          <select
-            name="departman"
-            id="selDepartman"
-            class="form-select"
-          ></select>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Sorumlu Personel</label>
-          <select
-            name="sorumlu_personel"
-            id="selPersonel"
-            class="form-select"
-          ></select>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Bağlı Olduğu Envanter</label>
-          <select
-            name="bagli_envanter_no"
-            id="selBagli"
-            class="form-select"
-          ></select>
+        <div class="form-grid">
+          <div>
+            <label class="form-label">Fabrika</label>
+            <select name="fabrika" id="selFabrika" class="form-select"></select>
+          </div>
+          <div>
+            <label class="form-label">Departman</label>
+            <select
+              name="departman"
+              id="selDepartman"
+              class="form-select"
+            ></select>
+          </div>
+          <div>
+            <label class="form-label">Sorumlu Personel</label>
+            <select
+              name="sorumlu_personel"
+              id="selPersonel"
+              class="form-select"
+            ></select>
+          </div>
+          <div>
+            <label class="form-label">Bağlı Olduğu Envanter</label>
+            <select
+              name="bagli_envanter_no"
+              id="selBagli"
+              class="form-select"
+            ></select>
+          </div>
         </div>
       </div>
       <div class="modal-footer">

--- a/templates/license_assign.html
+++ b/templates/license_assign.html
@@ -1,56 +1,70 @@
 {% extends "base.html" %} {% block title %}Lisans Atama{% endblock %} {% block
 content %}
-<div class="container-fluid p-3 content">
-  <div class="d-flex align-items-center justify-content-between mb-3">
-    <h4 class="mb-0">Lisans Atama</h4>
-    <a class="btn btn-light" href="{{ url_for('license_list') }}"
-      >← Listeye Dön</a
-    >
-  </div>
-  <div class="card shadow-sm">
-    <div class="card-body">
-      <form method="post" action="/lisans/{{ license.id }}/assign">
-        <input
-          type="hidden"
-          name="islem_yapan"
-          value="{{ current_user.full_name if current_user else 'system' }}"
-        />
-        <div class="mb-3">
-          <label class="form-label">Sorumlu Personel</label>
-          <select name="sorumlu_personel" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for u in users %}
-            <option
-              value="{{ u }}"
-              {% if license.sorumlu_personel == u %}selected{% endif %}
-            >
-              {{ u }}
-            </option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Bağlı Olduğu Envanter No</label>
-          <select name="bagli_envanter_no" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for inv in envanterler %}
-            <option
-              value="{{ inv.no }}"
-              {% if license.bagli_envanter_no == inv.no %}selected{% endif %}
-            >
-              {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
-            </option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="d-flex gap-2 mt-4">
-          <button class="btn btn-primary" type="submit">Kaydet</button>
-          <a class="btn btn-secondary" href="{{ url_for('license_list') }}"
-            >İptal</a
-          >
-        </div>
-      </form>
+<div class="container-fluid p-3">
+  <div class="form-shell">
+    <div class="form-shell__header">
+      <div>
+        <h2 class="form-shell__title">Lisans Atama</h2>
+        <p class="form-shell__subtitle">
+          Lisansı uygun personele ve envantere hızlıca yönlendirin.
+        </p>
+      </div>
+      <div class="form-shell__header-actions">
+        <a class="btn btn-light" href="{{ url_for('license_list') }}">
+          ← Listeye Dön
+        </a>
+      </div>
     </div>
+
+    <form
+      method="post"
+      action="/lisans/{{ license.id }}/assign"
+      class="form-shell__form"
+    >
+      <input
+        type="hidden"
+        name="islem_yapan"
+        value="{{ current_user.full_name if current_user else 'system' }}"
+      />
+      <div class="form-shell__body">
+        <div class="form-grid">
+          <div>
+            <label class="form-label">Sorumlu Personel</label>
+            <select name="sorumlu_personel" class="form-select">
+              <option value="">Seçiniz</option>
+              {% for u in users %}
+              <option
+                value="{{ u }}"
+                {% if license.sorumlu_personel == u %}selected{% endif %}
+              >
+                {{ u }}
+              </option>
+              {% endfor %}
+            </select>
+          </div>
+          <div>
+            <label class="form-label">Bağlı Olduğu Envanter No</label>
+            <select name="bagli_envanter_no" class="form-select">
+              <option value="">Seçiniz</option>
+              {% for inv in envanterler %}
+              <option
+                value="{{ inv.no }}"
+                {% if license.bagli_envanter_no == inv.no %}selected{% endif %}
+              >
+                {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
+              </option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+      </div>
+      <div class="form-shell__actions">
+        <button class="btn btn-primary" type="submit">Kaydet</button>
+        <a class="btn btn-outline-secondary" href="{{ url_for('license_list') }}"
+          >İptal</a
+        >
+      </div>
+    </form>
   </div>
 </div>
 {% endblock %}

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -1,23 +1,33 @@
 {% extends "base.html" %} {% block title %}Lisans {{ 'Düzenle' if license else
 'Ekle' }}{% endblock %} {% block content %}
-<div class="container-fluid p-3 content">
-  <div class="d-flex align-items-center justify-content-between mb-3">
-    <h4 class="mb-0">Lisans {{ 'Düzenle' if license else 'Ekle' }}</h4>
-    {% if not modal %}
-    <a class="btn btn-light" href="{{ url_for('license_list') }}"
-      >← Listeye Dön</a
-    >
-    {% endif %}
-  </div>
+<div class="container-fluid p-3">
+  <div class="form-shell">
+    <div class="form-shell__header">
+      <div>
+        <h2 class="form-shell__title">
+          Lisans {{ 'Düzenle' if license else 'Ekle' }}
+        </h2>
+        <p class="form-shell__subtitle">
+          Lisans kayıtlarınızdaki bilgileri kolayca yönetin.
+        </p>
+      </div>
+      {% if not modal %}
+      <div class="form-shell__header-actions">
+        <a class="btn btn-light" href="{{ url_for('license_list') }}">
+          ← Listeye Dön
+        </a>
+      </div>
+      {% endif %}
+    </div>
 
-  <div class="card shadow-sm">
-    <div class="card-body">
-      <form
-        method="post"
-        action="{{ form_action }}{{ '?modal=1' if modal else '' }}"
-      >
-        <div class="row g-3">
-          <div class="col-md-6">
+    <form
+      method="post"
+      action="{{ form_action }}{{ '?modal=1' if modal else '' }}"
+      class="form-shell__form"
+    >
+      <div class="form-shell__body">
+        <div class="form-grid">
+          <div>
             <label class="form-label">Lisans Adı</label>
             <select name="adi" class="form-select" required>
               <option value="">Seçiniz...</option>
@@ -32,7 +42,7 @@
             </select>
           </div>
 
-          <div class="col-md-6">
+          <div>
             <label class="form-label">Lisans Anahtarı</label>
             <input
               name="anahtar"
@@ -41,7 +51,7 @@
             />
           </div>
 
-          <div class="col-md-6">
+          <div>
             <label class="form-label">Sorumlu Personel</label>
             <select name="sorumlu_personel" class="form-select">
               <option value="">(Seçiniz)</option>
@@ -56,7 +66,7 @@
             </select>
           </div>
 
-          <div class="col-md-6">
+          <div>
             <label class="form-label">Bağlı Olduğu Envanter No</label>
             <select
               id="selBagliEnvanter"
@@ -75,7 +85,7 @@
             </select>
           </div>
 
-          <div class="col-md-4">
+          <div>
             <label class="form-label">IFS No</label>
             <input
               name="ifs_no"
@@ -84,7 +94,7 @@
             />
           </div>
 
-          <div class="col-md-6">
+          <div>
             <label class="form-label">Mail Adresi</label>
             <input
               type="email"
@@ -94,17 +104,17 @@
             />
           </div>
         </div>
+      </div>
 
-        <div class="d-flex gap-2 mt-4">
-          <button class="btn btn-primary" type="submit">Kaydet</button>
-          {% if not modal %}
-          <a class="btn btn-secondary" href="{{ url_for('license_list') }}"
-            >İptal</a
-          >
-          {% endif %}
-        </div>
-      </form>
-    </div>
+      <div class="form-shell__actions">
+        <button class="btn btn-primary" type="submit">Kaydet</button>
+        {% if not modal %}
+        <a class="btn btn-outline-secondary" href="{{ url_for('license_list') }}"
+          >İptal</a
+        >
+        {% endif %}
+      </div>
+    </form>
   </div>
 </div>
 {% endblock %} {% block scripts %} {{ super() }}

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -257,7 +257,7 @@ content %}
 
 <!-- ATAMA MODALI -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-lg">
+  <div class="modal-dialog modal-dialog-centered modal-lg modal-modern">
     <form method="post" id="assignForm">
       <div class="modal-content">
         <div class="modal-header">
@@ -274,8 +274,8 @@ content %}
             name="islem_yapan"
             value="{{ current_user.full_name if current_user else 'system' }}"
           />
-          <div class="row g-3">
-            <div class="col-12 col-md-6 col-xl-3">
+          <div class="form-grid">
+            <div>
               <label class="form-label">Sorumlu Personel</label>
               <select
                 name="sorumlu_personel"
@@ -288,7 +288,7 @@ content %}
                 {% endfor %}
               </select>
             </div>
-            <div class="col-12 col-md-6 col-xl-3">
+            <div>
               <label class="form-label">Bağlı Olduğu Envanter No</label>
               <select name="bagli_envanter_no" class="form-select" id="selBagli">
                 <option value="">Seçiniz</option>
@@ -300,13 +300,13 @@ content %}
               </select>
             </div>
           </div>
-          <small class="text-muted"
-            >Bu işlem lisansın geçmiş kayıtlarına eklenecek.</small
-          >
+          <p class="form-hint">
+            Bu işlem lisansın geçmiş kayıtlarına eklenecek.
+          </p>
         </div>
         <div class="modal-footer">
           <button class="btn btn-primary" type="submit">Kaydet</button>
-          <button class="btn btn-light" type="button" data-bs-dismiss="modal">
+          <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="modal">
             İptal
           </button>
         </div>

--- a/templates/printer_edit.html
+++ b/templates/printer_edit.html
@@ -1,16 +1,34 @@
 {% extends "base.html" %} {% block title %}Yazıcı Güncelle{% endblock %} {%
 block content %}
 <div class="container-fluid p-3">
-  <h5 class="mb-3">Yazıcı Güncelle</h5>
-  <form method="post" action="/printers/{{ item.id }}/update">
-    {% include "_printer_form_fields.html" %}
-    <div class="mt-3">
-      <button class="btn btn-primary btn-sm">Kaydet</button>
-      <a href="/printers/{{ item.id }}" class="btn btn-outline-secondary btn-sm"
-        >İptal</a
-      >
+  <div class="form-shell">
+    <div class="form-shell__header">
+      <div>
+        <h2 class="form-shell__title">Yazıcı Güncelle</h2>
+        <p class="form-shell__subtitle">
+          Yazıcı bilgilerini güncelleyerek kullanım detaylarını eşitleyin.
+        </p>
+      </div>
+      <div class="form-shell__header-actions">
+        <a class="btn btn-light" href="/printers/{{ item.id }}">← Detaya Dön</a>
+      </div>
     </div>
-  </form>
+    <form
+      method="post"
+      action="/printers/{{ item.id }}/update"
+      class="form-shell__form"
+    >
+      <div class="form-shell__body">
+        {% include "_printer_form_fields.html" %}
+      </div>
+      <div class="form-shell__actions">
+        <button class="btn btn-primary" type="submit">Kaydet</button>
+        <a href="/printers/{{ item.id }}" class="btn btn-outline-secondary"
+          >İptal</a
+        >
+      </div>
+    </form>
+  </div>
 </div>
 <script>
   document.addEventListener("DOMContentLoaded", async () => {

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -294,7 +294,7 @@ content %}
 
 <!-- ATAMA MODAL -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-scrollable modal-lg">
+  <div class="modal-dialog modal-dialog-scrollable modal-lg modal-modern">
     <form class="modal-content" id="assignForm">
       <div class="modal-header">
         <h6 class="modal-title">
@@ -309,8 +309,8 @@ content %}
       <div class="modal-body">
         <input type="hidden" id="assignPrinterId" name="printer_id" />
 
-        <div class="row g-3">
-          <div class="col-12 col-md-6 col-xl-3">
+        <div class="form-grid">
+          <div>
             <label class="form-label">Fabrika</label>
             <select id="selFabrika" name="fabrika" class="form-select">
               <option value="">Seçiniz</option>
@@ -320,7 +320,7 @@ content %}
             </select>
           </div>
 
-          <div class="col-12 col-md-6 col-xl-3">
+          <div>
             <label class="form-label">Kullanım Alanı</label>
             <select id="selKullanim" name="kullanim_alani" class="form-select">
               <option value="">Seçiniz</option>
@@ -330,7 +330,7 @@ content %}
             </select>
           </div>
 
-          <div class="col-12 col-md-6 col-xl-3">
+          <div>
             <label class="form-label">Sorumlu Personel</label>
             <select id="selPersonel" name="sorumlu_personel" class="form-select">
               <option value="">Seçiniz</option>
@@ -340,7 +340,7 @@ content %}
             </select>
           </div>
 
-          <div class="col-12 col-md-6 col-xl-3">
+          <div>
             <label class="form-label">Bağlı Olduğu Envanter</label>
             <select id="selBagliEnv" name="bagli_envanter_no" class="form-select">
               <option value="">Seçiniz</option>
@@ -352,10 +352,10 @@ content %}
         </div>
       </div>
       <div class="modal-footer">
-        <button class="btn btn-secondary" type="button" data-bs-dismiss="modal">
+        <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="modal">
           İptal
         </button>
-        <button class="btn btn-success" type="submit">Atamayı Kaydet</button>
+        <button class="btn btn-primary" type="submit">Atamayı Kaydet</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- introduce reusable `form-shell` and `modal-modern` styles to match the new gradient design
- restyle inventory, license and printer edit/assign views to use the shared layout helpers
- refresh assignment modals across inventory, licenses and printers with the new grid form presentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3f5c4c150832b97a2e8e96cf41007