### PR TITLE
Adjust printer edit modal sizing

### DIFF
--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -54,7 +54,10 @@
     if (map[val]) {
       const url = `/${entity}/${id}/${map[val]}`;
       if (val === "edit" && window.openModal) {
-        openModal(url + "?modal=1");
+        const selectedOption = sel.options[sel.selectedIndex];
+        const title = (sel.dataset.editModalTitle || selectedOption?.text || "").trim();
+        const size = sel.dataset.editModalSize || "lg";
+        openModal(`${url}?modal=1`, title, { size });
       } else {
         go(url);
       }

--- a/templates/partials/_actions_menu.html
+++ b/templates/partials/_actions_menu.html
@@ -11,6 +11,8 @@ filtered_actions = namespace(values=[]) %} {% for value, label in actions %} {%
 if value not in ['assign', 'edit', 'stock', 'fault'] %} {% set
 filtered_actions.values = filtered_actions.values + [(value, label)] %} {% endif
 %} {% endfor %} {% set actions = filtered_actions.values %} {% endif %}
+{% set edit_modal_size = edit_modal_size|default('lg') %}
+{% set edit_modal_title = edit_modal_title|default('') %}
 
 <div class="d-flex align-items-center">
   <button
@@ -30,6 +32,8 @@ filtered_actions.values = filtered_actions.values + [(value, label)] %} {% endif
     data-device="{{ fault_device or '' }}"
     data-title="{{ fault_title or '' }}"
     data-entity-key="{{ fault_entity_key or '' }}"
+    data-edit-modal-size="{{ edit_modal_size }}"
+    data-edit-modal-title="{{ edit_modal_title }}"
   >
     <option value="">Seçiniz...</option>
     {% for value, label in actions %}

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -118,7 +118,7 @@ content %}
             #' ~ p.id) %} {% set fault_title = (p.marka ~ ' ' ~ p.model)|trim %}
             {% set fault_entity_key = p.envanter_no or p.id %} {% set
             fault_status = p.durum %} {% include 'partials/_actions_menu.html'
-            %}
+            with edit_modal_size='md' %}
           </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- allow action menu selects to pass custom modal metadata
- open printer edit form in a medium-sized modal instead of navigating away

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5271ff51c832b90ed49f0bdc1a961