### PR TITLE
Refactor modals to Bootstrap 5 base

### DIFF
--- a/static/css/modals.css
+++ b/static/css/modals.css
@@ -1,0 +1,8 @@
+.custom-modal{border-radius:16px; box-shadow:0 10px 30px rgba(0,0,0,.15);}
+.custom-modal .modal-header{border-bottom:1px solid rgba(0,0,0,.06)}
+.custom-modal .modal-footer{border-top:1px solid rgba(0,0,0,.06)}
+.form-grid{display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:16px}
+.form-grid .col-12{grid-column:1 / -1}
+@media (max-width: 768px){.form-grid{grid-template-columns:1fr}}
+.form-label{font-weight:600; font-size:.95rem; color:#374151; margin-bottom:.35rem}
+.form-text-muted{color:#6b7280; font-size:.8rem}

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link href="{{ url_for('static', path='css/custom.css') }}" rel="stylesheet">
+  <link href="{{ url_for('static', path='css/modals.css') }}" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" rel="stylesheet">
   <title>{% block title %}{% endblock %}</title>
 </head>

--- a/templates/components/assignment_fields.html
+++ b/templates/components/assignment_fields.html
@@ -1,31 +1,42 @@
 <input type="hidden" name="item_id" value="{{ current_id or '' }}">
-<div class="grid md:grid-cols-2 gap-4">
+<div class="form-grid">
   <div>
-    <label class="lbl">Fabrika</label>
-    <select name="fabrika" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for x in lookups.fabrika %}<option {{ 'selected' if item and item.fabrika==x }}>{{ x }}</option>{% endfor %}
+    <label class="form-label">Fabrika</label>
+    <select name="fabrika" class="form-select">
+      <option value="">Seçiniz...</option>
+      {% for x in lookups.fabrika %}
+      <option value="{{ x }}" {{ 'selected' if item and item.fabrika==x }}>{{ x }}</option>
+      {% endfor %}
     </select>
   </div>
   <div>
-    <label class="lbl">Departman</label>
-    <select name="departman" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for x in lookups.departman %}<option {{ 'selected' if item and item.departman==x }}>{{ x }}</option>{% endfor %}
+    <label class="form-label">Departman</label>
+    <select name="departman" class="form-select">
+      <option value="">Seçiniz...</option>
+      {% for x in lookups.departman %}
+      <option value="{{ x }}" {{ 'selected' if item and item.departman==x }}>{{ x }}</option>
+      {% endfor %}
+    </select>
+  </div>
+
+  <div>
+    <label class="form-label">Sorumlu Personel</label>
+    <select name="sorumlu_personel" class="form-select">
+      <option value="">Seçiniz</option>
+      {% for p in lookups.personel %}
+      <option value="{{ p }}" {{ 'selected' if item and item.sorumlu_personel==p }}>{{ p }}</option>
+      {% endfor %}
     </select>
   </div>
   <div>
-    <label class="lbl">Sorumlu Personel</label>
-    <select name="sorumlu_personel" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for x in lookups.personel %}<option {{ 'selected' if item and item.sorumlu_personel==x }}>{{ x }}</option>{% endfor %}
-    </select>
-  </div>
-  <div>
-    <label class="lbl">Bağlı Envanter No</label>
-    <select name="bagli_envanter_no" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for e in lookups.envanterler %}<option value="{{ e.envanter_no }}" {{ 'selected' if item and item.bagli_envanter_no==e.envanter_no }}>{{ e.envanter_no }} — {{ e.bilgisayar_adi }}</option>{% endfor %}
+    <label class="form-label">Bağlı Olduğu Envanter</label>
+    <select name="bagli_envanter_no" class="form-select">
+      <option value="">Seçiniz</option>
+      {% for e in lookups.envanterler %}
+      <option value="{{ e.envanter_no }}" {{ 'selected' if item and item.bagli_envanter_no==e.envanter_no }}>
+        {{ e.envanter_no }} — {{ e.bilgisayar_adi }}
+      </option>
+      {% endfor %}
     </select>
   </div>
 </div>

--- a/templates/components/fields_inventory.html
+++ b/templates/components/fields_inventory.html
@@ -1,93 +1,124 @@
-{% set marka_id = id ~ '_marka' %}
-{% set model_id = id ~ '_model' %}
-<div class="grid md:grid-cols-2 gap-4">
+{% set marka_id = id ~ '-marka' %}
+{% set model_id = id ~ '-model' %}
+<div class="form-grid">
   <div>
-    <label class="lbl">Envanter No</label>
-    <input name="envanter_no" class="inp" value="{{ item.no if item else '' }}" required placeholder="ENV-000123">
+    <label class="form-label">Envanter No</label>
+    <input
+      name="envanter_no"
+      class="form-control"
+      placeholder="ENV-000123"
+      value="{{ item.no if item else '' }}"
+    >
   </div>
   <div>
-    <label class="lbl">Bilgisayar Adı</label>
-    <input name="bilgisayar_adi" class="inp" value="{{ item.bilgisayar_adi if item else '' }}" required placeholder="PC-OFIS-01">
+    <label class="form-label">Bilgisayar Adı</label>
+    <input
+      name="bilgisayar_adi"
+      class="form-control"
+      placeholder="PC-OFIS-01"
+      value="{{ item.bilgisayar_adi if item else '' }}"
+    >
   </div>
 
   <div>
-    <label class="lbl">Fabrika</label>
-    <select name="fabrika" class="inp" required>
-      <option value="">Seçiniz…</option>
+    <label class="form-label">Fabrika</label>
+    <select name="fabrika" class="form-select">
+      <option value="">Seçiniz...</option>
       {% for x in lookups.fabrika %}
-        <option value="{{ x }}" {{ 'selected' if item and item.fabrika == x else '' }}>{{ x }}</option>
+      <option value="{{ x }}" {{ 'selected' if item and item.fabrika==x }}>{{ x }}</option>
       {% endfor %}
     </select>
   </div>
   <div>
-    <label class="lbl">Departman</label>
-    <select name="departman" class="inp" required>
-      <option value="">Seçiniz…</option>
+    <label class="form-label">Departman</label>
+    <select name="departman" class="form-select">
+      <option value="">Seçiniz...</option>
       {% for x in lookups.departman %}
-        <option value="{{ x }}" {{ 'selected' if item and item.departman == x else '' }}>{{ x }}</option>
+      <option value="{{ x }}" {{ 'selected' if item and item.departman==x }}>{{ x }}</option>
       {% endfor %}
     </select>
   </div>
 
   <div>
-    <label class="lbl">Donanım Tipi</label>
-    <select name="donanim_tipi" class="inp" required>
-      <option value="">Seçiniz…</option>
+    <label class="form-label">Donanım Tipi</label>
+    <select name="donanim_tipi" class="form-select">
+      <option value="">Seçiniz...</option>
       {% for x in lookups.donanim_tipi %}
-        <option value="{{ x }}" {{ 'selected' if item and item.donanim_tipi == x else '' }}>{{ x }}</option>
+      <option value="{{ x }}" {{ 'selected' if item and item.donanim_tipi==x }}>{{ x }}</option>
       {% endfor %}
     </select>
   </div>
   <div>
-    <label class="lbl">Sorumlu Personel</label>
-    <select name="sorumlu_personel" class="inp" required>
-      <option value="">Seçiniz…</option>
-      {% for x in lookups.personel %}
-        <option value="{{ x }}" {{ 'selected' if item and item.sorumlu_personel == x else '' }}>{{ x }}</option>
+    <label class="form-label">Sorumlu Personel</label>
+    <select name="sorumlu_personel" class="form-select">
+      <option value="">Seçiniz...</option>
+      {% for p in lookups.personel %}
+      <option value="{{ p }}" {{ 'selected' if item and item.sorumlu_personel==p }}>{{ p }}</option>
       {% endfor %}
     </select>
   </div>
 
   <div>
-    <label class="lbl">Marka</label>
-    <select name="marka" class="inp" id="{{ marka_id }}">
-      <option value="">Seçiniz…</option>
-      {% for x in lookups.marka %}
-        <option value="{{ x }}" {{ 'selected' if item and item.marka == x else '' }}>{{ x }}</option>
+    <label class="form-label">Marka</label>
+    <select class="form-select" id="{{ marka_id }}" name="marka">
+      <option value="">Seçiniz...</option>
+      {% for m in lookups.marka %}
+      <option value="{{ m }}" {{ 'selected' if item and item.marka==m }}>{{ m }}</option>
       {% endfor %}
     </select>
   </div>
   <div>
-    <label class="lbl">Model</label>
-    <select name="model" class="inp" id="{{ model_id }}" data-depends="#{{ marka_id }}" data-url="/api/lookup/model?marka=">
-      <option value="">{{ 'Önce marka seçiniz…' }}</option>
+    <label class="form-label">Model</label>
+    <select
+      class="form-select"
+      id="{{ model_id }}"
+      name="model"
+      data-depends="#{{ marka_id }}"
+      data-url="/api/lookup/model?marka="
+    >
+      <option value="">{{ 'Önce marka seçiniz...' }}</option>
       {% if item and item.model %}
-        <option selected>{{ item.model }}</option>
+      <option selected>{{ item.model }}</option>
       {% endif %}
     </select>
   </div>
 
   <div>
-    <label class="lbl">Seri No</label>
-    <input name="seri_no" class="inp" value="{{ item.seri_no if item else '' }}" placeholder="SN123456789">
+    <label class="form-label">Seri No</label>
+    <input
+      name="seri_no"
+      class="form-control"
+      placeholder="SN123456789"
+      value="{{ item.seri_no if item else '' }}"
+    >
   </div>
   <div>
-    <label class="lbl">IFS No (opsiyonel)</label>
-    <input name="ifs_no" class="inp" value="{{ item.ifs_no if item else '' }}" placeholder="IFS-…">
+    <label class="form-label">IFS No <span class="form-text-muted">(zorunlu değil)</span></label>
+    <input
+      name="ifs_no"
+      class="form-control"
+      placeholder="IFS-..."
+      value="{{ item.ifs_no if item else '' }}"
+    >
   </div>
 
-  <div class="md:col-span-2">
-    <label class="lbl">Bağlı Envanter No (opsiyonel)</label>
-    <select name="bagli_envanter_no" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for e in lookups.envanterler %}
-        <option value="{{ e.envanter_no }}" {{ 'selected' if item and item.bagli_envanter_no == e.envanter_no else '' }}>{{ e.envanter_no }} — {{ e.bilgisayar_adi }}</option>
-      {% endfor %}
-    </select>
+  <div>
+    <label class="form-label">Bağlı Makina No <span class="form-text-muted">(zorunlu değil)</span></label>
+    <input
+      name="bagli_envanter_no"
+      class="form-control"
+      placeholder="Makina No"
+      value="{{ item.bagli_envanter_no if item else '' }}"
+    >
   </div>
 
-  <div class="md:col-span-2">
-    <label class="lbl">Not</label>
-    <textarea name="notlar" class="inp" rows="3">{{ item.not_ if item else '' }}</textarea>
+  <div class="col-12">
+    <label class="form-label">Not <span class="form-text-muted">(zorunlu değil)</span></label>
+    <textarea
+      name="notlar"
+      rows="3"
+      class="form-control"
+      placeholder="Açıklama / notlar"
+    >{{ item.not_ if item else '' }}</textarea>
   </div>
 </div>

--- a/templates/components/fields_license.html
+++ b/templates/components/fields_license.html
@@ -1,42 +1,65 @@
-<div class="grid md:grid-cols-2 gap-4">
+<div class="form-grid">
   <div>
-    <label class="lbl">Lisans Adı</label>
-    <input name="lisans_adi" class="inp" value="{{ item.lisans_adi if item else '' }}" placeholder="Microsoft 365 Business">
+    <label class="form-label">Lisans Adı</label>
+    <input
+      name="lisans_adi"
+      class="form-control"
+      placeholder="Microsoft 365 Business"
+      value="{{ item.lisans_adi if item else '' }}"
+    >
   </div>
   <div>
-    <label class="lbl">Lisans Anahtarı / Hesap</label>
-    <input name="lisans_kimlik" class="inp" value="{{ item.lisans_anahtari if item else '' }}" placeholder="XXXXX-XXXXX-… / mail@firma.com">
-  </div>
-
-  <div>
-    <label class="lbl">Fabrika</label>
-    <select name="fabrika" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for x in lookups.fabrika %}<option {{ 'selected' if item and getattr(item, 'fabrika', None)==x }}>{{ x }}</option>{% endfor %}
-    </select>
-  </div>
-  <div>
-    <label class="lbl">Departman</label>
-    <select name="departman" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for x in lookups.departman %}<option {{ 'selected' if item and getattr(item, 'departman', None)==x }}>{{ x }}</option>{% endfor %}
-    </select>
+    <label class="form-label">Lisans Anahtarı / Hesap</label>
+    <input
+      name="lisans_kimlik"
+      class="form-control"
+      placeholder="XXXXX-XXXXX-… / mail@firma.com"
+      value="{{ item.lisans_anahtari if item else '' }}"
+    >
   </div>
 
   <div>
-    <label class="lbl">Bağlı Envanter No (opsiyonel)</label>
-    <select name="bagli_envanter_no" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for e in lookups.envanterler %}<option value="{{ e.envanter_no }}" {{ 'selected' if item and item.bagli_envanter_no==e.envanter_no }}>{{ e.envanter_no }} — {{ e.bilgisayar_adi }}</option>{% endfor %}
+    <label class="form-label">Fabrika</label>
+    <select name="fabrika" class="form-select">
+      <option value="">Seçiniz...</option>
+      {% for x in lookups.fabrika %}
+      <option value="{{ x }}" {{ 'selected' if item and getattr(item, 'fabrika', None)==x }}>{{ x }}</option>
+      {% endfor %}
     </select>
   </div>
   <div>
-    <label class="lbl">Son Kullanım (opsiyonel)</label>
-    <input type="date" name="bitis" class="inp" value="{{ item.bitis if item and getattr(item, 'bitis', None) else '' }}">
+    <label class="form-label">Departman</label>
+    <select name="departman" class="form-select">
+      <option value="">Seçiniz...</option>
+      {% for x in lookups.departman %}
+      <option value="{{ x }}" {{ 'selected' if item and getattr(item, 'departman', None)==x }}>{{ x }}</option>
+      {% endfor %}
+    </select>
   </div>
 
-  <div class="md:col-span-2">
-    <label class="lbl">Not</label>
-    <textarea name="not" class="inp" rows="3">{{ item.notlar if item else '' }}</textarea>
+  <div>
+    <label class="form-label">Bağlı Envanter No <span class="form-text-muted">(opsiyonel)</span></label>
+    <select name="bagli_envanter_no" class="form-select">
+      <option value="">Seçiniz...</option>
+      {% for e in lookups.envanterler %}
+      <option value="{{ e.envanter_no }}" {{ 'selected' if item and item.bagli_envanter_no==e.envanter_no }}>
+        {{ e.envanter_no }} — {{ e.bilgisayar_adi }}
+      </option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label class="form-label">Son Kullanım <span class="form-text-muted">(opsiyonel)</span></label>
+    <input
+      type="date"
+      name="bitis"
+      class="form-control"
+      value="{{ item.bitis if item and getattr(item, 'bitis', None) else '' }}"
+    >
+  </div>
+
+  <div class="col-12">
+    <label class="form-label">Not <span class="form-text-muted">(opsiyonel)</span></label>
+    <textarea name="not" class="form-control" rows="3">{{ item.notlar if item else '' }}</textarea>
   </div>
 </div>

--- a/templates/components/fields_printer.html
+++ b/templates/components/fields_printer.html
@@ -1,55 +1,69 @@
-{% set marka_id = id ~ '_marka' %}
-{% set model_id = id ~ '_model' %}
-<div class="grid md:grid-cols-2 gap-4">
+{% set marka_id = id ~ '-marka' %}
+{% set model_id = id ~ '-model' %}
+<div class="form-grid">
   <div>
-    <label class="lbl">Fabrika</label>
-    <select name="fabrika" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for x in lookups.fabrika %}<option {{ 'selected' if item and item.fabrika==x }}>{{ x }}</option>{% endfor %}
+    <label class="form-label">Fabrika</label>
+    <select name="fabrika" class="form-select">
+      <option value="">Seçiniz...</option>
+      {% for x in lookups.fabrika %}
+      <option value="{{ x }}" {{ 'selected' if item and item.fabrika==x }}>{{ x }}</option>
+      {% endfor %}
     </select>
   </div>
   <div>
-    <label class="lbl">Departman</label>
-    <select name="departman" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for x in lookups.departman %}<option {{ 'selected' if item and item.kullanim_alani==x }}>{{ x }}</option>{% endfor %}
+    <label class="form-label">Departman</label>
+    <select name="departman" class="form-select">
+      <option value="">Seçiniz...</option>
+      {% for x in lookups.departman %}
+      <option value="{{ x }}" {{ 'selected' if item and item.kullanim_alani==x }}>{{ x }}</option>
+      {% endfor %}
     </select>
   </div>
 
   <div>
-    <label class="lbl">Marka</label>
-    <select name="marka" class="inp" id="{{ marka_id }}">
-      <option value="">Seçiniz…</option>
-      {% for m in lookups.yazici_marka %}<option {{ 'selected' if item and item.marka==m }}>{{ m }}</option>{% endfor %}
+    <label class="form-label">Marka</label>
+    <select name="marka" class="form-select" id="{{ marka_id }}">
+      <option value="">Seçiniz...</option>
+      {% for m in lookups.yazici_marka %}
+      <option value="{{ m }}" {{ 'selected' if item and item.marka==m }}>{{ m }}</option>
+      {% endfor %}
     </select>
   </div>
   <div>
-    <label class="lbl">Model</label>
-    <select name="model" class="inp" id="{{ model_id }}" data-depends="#{{ marka_id }}" data-url="/api/lookup/printer-model?marka=">
-      <option value="">{{ 'Önce marka seçiniz…' }}</option>
+    <label class="form-label">Model</label>
+    <select
+      name="model"
+      class="form-select"
+      id="{{ model_id }}"
+      data-depends="#{{ marka_id }}"
+      data-url="/api/lookup/printer-model?marka="
+    >
+      <option value="">{{ 'Önce marka seçiniz...' }}</option>
       {% if item and item.model %}<option selected>{{ item.model }}</option>{% endif %}
     </select>
   </div>
 
   <div>
-    <label class="lbl">IP Adresi</label>
-    <input name="ip" value="{{ item.ip_adresi if item else '' }}" class="inp" placeholder="10.0.0.50">
+    <label class="form-label">IP Adresi</label>
+    <input name="ip" value="{{ item.ip_adresi if item else '' }}" class="form-control" placeholder="10.0.0.50">
   </div>
   <div>
-    <label class="lbl">MAC</label>
-    <input name="mac" value="{{ item.mac if item else '' }}" class="inp" placeholder="CC:DB:A7:…">
+    <label class="form-label">MAC</label>
+    <input name="mac" value="{{ item.mac if item else '' }}" class="form-control" placeholder="CC:DB:A7:…">
   </div>
 
-  <div class="md:col-span-2">
-    <label class="lbl">Bağlı Envanter No (opsiyonel)</label>
-    <select name="bagli_envanter_no" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for e in lookups.envanterler %}<option value="{{ e.envanter_no }}" {{ 'selected' if item and item.bagli_envanter_no==e.envanter_no }}>{{ e.envanter_no }} — {{ e.bilgisayar_adi }}</option>{% endfor %}
+  <div class="col-12">
+    <label class="form-label">Bağlı Envanter No <span class="form-text-muted">(opsiyonel)</span></label>
+    <select name="bagli_envanter_no" class="form-select">
+      <option value="">Seçiniz...</option>
+      {% for e in lookups.envanterler %}
+      <option value="{{ e.envanter_no }}" {{ 'selected' if item and item.bagli_envanter_no==e.envanter_no }}>{{ e.envanter_no }} — {{ e.bilgisayar_adi }}</option>
+      {% endfor %}
     </select>
   </div>
 
-  <div class="md:col-span-2">
-    <label class="lbl">Not</label>
-    <textarea name="not" class="inp" rows="3">{{ item.notlar if item else '' }}</textarea>
+  <div class="col-12">
+    <label class="form-label">Not <span class="form-text-muted">(opsiyonel)</span></label>
+    <textarea name="not" class="form-control" rows="3">{{ item.notlar if item else '' }}</textarea>
   </div>
 </div>

--- a/templates/components/fields_stock.html
+++ b/templates/components/fields_stock.html
@@ -1,48 +1,58 @@
-{% set marka_id = id ~ '_marka' %}
-{% set model_id = id ~ '_model' %}
-<div class="grid md:grid-cols-2 gap-4">
+{% set marka_id = id ~ '-marka' %}
+{% set model_id = id ~ '-model' %}
+<div class="form-grid">
   <div>
-    <label class="lbl">Donanım Tipi</label>
-    <select name="donanim_tipi" class="inp">
-      <option value="">Seçiniz…</option>
-      {% for x in lookups.donanim_tipi %}<option {{ 'selected' if item and item.donanim_tipi==x }}>{{ x }}</option>{% endfor %}
+    <label class="form-label">Donanım Tipi</label>
+    <select name="donanim_tipi" class="form-select">
+      <option value="">Seçiniz...</option>
+      {% for x in lookups.donanim_tipi %}
+      <option value="{{ x }}" {{ 'selected' if item and item.donanim_tipi==x }}>{{ x }}</option>
+      {% endfor %}
     </select>
   </div>
   <div>
-    <label class="lbl">Marka (opsiyonel)</label>
-    <select name="marka" class="inp" id="{{ marka_id }}">
-      <option value="">Seçiniz…</option>
-      {% for m in lookups.marka %}<option {{ 'selected' if item and item.marka==m }}>{{ m }}</option>{% endfor %}
-    </select>
-  </div>
-
-  <div>
-    <label class="lbl">Model (opsiyonel)</label>
-    <select name="model" class="inp" id="{{ model_id }}" data-depends="#{{ marka_id }}" data-url="/api/lookup/model?marka=">
-      <option value="">Seçiniz…</option>
-      {% if item and item.model %}<option selected>{{ item.model }}</option>{% endif %}
-    </select>
-  </div>
-  <div>
-    <label class="lbl">Miktar</label>
-    <input name="miktar" type="number" min="1" class="inp" value="{{ item.miktar if item else 1 }}" placeholder="1">
-  </div>
-
-  <div>
-    <label class="lbl">IFS No (opsiyonel)</label>
-    <input name="ifs_no" class="inp" value="{{ item.ifs_no if item else '' }}" placeholder="IFS-…">
-  </div>
-  <div>
-    <label class="lbl">Durum / İşlem</label>
-    <select name="islem" class="inp">
-      {% for x in ['Stokta','Rezerve','Atandı','Hurda'] %}
-        <option {{ 'selected' if item and getattr(item, 'islem', None)==x }}>{{ x }}</option>
+    <label class="form-label">Marka <span class="form-text-muted">(opsiyonel)</span></label>
+    <select name="marka" class="form-select" id="{{ marka_id }}">
+      <option value="">Seçiniz...</option>
+      {% for m in lookups.marka %}
+      <option value="{{ m }}" {{ 'selected' if item and item.marka==m }}>{{ m }}</option>
       {% endfor %}
     </select>
   </div>
 
-  <div class="md:col-span-2">
-    <label class="lbl">Not</label>
-    <textarea name="not" rows="3" class="inp">{{ item.aciklama if item else '' }}</textarea>
+  <div>
+    <label class="form-label">Model <span class="form-text-muted">(opsiyonel)</span></label>
+    <select
+      name="model"
+      class="form-select"
+      id="{{ model_id }}"
+      data-depends="#{{ marka_id }}"
+      data-url="/api/lookup/model?marka="
+    >
+      <option value="">Seçiniz...</option>
+      {% if item and item.model %}<option selected>{{ item.model }}</option>{% endif %}
+    </select>
+  </div>
+  <div>
+    <label class="form-label">Miktar</label>
+    <input name="miktar" type="number" min="1" class="form-control" value="{{ item.miktar if item else 1 }}" placeholder="1">
+  </div>
+
+  <div>
+    <label class="form-label">IFS No <span class="form-text-muted">(opsiyonel)</span></label>
+    <input name="ifs_no" class="form-control" value="{{ item.ifs_no if item else '' }}" placeholder="IFS-...">
+  </div>
+  <div>
+    <label class="form-label">Durum / İşlem</label>
+    <select name="islem" class="form-select">
+      {% for x in ['Stokta','Rezerve','Atandı','Hurda'] %}
+      <option value="{{ x }}" {{ 'selected' if item and getattr(item, 'islem', None)==x }}>{{ x }}</option>
+      {% endfor %}
+    </select>
+  </div>
+
+  <div class="col-12">
+    <label class="form-label">Not</label>
+    <textarea name="not" rows="3" class="form-control">{{ item.aciklama if item else '' }}</textarea>
   </div>
 </div>

--- a/templates/components/modal_base.html
+++ b/templates/components/modal_base.html
@@ -1,36 +1,30 @@
 {% macro body() %}
-<div class="modal-shell" id="{{ id }}" data-modal hidden>
-  <div class="modal-backdrop" data-close></div>
-  <div
-    class="modal-dialog"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="{{ id }}Title"
-  >
-    <form
-      method="{{ method or 'post' }}"
-      action="{{ action }}"
-      class="modal-card"
-      novalidate
-    >
-      <header class="modal-header">
-        <h3 id="{{ id }}Title" class="modal-title">{{ title }}</h3>
-        <button type="button" class="modal-close" data-close aria-label="Kapat">
-          &times;
-        </button>
-      </header>
-      <div class="modal-body">{{ caller() }}</div>
-      <footer class="modal-footer">
-        {% if secondary_label is not defined or secondary_label %}
-        <button type="button" class="btn-secondary" data-close>
-          {{ secondary_label or 'Vazgeç' }}
-        </button>
-        {% endif %}
-        <button type="submit" class="btn-primary">
-          {{ submit_label or 'Kaydet' }}
-        </button>
-      </footer>
-    </form>
+{# Bootstrap 5 tabanlı ortak modal #}
+<div class="modal fade" id="{{ id }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content custom-modal">
+      <div class="modal-header">
+        <h5 class="modal-title">{{ title }}</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+
+      <form action="{{ action or '' }}" method="{{ method or 'post' }}" id="{{ id }}-form">
+        <div class="modal-body">
+          {{ caller() }}
+        </div>
+
+        <div class="modal-footer">
+          {% if secondary_label is not defined or secondary_label %}
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+            {{ secondary_label or 'İptal' }}
+          </button>
+          {% endif %}
+          <button type="submit" class="btn btn-primary">
+            {{ submit_label or 'Kaydet' }}
+          </button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 {% endmacro %}

--- a/templates/inventory/index.html
+++ b/templates/inventory/index.html
@@ -9,9 +9,9 @@ content %}
       <p class="text-muted small mb-0">Aktif cihaz kayıtlarının listesi</p>
     </div>
     <div class="d-flex gap-2 flex-wrap">
-      <button class="btn-primary" data-open="invAdd">+ Ekle</button>
-      <button class="btn-secondary" data-open="invEdit">Düzenle</button>
-      <button class="btn-secondary" data-open="invAssign">Atama</button>
+      <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#invAdd">+ Ekle</button>
+      <button class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#invEdit">Düzenle</button>
+      <button class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#invAssign">Atama</button>
     </div>
   </div>
 

--- a/templates/licenses/index.html
+++ b/templates/licenses/index.html
@@ -9,8 +9,8 @@ content %}
       <p class="text-muted small mb-0">Aktif lisans kayıtları</p>
     </div>
     <div class="d-flex gap-2 flex-wrap">
-      <button class="btn-primary" data-open="licAdd">+ Ekle</button>
-      <button class="btn-secondary" data-open="licEdit">Düzenle</button>
+      <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#licAdd">+ Ekle</button>
+      <button class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#licEdit">Düzenle</button>
     </div>
   </div>
 

--- a/templates/printers/index.html
+++ b/templates/printers/index.html
@@ -9,8 +9,8 @@ content %}
       <p class="text-muted small mb-0">Yazıcı envanterine ait kayıtlar</p>
     </div>
     <div class="d-flex gap-2 flex-wrap">
-      <button class="btn-primary" data-open="printerAdd">+ Ekle</button>
-      <button class="btn-secondary" data-open="printerEdit">Düzenle</button>
+      <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#printerAdd">+ Ekle</button>
+      <button class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#printerEdit">Düzenle</button>
     </div>
   </div>
 

--- a/templates/stock/index.html
+++ b/templates/stock/index.html
@@ -9,8 +9,8 @@
       <p class="text-muted small mb-0">Donanım hareketleri</p>
     </div>
     <div class="d-flex gap-2 flex-wrap">
-      <button class="btn-primary" data-open="stockAdd">+ Ekle</button>
-      <button class="btn-secondary" data-open="stockEdit">Düzenle</button>
+      <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#stockAdd">+ Ekle</button>
+      <button class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#stockEdit">Düzenle</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- replace the shared modal partial with Bootstrap 5 markup and add a dedicated stylesheet
- restyle the inventory, printer, license, stock and assignment field components to use the new grid layout
- update module index pages to trigger the Bootstrap modals directly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4fcbef564832b92950788a3dd9ec3