### PR TITLE
Refine assignment modals and compact edit layout

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -843,6 +843,17 @@ tr[data-href] > td:first-child {
   min-width: 120px;
 }
 
+.form-shell--compact {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+  .form-shell--compact {
+    max-width: 100%;
+  }
+}
+
 .form-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/templates/base.html
+++ b/templates/base.html
@@ -119,14 +119,14 @@
 
     <!-- iframe modal -->
     <div class="modal fade" id="iframeModal" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-dialog modal-dialog-centered" id="iframeModalDialog">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="iframeModalTitle"></h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body p-0">
-            <iframe id="iframeModalFrame" style="width:100%;height:70vh;border:0;"></iframe>
+            <iframe id="iframeModalFrame" style="width:100%;border:0;"></iframe>
           </div>
         </div>
       </div>
@@ -192,11 +192,36 @@ document.addEventListener("DOMContentLoaded", () => {
 // Use this for interactive elements inside rows
 function stopRowClick(e) { e.stopPropagation(); }
 
-function openModal(url, title="") {
+function openModal(url, title = "", size = "lg", height = "70vh") {
   const frame = document.getElementById("iframeModalFrame");
+  if (!frame) return;
+  frame.style.height = height || "70vh";
   frame.src = url;
-  document.getElementById("iframeModalTitle").textContent = title;
-  const modal = new bootstrap.Modal(document.getElementById("iframeModal"));
+
+  const titleEl = document.getElementById("iframeModalTitle");
+  if (titleEl) titleEl.textContent = title;
+
+  const dialog = document.getElementById("iframeModalDialog");
+  if (dialog) {
+    dialog.classList.remove(
+      "modal-sm",
+      "modal-md",
+      "modal-lg",
+      "modal-xl",
+      "modal-fullscreen"
+    );
+    if (size === "fullscreen") {
+      dialog.classList.add("modal-fullscreen");
+    } else if (size) {
+      dialog.classList.add(`modal-${size}`);
+    } else {
+      dialog.classList.add("modal-lg");
+    }
+  }
+
+  const modalEl = document.getElementById("iframeModal");
+  if (!modalEl) return;
+  const modal = new bootstrap.Modal(modalEl);
   modal.show();
 }
 window.openModal = openModal;
@@ -205,7 +230,17 @@ document.addEventListener("click", (e) => {
   const link = e.target.closest("[data-modal-url]");
   if (!link) return;
   e.preventDefault();
-  openModal(link.dataset.modalUrl, link.dataset.modalTitle || "");
+  const size = link.dataset.modalSize || "lg";
+  const height = link.dataset.modalHeight || "70vh";
+  const title = link.dataset.modalTitle || "";
+  openModal(link.dataset.modalUrl, title, size, height);
+});
+
+document.getElementById("iframeModal")?.addEventListener("hidden.bs.modal", () => {
+  const frame = document.getElementById("iframeModalFrame");
+  if (frame) {
+    frame.src = "about:blank";
+  }
 });
 
 window.addEventListener("message", (e) => {

--- a/templates/inventory/detail.html
+++ b/templates/inventory/detail.html
@@ -6,6 +6,9 @@ block content %}
   <a
     href="#"
     data-modal-url="/inventory/{{ item_id }}/edit?modal=1"
+    data-modal-title="Envanter Düzenle"
+    data-modal-size="md"
+    data-modal-height="560px"
     class="btn btn-primary btn-sm"
     >Düzenle</a
   >

--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}{% block title %}Envanter Düzenle{% endblock %} {%
 block content %}
 <div class="container-fluid p-3">
-  <div class="form-shell">
+  <div class="form-shell form-shell--compact">
     <div class="form-shell__header">
       <div>
         <h2 class="form-shell__title">Envanter Düzenle</h2>

--- a/templates/license_assign.html
+++ b/templates/license_assign.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %} {% block title %}Lisans Atama{% endblock %} {% block
 content %}
 <div class="container-fluid p-3">
-  <div class="form-shell">
+  <div class="form-shell form-shell--compact">
     <div class="form-shell__header">
       <div>
         <h2 class="form-shell__title">Lisans Atama</h2>

--- a/templates/license_detail.html
+++ b/templates/license_detail.html
@@ -8,6 +8,9 @@ content %}
         href="#"
         class="btn btn-sm btn-primary"
         data-modal-url="/lisans/{{ item.id }}/edit?modal=1"
+        data-modal-title="Lisans Düzenle"
+        data-modal-size="md"
+        data-modal-height="560px"
         >Düzenle</a
       >
       <a href="/lisans" class="btn btn-sm btn-outline-secondary"

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %} {% block title %}Lisans {{ 'Düzenle' if license else
 'Ekle' }}{% endblock %} {% block content %}
 <div class="container-fluid p-3">
-  <div class="form-shell">
+  <div class="form-shell form-shell--compact">
     <div class="form-shell__header">
       <div>
         <h2 class="form-shell__title">

--- a/templates/printer_edit.html
+++ b/templates/printer_edit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %} {% block title %}Yazıcı Güncelle{% endblock %} {%
 block content %}
 <div class="container-fluid p-3">
-  <div class="form-shell">
+  <div class="form-shell form-shell--compact">
     <div class="form-shell__header">
       <div>
         <h2 class="form-shell__title">Yazıcı Güncelle</h2>

--- a/templates/printers_detail.html
+++ b/templates/printers_detail.html
@@ -8,6 +8,9 @@ content %}
         class="btn btn-sm btn-primary"
         href="#"
         data-modal-url="/printers/{{ p.id }}/edit?modal=1"
+        data-modal-title="Yazıcı Düzenle"
+        data-modal-size="md"
+        data-modal-height="520px"
         >Düzenle</a
       >
       <a class="btn btn-sm btn-outline-secondary" href="/printers">Geri</a>

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %} {% block title %}Yazıcı Düzenle{% endblock %} {% block
 content %}
 <div class="container-fluid p-3">
-  <div class="form-shell">
+  <div class="form-shell form-shell--compact">
     <div class="form-shell__header">
       <div>
         <h2 class="form-shell__title">Yazıcı Düzenle</h2>


### PR DESCRIPTION
## Summary
- add a compact form-shell helper to center smaller edit/assign forms
- allow iframe modal links to control dialog size and frame height, clearing the iframe when closed
- apply the compact layout to inventory, license, and printer edit/assign screens and tune printer detail links for a smaller edit modal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4e512de50832b9eb9d48eb14a2a04