### PR TITLE
Fix inventory template modal macros and restore factory lookup

### DIFF
--- a/routers/printers.py
+++ b/routers/printers.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from database import get_db
 from models import (
     Brand,
+    Factory,
     Inventory,
     Model,
     Printer,

--- a/templates/inventory/index.html
+++ b/templates/inventory/index.html
@@ -1,5 +1,7 @@
-{% extends "base.html" %} {% block title %}Envanter{% endblock %} {% block
-content %}
+{% extends "base.html" %}
+{% import "components/modal_base.html" as modal %}
+{% block title %}Envanter{% endblock %}
+{% block content %}
 <div class="container-fluid px-0">
   <div
     class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4"
@@ -54,15 +56,21 @@ content %}
   </div>
 </div>
 
-{% set id = "invAdd" %} {% set title = "Envanter Ekle" %} {% set action =
-"/inventory/create" %} {% set item = None %} {% include
-"components/modal_base.html" with context %} {% call(body) %}{% include
-"components/fields_inventory.html" %}{% endcall %} {% set id = "invEdit" %} {%
-set title = "Envanter Düzenle" %} {% set action = "/inventory/" ~ (current_id or
-'') ~ "/edit" %} {% set item = current_item %} {% include
-"components/modal_base.html" with context %} {% call(body) %}{% include
-"components/fields_inventory.html" %}{% endcall %} {% set id = "invAssign" %} {%
-set title = "Envanter Atama" %} {% set action = "/inventory/assign" %} {% set
-item = current_item %} {% include "components/modal_base.html" with context %}
-{% call(body) %}{% include "components/assignment_fields.html" %}{% endcall %}
+{% set id = "invAdd" %}
+{% set title = "Envanter Ekle" %}
+{% set action = "/inventory/create" %}
+{% set item = None %}
+{% call modal.body() %}{% include "components/fields_inventory.html" %}{% endcall %}
+
+{% set id = "invEdit" %}
+{% set title = "Envanter Düzenle" %}
+{% set action = "/inventory/" ~ (current_id or '' ) ~ "/edit" %}
+{% set item = current_item %}
+{% call modal.body() %}{% include "components/fields_inventory.html" %}{% endcall %}
+
+{% set id = "invAssign" %}
+{% set title = "Envanter Atama" %}
+{% set action = "/inventory/assign" %}
+{% set item = current_item %}
+{% call modal.body() %}{% include "components/assignment_fields.html" %}{% endcall %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- import the modal macro template to properly call it for inventory create/edit/assign modals
- add the missing Factory model import in the printers router so lookup queries work again

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4ff8704ac832b932ffa7b95728b8b