### PR TITLE
Open license assignment in Bootstrap modal

### DIFF
--- a/routers/license.py
+++ b/routers/license.py
@@ -86,6 +86,8 @@ def _logla(db: Session, lic: License, islem: str, detay: str, islem_yapan: str):
     db.add(
         LicenseLog(license_id=lic.id, islem=islem, detay=detay, islem_yapan=islem_yapan)
     )
+
+
 @router.get("/new", response_class=HTMLResponse, name="license.new")
 def new_license_form(request: Request, db: Session = Depends(get_db)):
     envanterler = db.query(Inventory).order_by(Inventory.no).all()

--- a/routers/license.py
+++ b/routers/license.py
@@ -249,6 +249,7 @@ def edit_license_post(
 def assign_license_form(
     lic_id: int,
     request: Request,
+    modal: bool = False,
     db: Session = Depends(get_db),
     user=Depends(current_user),
 ):
@@ -270,6 +271,7 @@ def assign_license_form(
             "envanterler": envanterler,
             "users": users,
             "current_user": user,
+            "modal": modal,
         },
     )
 
@@ -281,6 +283,7 @@ def assign_license(
     bagli_envanter_no: str = Form(""),
     islem_yapan: str = Form("system"),
     request: Request = None,
+    modal: bool = False,
     db: Session = Depends(get_db),
 ):
     lic = db.get(License, lic_id)
@@ -298,6 +301,10 @@ def assign_license(
         islem_yapan,
     )
     db.commit()
+    if modal:
+        return HTMLResponse(
+            "<script>window.parent.postMessage('modal-close','*');</script>"
+        )
     return RedirectResponse(
         url=request.url_for("license_list"), status_code=status.HTTP_303_SEE_OTHER
     )

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -53,8 +53,9 @@
     };
     if (map[val]) {
       const url = `/${entity}/${id}/${map[val]}`;
-      if (val === "edit" && window.openModal) {
-        openModal(url + "?modal=1");
+      const label = sel.options[sel.selectedIndex]?.textContent?.trim() || "";
+      if (window.openModal && (val === "edit" || val === "assign")) {
+        openModal(url + "?modal=1", label);
       } else {
         go(url);
       }

--- a/templates/license_assign.html
+++ b/templates/license_assign.html
@@ -37,7 +37,13 @@ content %}
               {% for u in users %}
               <option
                 value="{{ u }}"
-                {% if license.sorumlu_personel == u %}selected{% endif %}
+                {%
+                if
+                license.sorumlu_personel=""
+                ="u"
+                %}selected{%
+                endif
+                %}
               >
                 {{ u }}
               </option>
@@ -51,7 +57,13 @@ content %}
               {% for inv in envanterler %}
               <option
                 value="{{ inv.no }}"
-                {% if license.bagli_envanter_no == inv.no %}selected{% endif %}
+                {%
+                if
+                license.bagli_envanter_no=""
+                ="inv.no"
+                %}selected{%
+                endif
+                %}
               >
                 {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
               </option>
@@ -63,7 +75,9 @@ content %}
       <div class="form-shell__actions">
         <button class="btn btn-primary" type="submit">Kaydet</button>
         {% if not modal %}
-        <a class="btn btn-outline-secondary" href="{{ url_for('license_list') }}"
+        <a
+          class="btn btn-outline-secondary"
+          href="{{ url_for('license_list') }}"
           >İptal</a
         >
         {% endif %}

--- a/templates/license_assign.html
+++ b/templates/license_assign.html
@@ -9,16 +9,18 @@ content %}
           Lisansı uygun personele ve envantere hızlıca yönlendirin.
         </p>
       </div>
+      {% if not modal %}
       <div class="form-shell__header-actions">
         <a class="btn btn-light" href="{{ url_for('license_list') }}">
           ← Listeye Dön
         </a>
       </div>
+      {% endif %}
     </div>
 
     <form
       method="post"
-      action="/lisans/{{ license.id }}/assign"
+      action="/lisans/{{ license.id }}/assign{{ '?modal=1' if modal else '' }}"
       class="form-shell__form"
     >
       <input
@@ -60,9 +62,11 @@ content %}
       </div>
       <div class="form-shell__actions">
         <button class="btn btn-primary" type="submit">Kaydet</button>
+        {% if not modal %}
         <a class="btn btn-outline-secondary" href="{{ url_for('license_list') }}"
           >İptal</a
         >
+        {% endif %}
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- use the global iframe modal when "Atama" or "Düzenle" is chosen from the actions dropdown
- extend the license assign view and template to support modal rendering and closing the parent on save

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4018655e0832b8fa5f2c859e7078b