### PR TITLE
Align inventory add and printer edit forms with modern layout

### DIFF
--- a/templates/inventory_add.html
+++ b/templates/inventory_add.html
@@ -1,136 +1,151 @@
-<form
-  method="post"
-  action="/inventory/create"
-  class="needs-validation"
-  novalidate
->
-  <div class="row g-3" id="envanter-ekle">
-    <!-- Envanter No / Bilgisayar Adı -->
-    <div class="col-md-6">
-      <label class="form-label">Envanter No</label>
-      <input
-        name="envanter_no"
-        type="text"
-        class="form-control"
-        required
-        placeholder="ENV-000123"
-      />
+<div class="container-fluid p-3">
+  <div class="form-shell">
+    <div class="form-shell__header">
+      <div>
+        <h2 class="form-shell__title">Envanter Ekle</h2>
+        <p class="form-shell__subtitle">
+          Yeni ekipman kaydı oluşturarak envanter listenizi güncel tutun.
+        </p>
+      </div>
     </div>
-    <div class="col-md-6">
-      <label class="form-label">Bilgisayar Adı</label>
-      <input
-        name="bilgisayar_adi"
-        type="text"
-        class="form-control"
-        required
-        placeholder="PC-OFIS-01"
-      />
-    </div>
-
-    <!-- Fabrika / Departman -->
-    <div class="col-md-6">
-      <label class="form-label">Fabrika</label>
-      <select id="fabrika" name="fabrika" class="form-select" required></select>
-    </div>
-    <div class="col-md-6">
-      <label class="form-label">Departman</label>
-      <select
-        id="departman"
-        name="departman"
-        class="form-select"
-        required
-      ></select>
-    </div>
-
-    <!-- Donanım Tipi / Sorumlu Personel -->
-    <div class="col-md-6">
-      <label class="form-label">Donanım Tipi</label>
-      <select
-        id="donanim_tipi"
-        name="donanim_tipi"
-        class="form-select"
-        required
-      ></select>
-    </div>
-    <div class="col-md-6">
-      <label class="form-label">Sorumlu Personel</label>
-      <select
-        id="sorumlu_personel"
-        name="sorumlu_personel"
-        class="form-select"
-        required
-      ></select>
-    </div>
-
-    <!-- Marka / Model -->
-    <div class="col-md-6">
-      <label class="form-label">Marka</label>
-      <select id="marka" name="marka" class="form-select" required></select>
-    </div>
-    <div class="col-md-6">
-      <label class="form-label">Model</label>
-      <select id="model" name="model" class="form-select" required disabled>
-        <option value="">Önce marka seçiniz...</option>
-      </select>
-    </div>
-
-    <!-- Seri No / IFS No -->
-    <div class="col-md-6">
-      <label class="form-label">Seri No</label>
-      <input
-        name="seri_no"
-        type="text"
-        class="form-control"
-        required
-        placeholder="SN123456789"
-      />
-    </div>
-    <div class="col-md-6">
-      <label class="form-label"
-        >IFS No <span class="text-muted">(zorunlu değil)</span></label
-      >
-      <input
-        name="ifs_no"
-        type="text"
-        class="form-control"
-        placeholder="IFS-..."
-      />
-    </div>
-
-    <!-- Bağlı Makina No -->
-    <div class="col-md-6">
-      <label class="form-label"
-        >Bağlı Makina No <span class="text-muted">(zorunlu değil)</span></label
-      >
-      <input
-        name="bagli_makina_no"
-        type="text"
-        class="form-control"
-        placeholder="Makina No"
-      />
-    </div>
-
-    <!-- Not -->
-    <div class="col-12">
-      <label class="form-label"
-        >Not <span class="text-muted">(zorunlu değil)</span></label
-      >
-      <textarea
-        name="notlar"
-        class="form-control"
-        rows="2"
-        placeholder="Açıklama / notlar"
-      ></textarea>
-    </div>
+    <form
+      method="post"
+      action="/inventory/create"
+      class="form-shell__form needs-validation"
+      novalidate
+    >
+      <div class="form-shell__body">
+        <div class="form-grid" id="envanter-ekle">
+          <div>
+            <label class="form-label">Envanter No</label>
+            <input
+              name="envanter_no"
+              type="text"
+              class="form-control"
+              required
+              placeholder="ENV-000123"
+            />
+          </div>
+          <div>
+            <label class="form-label">Bilgisayar Adı</label>
+            <input
+              name="bilgisayar_adi"
+              type="text"
+              class="form-control"
+              required
+              placeholder="PC-OFIS-01"
+            />
+          </div>
+          <div>
+            <label class="form-label">Fabrika</label>
+            <select
+              id="fabrika"
+              name="fabrika"
+              class="form-select"
+              required
+            ></select>
+          </div>
+          <div>
+            <label class="form-label">Departman</label>
+            <select
+              id="departman"
+              name="departman"
+              class="form-select"
+              required
+            ></select>
+          </div>
+          <div>
+            <label class="form-label">Donanım Tipi</label>
+            <select
+              id="donanim_tipi"
+              name="donanim_tipi"
+              class="form-select"
+              required
+            ></select>
+          </div>
+          <div>
+            <label class="form-label">Sorumlu Personel</label>
+            <select
+              id="sorumlu_personel"
+              name="sorumlu_personel"
+              class="form-select"
+              required
+            ></select>
+          </div>
+          <div>
+            <label class="form-label">Marka</label>
+            <select id="marka" name="marka" class="form-select" required></select>
+          </div>
+          <div>
+            <label class="form-label">Model</label>
+            <select
+              id="model"
+              name="model"
+              class="form-select"
+              required
+              disabled
+            >
+              <option value="">Önce marka seçiniz...</option>
+            </select>
+          </div>
+          <div>
+            <label class="form-label">Seri No</label>
+            <input
+              name="seri_no"
+              type="text"
+              class="form-control"
+              required
+              placeholder="SN123456789"
+            />
+          </div>
+          <div>
+            <label class="form-label">
+              IFS No <span class="text-muted">(zorunlu değil)</span>
+            </label>
+            <input
+              name="ifs_no"
+              type="text"
+              class="form-control"
+              placeholder="IFS-..."
+            />
+          </div>
+          <div>
+            <label class="form-label">
+              Bağlı Makina No <span class="text-muted">(zorunlu değil)</span>
+            </label>
+            <input
+              name="bagli_makina_no"
+              type="text"
+              class="form-control"
+              placeholder="Makina No"
+            />
+          </div>
+          <div class="grid-span-2">
+            <label class="form-label">
+              Not <span class="text-muted">(zorunlu değil)</span>
+            </label>
+            <textarea
+              name="notlar"
+              class="form-control"
+              rows="3"
+              placeholder="Açıklama / notlar"
+            ></textarea>
+          </div>
+        </div>
+      </div>
+      <div class="form-shell__actions">
+        <button type="submit" class="btn btn-primary">Kaydet</button>
+        <button
+          type="button"
+          class="btn btn-outline-secondary"
+          data-bs-dismiss="modal"
+        >
+          İptal
+        </button>
+      </div>
+    </form>
   </div>
-
-  <div class="mt-3 d-flex gap-2">
-    <button type="submit" class="btn btn-primary">Kaydet</button>
-    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-      İptal
-    </button>
-  </div>
-</form>
+</div>
 
 <script>
   (async function () {

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -1,47 +1,73 @@
 {% extends "base.html" %} {% block title %}Yazıcı Düzenle{% endblock %} {% block
 content %}
 <div class="container-fluid p-3">
-  <h5 class="mb-3">Yazıcı Düzenle</h5>
-  <form method="post" action="{{ '?modal=1' if modal else '' }}">
-    <div class="mb-2">
-      <label class="form-label">Marka</label>
-      <input
-        type="text"
-        name="marka"
-        value="{{ p.marka or '' }}"
-        class="form-control"
-      />
+  <div class="form-shell">
+    <div class="form-shell__header">
+      <div>
+        <h2 class="form-shell__title">Yazıcı Düzenle</h2>
+        <p class="form-shell__subtitle">
+          Yazıcı bilgilerini güncelleyerek takip kayıtlarını tutarlı hale getirin.
+        </p>
+      </div>
+      {% if not modal %}
+      <div class="form-shell__header-actions">
+        <a class="btn btn-light" href="/printers/{{ p.id }}">← Detaya Dön</a>
+      </div>
+      {% endif %}
     </div>
-    <div class="mb-2">
-      <label class="form-label">Model</label>
-      <input
-        type="text"
-        name="model"
-        value="{{ p.model or '' }}"
-        class="form-control"
-      />
-    </div>
-    <div class="mb-2">
-      <label class="form-label">Seri No</label>
-      <input
-        type="text"
-        name="seri_no"
-        value="{{ p.seri_no or '' }}"
-        class="form-control"
-      />
-    </div>
-    <div class="mb-3">
-      <label class="form-label">Notlar</label>
-      <textarea name="notlar" class="form-control" rows="3">
-{{ p.notlar or '' }}</textarea
-      >
-    </div>
-    <button class="btn btn-primary btn-sm">Kaydet</button>
-    {% if not modal %}
-    <a href="/printers/{{ p.id }}" class="btn btn-outline-secondary btn-sm"
-      >İptal</a
+    <form
+      method="post"
+      action="{{ '?modal=1' if modal else '' }}"
+      class="form-shell__form"
     >
-    {% endif %}
-  </form>
+      <div class="form-shell__body">
+        <div class="form-grid">
+          <div>
+            <label class="form-label">Marka</label>
+            <input
+              type="text"
+              name="marka"
+              value="{{ p.marka or '' }}"
+              class="form-control"
+            />
+          </div>
+          <div>
+            <label class="form-label">Model</label>
+            <input
+              type="text"
+              name="model"
+              value="{{ p.model or '' }}"
+              class="form-control"
+            />
+          </div>
+          <div>
+            <label class="form-label">Seri No</label>
+            <input
+              type="text"
+              name="seri_no"
+              value="{{ p.seri_no or '' }}"
+              class="form-control"
+            />
+          </div>
+          <div class="grid-span-2">
+            <label class="form-label">Notlar</label>
+            <textarea
+              name="notlar"
+              class="form-control"
+              rows="3"
+            >{{ p.notlar or '' }}</textarea>
+          </div>
+        </div>
+      </div>
+      <div class="form-shell__actions">
+        <button class="btn btn-primary" type="submit">Kaydet</button>
+        {% if not modal %}
+        <a href="/printers/{{ p.id }}" class="btn btn-outline-secondary"
+          >İptal</a
+        >
+        {% endif %}
+      </div>
+    </form>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- wrap the inventory creation form with the modern form-shell container and grid-based field layout
- restyle the printer edit page to reuse the new form-shell header, body, and action styling with a back link when not in a modal

## Testing
- `pip install -r requirements.txt` *(fails: proxy blocks package downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fb8b8cd4832bbc8c72810308ca66