### PR TITLE
Unify tracking pages with shared layout components

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -155,6 +155,97 @@ small,
     transform var(--transition-base);
 }
 
+/* -------------------------------------------------------------------------- */
+/* Page shell                                                                 */
+/* -------------------------------------------------------------------------- */
+.page-shell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+@media (min-width: 768px) {
+  .page-header {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+}
+
+.page-header__heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.page-header__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 1.2rem + 0.6vw, 1.8rem);
+  font-weight: 600;
+}
+
+.page-header__subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: var(--font-size-sm);
+  max-width: 640px;
+}
+
+.page-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: stretch;
+}
+
+@media (min-width: 992px) {
+  .page-header__actions {
+    justify-content: flex-end;
+  }
+}
+
+.page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.page-actions__group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.page-actions__group--grow {
+  flex: 1 1 220px;
+  min-width: 200px;
+}
+
+.page-actions__group--grow .form-control,
+.page-actions__group--grow .form-select {
+  width: 100%;
+  min-width: 0;
+}
+
+.page-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  padding: clamp(1rem, 0.75rem + 1vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
 @media (hover: hover) {
   .soft-card:hover {
     box-shadow: var(--shadow-md);
@@ -732,6 +823,20 @@ tr[data-href] > td:first-child {
 .form-check-input.is-invalid {
   border-color: var(--color-danger);
   box-shadow: 0 0 0 3px var(--color-danger-soft);
+}
+
+.form-grid {
+  display: grid;
+  gap: var(--space-md);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.form-grid__full {
+  grid-column: 1 / -1;
 }
 
 .form-text-error {

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -1,23 +1,32 @@
-{% macro modal(id, title, dialog_class="", form_attrs=None, footer=None, content_class="") -%}
+{% macro modal(id, title, dialog_class="", form_attrs=None, footer=None, content_class="", subtitle=None) -%}
 <div class="modal fade" id="{{ id }}" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog {{ dialog_class }}">
     {%- if form_attrs is not none %}
-    <form {{ form_attrs|xmlattr }} class="modal-content{% if content_class %} {{ content_class }}{% endif %}">
+    <form {{ form_attrs|xmlattr }} class="modal-content border-0 bg-transparent p-0">
     {%- else %}
-    <div class="modal-content{% if content_class %} {{ content_class }}{% endif %}">
+    <div class="modal-content border-0 bg-transparent p-0">
     {%- endif %}
-      <div class="modal-header">
-        <h5 class="modal-title">{{ title }}</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">{{ title }}</h5>
+            {%- if subtitle %}
+            <p class="modal-shell__subtitle">{{ subtitle }}</p>
+            {%- endif %}
+          </div>
+          <div class="modal-shell__header-actions">
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+          </div>
+        </div>
+        <div class="modal-shell__body{% if content_class %} {{ content_class }}{% endif %}">
+          {{ caller() }}
+        </div>
+        {%- if footer %}
+        <div class="modal-shell__footer">
+          {{ footer }}
+        </div>
+        {%- endif %}
       </div>
-      <div class="modal-body">
-        {{ caller() }}
-      </div>
-      {%- if footer %}
-      <div class="modal-footer">
-        {{ footer }}
-      </div>
-      {%- endif %}
     {%- if form_attrs is not none %}
     </form>
     {%- else %}

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -1,116 +1,132 @@
 {% extends "base.html" %} {% block title %}Lisans Takip{% endblock %} {% block
 content %}
-<div id="licenses-list" class="container-fluid p-2 content">
-  <div class="d-flex align-items-center justify-content-between mb-3">
-    <h5 class="mb-0">Lisans</h5>
-    <div class="d-flex align-items-center gap-2 flex-wrap">
-      <a
-        href="#"
-        class="btn btn-success btn-sm d-flex align-items-center gap-1"
-        title="Yeni Ekle"
-        data-bs-toggle="modal"
-        data-bs-target="#addModal"
-      >
-        <i class="bi bi-plus-lg"></i>
-        <span>Ekle</span>
-      </a>
-      <div class="dropdown">
-        <button
-          class="btn btn-outline-primary btn-sm dropdown-toggle"
-          type="button"
-          data-bs-toggle="dropdown"
-          aria-expanded="false"
-        >
-          Excel
-        </button>
-        <ul class="dropdown-menu dropdown-menu-end">
-          <li><a class="dropdown-item" href="/lisans/export">Dışa Aktar</a></li>
-          <li>
-            <form
-              action="/lisans/import"
-              method="post"
-              enctype="multipart/form-data"
-            >
-              <input
-                type="file"
-                name="file"
-                id="licExcel"
-                class="d-none"
-                onchange="this.form.submit()"
-              />
-              <label for="licExcel" class="dropdown-item mb-0">İçe Aktar</label>
-            </form>
-          </li>
-        </ul>
+<div id="licenses-list" class="container-fluid py-4">
+  <div class="page-shell">
+    <header class="page-header">
+      <div class="page-header__heading">
+        <span class="eyebrow text-primary">Lisans Takip</span>
+        <h1 class="page-header__title">Lisanslar</h1>
+        <p class="page-header__subtitle">
+          Envanterinizdeki yazılım lisanslarını görüntüleyin, aktarın ve yönetin.
+        </p>
       </div>
-      <button class="btn btn-outline-secondary btn-sm" id="filterBtn">
-        Filtre
-      </button>
-      <button
-        class="btn btn-outline-secondary btn-sm d-none"
-        id="clearFilterBtn"
-      >
-        Temizle
-      </button>
-      <input
-        type="text"
-        id="searchInput"
-        class="form-control form-control-sm"
-        placeholder="Ara..."
-      />
-    </div>
-  </div>
-  <div class="table-responsive">
-    <table
-      id="licensesTable"
-      class="table table-hover align-middle table-rounded"
-    >
-      <thead>
-        <tr>
-          <th data-field="no">No</th>
-          <th data-field="lisans_adi">Lisans Adı</th>
-          <th data-field="lisans_anahtari">Key</th>
-          <th data-field="sorumlu_personel">Sorumlu</th>
-          <th data-field="bagli_envanter_no">Bağlı Envanter</th>
-          <th data-field="mail_adresi">E-posta</th>
-          <th data-field="durum">Durum</th>
-          <th class="actions text-start">İşlemler</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in items %}
-        <tr
-          data-id="{{ row.id }}"
-          data-personel="{{ row.sorumlu_personel or '' }}"
-          data-bagli="{{ row.bagli_envanter_no or '' }}"
-          data-durum="{{ row.durum or '' }}"
+      <div class="page-header__actions page-actions">
+        <div class="page-actions__group">
+          <a
+            href="#"
+            class="btn btn-success btn-sm d-flex align-items-center gap-1"
+            title="Yeni Ekle"
+            data-bs-toggle="modal"
+            data-bs-target="#addModal"
+          >
+            <i class="bi bi-plus-lg"></i>
+            <span>Ekle</span>
+          </a>
+          <div class="dropdown">
+            <button
+              class="btn btn-outline-primary btn-sm dropdown-toggle"
+              type="button"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+            >
+              Excel
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              <li><a class="dropdown-item" href="/lisans/export">Dışa Aktar</a></li>
+              <li>
+                <form
+                  action="/lisans/import"
+                  method="post"
+                  enctype="multipart/form-data"
+                >
+                  <input
+                    type="file"
+                    name="file"
+                    id="licExcel"
+                    class="d-none"
+                    onchange="this.form.submit()"
+                  />
+                  <label for="licExcel" class="dropdown-item mb-0">İçe Aktar</label>
+                </form>
+              </li>
+            </ul>
+          </div>
+          <button class="btn btn-outline-secondary btn-sm" id="filterBtn">
+            Filtre
+          </button>
+          <button
+            class="btn btn-outline-secondary btn-sm d-none"
+            id="clearFilterBtn"
+          >
+            Temizle
+          </button>
+        </div>
+        <div class="page-actions__group page-actions__group--grow">
+          <label for="searchInput" class="visually-hidden">Ara</label>
+          <input
+            type="text"
+            id="searchInput"
+            class="form-control form-control-sm"
+            placeholder="Ara..."
+          />
+        </div>
+      </div>
+    </header>
+
+    <div class="page-card soft-card">
+      <div class="table-responsive">
+        <table
+          id="licensesTable"
+          class="table table-hover align-middle table-rounded"
         >
-          <td>{{ row.id }}</td>
-          <td>{{ row.lisans_adi }}</td>
-          <td class="text-truncate" style="max-width: 180px">
-            {{ row.lisans_key }}
-          </td>
-          <td>{{ row.sorumlu_personel or '-' }}</td>
-          <td>{{ row.bagli_envanter_no or '-' }}</td>
-          <td>{{ row.mail_adresi or '-' }}</td>
-          <td>
-            {% if row.durum == 'hurda' %}
-            <span class="badge bg-secondary">Hurda</span>
-            {% elif row.durum == 'arızalı' %}
-            <span class="badge text-bg-warning text-dark">Arızalı</span>
-            {% else %}
-            <span class="badge bg-success">Aktif</span>
-            {% endif %}
-          </td>
-          <td class="actions">
-            {% set entity = 'lisans' %} {% set row_id = row.id %} {% set
-            fault_status = row.durum %} {% include 'partials/_actions_menu.html'
-            %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+          <thead>
+            <tr>
+              <th data-field="no">No</th>
+              <th data-field="lisans_adi">Lisans Adı</th>
+              <th data-field="lisans_anahtari">Key</th>
+              <th data-field="sorumlu_personel">Sorumlu</th>
+              <th data-field="bagli_envanter_no">Bağlı Envanter</th>
+              <th data-field="mail_adresi">E-posta</th>
+              <th data-field="durum">Durum</th>
+              <th class="actions text-start">İşlemler</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in items %}
+            <tr
+              data-id="{{ row.id }}"
+              data-personel="{{ row.sorumlu_personel or '' }}"
+              data-bagli="{{ row.bagli_envanter_no or '' }}"
+              data-durum="{{ row.durum or '' }}"
+            >
+              <td>{{ row.id }}</td>
+              <td>{{ row.lisans_adi }}</td>
+              <td class="text-truncate" style="max-width: 180px">
+                {{ row.lisans_key }}
+              </td>
+              <td>{{ row.sorumlu_personel or '-' }}</td>
+              <td>{{ row.bagli_envanter_no or '-' }}</td>
+              <td>{{ row.mail_adresi or '-' }}</td>
+              <td>
+                {% if row.durum == 'hurda' %}
+                <span class="badge bg-secondary">Hurda</span>
+                {% elif row.durum == 'arızalı' %}
+                <span class="badge text-bg-warning text-dark">Arızalı</span>
+                {% else %}
+                <span class="badge bg-success">Aktif</span>
+                {% endif %}
+              </td>
+              <td class="actions">
+                {% set entity = 'lisans' %} {% set row_id = row.id %} {% set
+                fault_status = row.durum %} {% include
+                'partials/_actions_menu.html' %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -120,26 +136,35 @@ content %}
 
 <!-- Yeni Ekle Modal -->
 <div class="modal fade" id="addModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Lisans Ekle</h5>
-        <button
-          type="button"
-          class="btn-close"
-          data-bs-dismiss="modal"
-        ></button>
-      </div>
-      <div class="modal-body">
-        <form
-          method="post"
-          action="/lisans/create"
-          class="needs-validation"
-          novalidate
-        >
-          <div class="row g-3">
-            <div class="col-md-6">
-              <label class="form-label">Lisans Adı</label>
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+    <form
+      method="post"
+      action="/lisans/create"
+      class="modal-content border-0 bg-transparent p-0 needs-validation"
+      novalidate
+    >
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Lisans Ekle</h5>
+            <p class="modal-shell__subtitle">
+              Yeni bir lisans kaydı oluşturarak stokunuzu güncel tutun.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
+          </div>
+        </div>
+
+        <div class="modal-shell__body">
+          <div class="modal-form-grid">
+            <div class="form-group">
+              <label class="form-label" for="selLisansAdi">Lisans Adı</label>
               <select
                 id="selLisansAdi"
                 name="lisans_adi"
@@ -152,9 +177,10 @@ content %}
                 {% endfor %}
               </select>
             </div>
-            <div class="col-md-6">
-              <label class="form-label">Lisans Anahtarı</label>
+            <div class="form-group">
+              <label class="form-label" for="lisansAnahtari">Lisans Anahtarı</label>
               <input
+                id="lisansAnahtari"
                 name="lisans_anahtari"
                 type="text"
                 class="form-control"
@@ -163,8 +189,8 @@ content %}
               />
             </div>
 
-            <div class="col-md-6">
-              <label class="form-label">Sorumlu Personel</label>
+            <div class="form-group">
+              <label class="form-label" for="selPersonelAdd">Sorumlu Personel</label>
               <select
                 id="selPersonelAdd"
                 name="sorumlu_personel"
@@ -177,9 +203,14 @@ content %}
               </select>
             </div>
 
-            <div class="col-md-6">
-              <label class="form-label">Bağlı Olduğu Envanter No</label>
-              <select name="bagli_envanter_no" class="form-select" required>
+            <div class="form-group">
+              <label class="form-label" for="bagliEnvanter">Bağlı Olduğu Envanter No</label>
+              <select
+                id="bagliEnvanter"
+                name="bagli_envanter_no"
+                class="form-select"
+                required
+              >
                 <option value="">Seçiniz...</option>
                 {% for inv in envanterler %}
                 <option value="{{ inv.no }}">{{ inv.no }}</option>
@@ -187,11 +218,12 @@ content %}
               </select>
             </div>
 
-            <div class="col-md-6">
-              <label class="form-label"
-                >IFS No <small class="text-muted">(zorunlu değil)</small></label
-              >
+            <div class="form-group">
+              <label class="form-label" for="ifsNo">
+                IFS No <small class="text-muted">(opsiyonel)</small>
+              </label>
               <input
+                id="ifsNo"
                 name="ifs_no"
                 type="text"
                 class="form-control"
@@ -199,9 +231,10 @@ content %}
               />
             </div>
 
-            <div class="col-md-6">
-              <label class="form-label">E-posta (opsiyonel)</label>
+            <div class="form-group">
+              <label class="form-label" for="lisansEmail">E-posta (opsiyonel)</label>
               <input
+                id="lisansEmail"
                 name="mail_adresi"
                 type="email"
                 class="form-control"
@@ -209,47 +242,63 @@ content %}
               />
             </div>
           </div>
+        </div>
 
-          <div class="mt-3 d-flex gap-2">
-            <button type="submit" class="btn btn-primary">Kaydet</button>
+        <div class="modal-shell__footer">
+          <div class="modal-shell__actions">
             <button
               type="button"
-              class="btn btn-secondary"
+              class="btn btn-outline-secondary"
               data-bs-dismiss="modal"
             >
               İptal
             </button>
+            <button type="submit" class="btn btn-primary">Kaydet</button>
           </div>
-        </form>
+        </div>
       </div>
-    </div>
+    </form>
   </div>
 </div>
 
 <!-- Filtre Modal -->
 <div class="modal fade" id="filterModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form id="filterForm" class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Filtrele</h5>
-        <button
-          type="button"
-          class="btn-close"
-          data-bs-dismiss="modal"
-        ></button>
-      </div>
-      <div class="modal-body">
-        <div id="filterRows"></div>
-      </div>
-      <div class="modal-footer">
-        <button
-          type="button"
-          class="btn btn-secondary btn-sm"
-          data-bs-dismiss="modal"
-        >
-          Kapat
-        </button>
-        <button type="submit" class="btn btn-primary btn-sm">Uygula</button>
+  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+    <form id="filterForm" class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Lisansları Filtrele</h5>
+            <p class="modal-shell__subtitle">
+              Birden fazla kriter belirleyerek tabloyu daraltabilirsiniz.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
+          </div>
+        </div>
+
+        <div class="modal-shell__body">
+          <div id="filterRows" class="stack-sm"></div>
+        </div>
+
+        <div class="modal-shell__footer">
+          <div class="modal-shell__actions">
+            <button
+              type="button"
+              class="btn btn-outline-secondary btn-sm"
+              data-bs-dismiss="modal"
+            >
+              Vazgeç
+            </button>
+            <button type="submit" class="btn btn-primary btn-sm">Uygula</button>
+          </div>
+        </div>
       </div>
     </form>
   </div>
@@ -257,56 +306,70 @@ content %}
 
 <!-- ATAMA MODALI -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
-    <form method="post" id="assignForm">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title">Atama Yap</h5>
-          <button
-            type="button"
-            class="btn-close"
-            data-bs-dismiss="modal"
-          ></button>
+  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+    <form method="post" id="assignForm" class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Lisansı Ata</h5>
+            <p class="modal-shell__subtitle">
+              Lisansı bir personele veya envanter kaydına bağlayın.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
+          </div>
         </div>
-        <div class="modal-body">
+
+        <div class="modal-shell__body">
           <input
             type="hidden"
             name="islem_yapan"
             value="{{ current_user.full_name if current_user else 'system' }}"
           />
-          <div class="mb-2">
-            <label class="form-label">Sorumlu Personel</label>
-            <select
-              name="sorumlu_personel"
-              class="form-select"
-              id="selPersonel"
-            >
-              <option value="">Seçiniz</option>
-              {% for u in users %}
-              <option value="{{ u }}">{{ u }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="mb-2">
-            <label class="form-label">Bağlı Olduğu Envanter No</label>
-            <select name="bagli_envanter_no" class="form-select" id="selBagli">
-              <option value="">Seçiniz</option>
-              {% for inv in envanterler %}
-              <option value="{{ inv.no }}">
-                {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
-              </option>
-              {% endfor %}
-            </select>
+          <div class="modal-form-grid">
+            <div class="form-group">
+              <label class="form-label" for="selPersonel">Sorumlu Personel</label>
+              <select
+                name="sorumlu_personel"
+                class="form-select"
+                id="selPersonel"
+              >
+                <option value="">Seçiniz</option>
+                {% for u in users %}
+                <option value="{{ u }}">{{ u }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="selBagli">Bağlı Olduğu Envanter No</label>
+              <select name="bagli_envanter_no" class="form-select" id="selBagli">
+                <option value="">Seçiniz</option>
+                {% for inv in envanterler %}
+                <option value="{{ inv.no }}">
+                  {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
+                </option>
+                {% endfor %}
+              </select>
+            </div>
           </div>
           <small class="text-muted"
             >Bu işlem lisansın geçmiş kayıtlarına eklenecek.</small
           >
         </div>
-        <div class="modal-footer">
-          <button class="btn btn-primary" type="submit">Kaydet</button>
-          <button class="btn btn-light" type="button" data-bs-dismiss="modal">
-            İptal
-          </button>
+
+        <div class="modal-shell__footer">
+          <div class="modal-shell__actions">
+            <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="modal">
+              İptal
+            </button>
+            <button class="btn btn-primary" type="submit">Kaydet</button>
+          </div>
         </div>
       </div>
     </form>
@@ -315,38 +378,57 @@ content %}
 
 <!-- HURDA MODALI -->
 <div class="modal fade" id="scrapModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form id="scrapForm" class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Hurdaya Ayır</h5>
-        <button
-          type="button"
-          class="btn-close"
-          data-bs-dismiss="modal"
-        ></button>
-      </div>
-      <div class="modal-body">
-        <p>Bu lisans hurdaya ayrılacak. Onaylıyor musunuz?</p>
-        <div class="mb-2">
-          <label class="form-label">Açıklama (opsiyonel)</label>
-          <textarea
-            name="aciklama"
-            class="form-control"
-            rows="3"
-            placeholder="Hurda sebebi / not"
-          ></textarea>
+  <div class="modal-dialog modal-dialog-centered">
+    <form id="scrapForm" class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Hurdaya Ayır</h5>
+            <p class="modal-shell__subtitle">
+              Lisansı hurdaya ayırmadan önce kısa bir not ekleyebilirsiniz.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
+          </div>
         </div>
-        <input
-          type="hidden"
-          name="islem_yapan"
-          value="{{ current_user.full_name if current_user else 'system' }}"
-        />
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-secondary" data-bs-dismiss="modal" type="button">
-          Vazgeç
-        </button>
-        <button class="btn btn-danger" type="submit">Hurdaya Ayır</button>
+
+        <div class="modal-shell__body">
+          <p class="mb-2">
+            Bu lisans hurdaya ayrılacak. Onaylıyor musunuz?
+          </p>
+          <div class="modal-form-grid">
+            <div class="form-group modal-form-grid--full">
+              <label class="form-label" for="scrapNote">Açıklama (opsiyonel)</label>
+              <textarea
+                id="scrapNote"
+                name="aciklama"
+                class="form-control"
+                rows="3"
+                placeholder="Hurda sebebi / not"
+              ></textarea>
+            </div>
+          </div>
+          <input
+            type="hidden"
+            name="islem_yapan"
+            value="{{ current_user.full_name if current_user else 'system' }}"
+          />
+        </div>
+
+        <div class="modal-shell__footer">
+          <div class="modal-shell__actions">
+            <button class="btn btn-outline-secondary" data-bs-dismiss="modal" type="button">
+              Vazgeç
+            </button>
+            <button class="btn btn-danger" type="submit">Hurdaya Ayır</button>
+          </div>
+        </div>
       </div>
     </form>
   </div>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -7,7 +7,8 @@ content %}
         <span class="eyebrow text-primary">Lisans Takip</span>
         <h1 class="page-header__title">Lisanslar</h1>
         <p class="page-header__subtitle">
-          Envanterinizdeki yazılım lisanslarını görüntüleyin, aktarın ve yönetin.
+          Envanterinizdeki yazılım lisanslarını görüntüleyin, aktarın ve
+          yönetin.
         </p>
       </div>
       <div class="page-header__actions page-actions">
@@ -32,7 +33,9 @@ content %}
               Excel
             </button>
             <ul class="dropdown-menu dropdown-menu-end">
-              <li><a class="dropdown-item" href="/lisans/export">Dışa Aktar</a></li>
+              <li>
+                <a class="dropdown-item" href="/lisans/export">Dışa Aktar</a>
+              </li>
               <li>
                 <form
                   action="/lisans/import"
@@ -46,7 +49,9 @@ content %}
                     class="d-none"
                     onchange="this.form.submit()"
                   />
-                  <label for="licExcel" class="dropdown-item mb-0">İçe Aktar</label>
+                  <label for="licExcel" class="dropdown-item mb-0"
+                    >İçe Aktar</label
+                  >
                 </form>
               </li>
             </ul>
@@ -136,7 +141,9 @@ content %}
 
 <!-- Yeni Ekle Modal -->
 <div class="modal fade" id="addModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+  <div
+    class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable"
+  >
     <form
       method="post"
       action="/lisans/create"
@@ -178,7 +185,9 @@ content %}
               </select>
             </div>
             <div class="form-group">
-              <label class="form-label" for="lisansAnahtari">Lisans Anahtarı</label>
+              <label class="form-label" for="lisansAnahtari"
+                >Lisans Anahtarı</label
+              >
               <input
                 id="lisansAnahtari"
                 name="lisans_anahtari"
@@ -190,7 +199,9 @@ content %}
             </div>
 
             <div class="form-group">
-              <label class="form-label" for="selPersonelAdd">Sorumlu Personel</label>
+              <label class="form-label" for="selPersonelAdd"
+                >Sorumlu Personel</label
+              >
               <select
                 id="selPersonelAdd"
                 name="sorumlu_personel"
@@ -204,7 +215,9 @@ content %}
             </div>
 
             <div class="form-group">
-              <label class="form-label" for="bagliEnvanter">Bağlı Olduğu Envanter No</label>
+              <label class="form-label" for="bagliEnvanter"
+                >Bağlı Olduğu Envanter No</label
+              >
               <select
                 id="bagliEnvanter"
                 name="bagli_envanter_no"
@@ -232,7 +245,9 @@ content %}
             </div>
 
             <div class="form-group">
-              <label class="form-label" for="lisansEmail">E-posta (opsiyonel)</label>
+              <label class="form-label" for="lisansEmail"
+                >E-posta (opsiyonel)</label
+              >
               <input
                 id="lisansEmail"
                 name="mail_adresi"
@@ -307,7 +322,11 @@ content %}
 <!-- ATAMA MODALI -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
-    <form method="post" id="assignForm" class="modal-content border-0 bg-transparent p-0">
+    <form
+      method="post"
+      id="assignForm"
+      class="modal-content border-0 bg-transparent p-0"
+    >
       <div class="modal-shell">
         <div class="modal-shell__header">
           <div class="modal-shell__heading">
@@ -334,7 +353,9 @@ content %}
           />
           <div class="modal-form-grid">
             <div class="form-group">
-              <label class="form-label" for="selPersonel">Sorumlu Personel</label>
+              <label class="form-label" for="selPersonel"
+                >Sorumlu Personel</label
+              >
               <select
                 name="sorumlu_personel"
                 class="form-select"
@@ -347,8 +368,14 @@ content %}
               </select>
             </div>
             <div class="form-group">
-              <label class="form-label" for="selBagli">Bağlı Olduğu Envanter No</label>
-              <select name="bagli_envanter_no" class="form-select" id="selBagli">
+              <label class="form-label" for="selBagli"
+                >Bağlı Olduğu Envanter No</label
+              >
+              <select
+                name="bagli_envanter_no"
+                class="form-select"
+                id="selBagli"
+              >
                 <option value="">Seçiniz</option>
                 {% for inv in envanterler %}
                 <option value="{{ inv.no }}">
@@ -365,7 +392,11 @@ content %}
 
         <div class="modal-shell__footer">
           <div class="modal-shell__actions">
-            <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="modal">
+            <button
+              class="btn btn-outline-secondary"
+              type="button"
+              data-bs-dismiss="modal"
+            >
               İptal
             </button>
             <button class="btn btn-primary" type="submit">Kaydet</button>
@@ -399,12 +430,12 @@ content %}
         </div>
 
         <div class="modal-shell__body">
-          <p class="mb-2">
-            Bu lisans hurdaya ayrılacak. Onaylıyor musunuz?
-          </p>
+          <p class="mb-2">Bu lisans hurdaya ayrılacak. Onaylıyor musunuz?</p>
           <div class="modal-form-grid">
             <div class="form-group modal-form-grid--full">
-              <label class="form-label" for="scrapNote">Açıklama (opsiyonel)</label>
+              <label class="form-label" for="scrapNote"
+                >Açıklama (opsiyonel)</label
+              >
               <textarea
                 id="scrapNote"
                 name="aciklama"
@@ -423,7 +454,11 @@ content %}
 
         <div class="modal-shell__footer">
           <div class="modal-shell__actions">
-            <button class="btn btn-outline-secondary" data-bs-dismiss="modal" type="button">
+            <button
+              class="btn btn-outline-secondary"
+              data-bs-dismiss="modal"
+              type="button"
+            >
               Vazgeç
             </button>
             <button class="btn btn-danger" type="submit">Hurdaya Ayır</button>

--- a/templates/license_scrap_list.html
+++ b/templates/license_scrap_list.html
@@ -1,10 +1,20 @@
 {% extends "base.html" %} {% block title %}Hurdalar - Lisans{% endblock %} {%
 block content %}
-<div class="container-fluid p-2 content">
-  <h5 class="mb-3">Hurdaya Ayrılan Lisanslar</h5>
-  <div class="page-section">
-    <div class="table-responsive">
-      <table class="table table-sm align-middle table-rounded">
+<div class="container-fluid py-4">
+  <div class="page-shell">
+    <header class="page-header">
+      <div class="page-header__heading">
+        <span class="eyebrow text-primary">Lisans Takip</span>
+        <h1 class="page-header__title">Hurdaya Ayrılan Lisanslar</h1>
+        <p class="page-header__subtitle">
+          Hurdaya ayrılan lisans kayıtlarını görüntüleyin ve detaylarını inceleyin.
+        </p>
+      </div>
+    </header>
+
+    <div class="page-card soft-card">
+      <div class="table-responsive">
+        <table class="table table-sm align-middle table-rounded">
         <thead>
           <tr>
             <th>No</th>
@@ -48,22 +58,32 @@ block content %}
           {% endfor %}
         </tbody>
       </table>
+      </div>
     </div>
   </div>
 </div>
 
 <div class="modal fade" id="hurdaDetayModal" tabindex="-1">
-  <div class="modal-dialog modal-lg">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Hurda Detayı</h5>
-        <button
-          class="btn-close"
-          data-bs-dismiss="modal"
-          aria-label="Kapat"
-        ></button>
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+    <div class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Hurda Detayı</h5>
+            <p class="modal-shell__subtitle">
+              Seçilen lisans kaydına ait hurda detaylarını görüntüleyin.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
+          </div>
+        </div>
+        <div class="modal-shell__body" id="hurdaDetayBody">Yükleniyor...</div>
       </div>
-      <div class="modal-body" id="hurdaDetayBody">Yükleniyor...</div>
     </div>
   </div>
 </div>

--- a/templates/license_scrap_list.html
+++ b/templates/license_scrap_list.html
@@ -7,7 +7,8 @@ block content %}
         <span class="eyebrow text-primary">Lisans Takip</span>
         <h1 class="page-header__title">Hurdaya Ayrılan Lisanslar</h1>
         <p class="page-header__subtitle">
-          Hurdaya ayrılan lisans kayıtlarını görüntüleyin ve detaylarını inceleyin.
+          Hurdaya ayrılan lisans kayıtlarını görüntüleyin ve detaylarını
+          inceleyin.
         </p>
       </div>
     </header>
@@ -15,56 +16,58 @@ block content %}
     <div class="page-card soft-card">
       <div class="table-responsive">
         <table class="table table-sm align-middle table-rounded">
-        <thead>
-          <tr>
-            <th>No</th>
-            <th>Lisans Adı</th>
-            <th>Key</th>
-            <th>Sorumlu</th>
-            <th>Bağlı Envanter</th>
-            <th>E-posta</th>
-            <th>Not</th>
-            <th>Durum</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in items %}
-          <tr>
-            <td>{{ row.id }}</td>
-            <td>{{ row.lisans_adi }}</td>
-            <td class="text-truncate" style="max-width: 220px">
-              {{ row.lisans_key }}
-            </td>
-            <td>{{ row.sorumlu_personel or '-' }}</td>
-            <td>{{ row.bagli_envanter_no or '-' }}</td>
-            <td>{{ row.mail_adresi or '-' }}</td>
-            <td>{{ row.notlar or '-' }}</td>
-            <td><span class="badge bg-secondary">Hurda</span></td>
-            <td class="text-nowrap">
-              <button
-                class="btn btn-outline-secondary btn-sm view-btn"
-                data-id="{{ row.id }}"
-                title="Detayı Göster"
-              >
-                <i class="bi bi-eye"></i>
-              </button>
-            </td>
-          </tr>
-          {% else %}
-          <tr>
-            <td colspan="8" class="text-muted">Kayıt yok.</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          <thead>
+            <tr>
+              <th>No</th>
+              <th>Lisans Adı</th>
+              <th>Key</th>
+              <th>Sorumlu</th>
+              <th>Bağlı Envanter</th>
+              <th>E-posta</th>
+              <th>Not</th>
+              <th>Durum</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in items %}
+            <tr>
+              <td>{{ row.id }}</td>
+              <td>{{ row.lisans_adi }}</td>
+              <td class="text-truncate" style="max-width: 220px">
+                {{ row.lisans_key }}
+              </td>
+              <td>{{ row.sorumlu_personel or '-' }}</td>
+              <td>{{ row.bagli_envanter_no or '-' }}</td>
+              <td>{{ row.mail_adresi or '-' }}</td>
+              <td>{{ row.notlar or '-' }}</td>
+              <td><span class="badge bg-secondary">Hurda</span></td>
+              <td class="text-nowrap">
+                <button
+                  class="btn btn-outline-secondary btn-sm view-btn"
+                  data-id="{{ row.id }}"
+                  title="Detayı Göster"
+                >
+                  <i class="bi bi-eye"></i>
+                </button>
+              </td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="8" class="text-muted">Kayıt yok.</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
     </div>
   </div>
 </div>
 
 <div class="modal fade" id="hurdaDetayModal" tabindex="-1">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+  <div
+    class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable"
+  >
     <div class="modal-content border-0 bg-transparent p-0">
       <div class="modal-shell">
         <div class="modal-shell__header">

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -7,7 +7,8 @@ content %}
         <span class="eyebrow text-primary">Yazıcı Takip</span>
         <h1 class="page-header__title">Yazıcılar</h1>
         <p class="page-header__subtitle">
-          Tüm yazıcı envanterini görüntüleyin, durumlarını yönetin ve hızlıca aksiyon alın.
+          Tüm yazıcı envanterini görüntüleyin, durumlarını yönetin ve hızlıca
+          aksiyon alın.
         </p>
       </div>
       <div class="page-header__actions page-actions">
@@ -83,66 +84,66 @@ content %}
     <div class="page-card soft-card">
       <div class="table-responsive">
         <table class="table table-sm align-middle table-rounded">
-      <thead class="table-light">
-        <tr>
-          <th data-field="id">ID</th>
-          <th data-field="marka">Marka</th>
-          <th data-field="model">Model</th>
-          <th data-field="seri_no">Seri No</th>
-          <th data-field="fabrika">Fabrika</th>
-          <th data-field="kullanim_alani">Kullanım Alanı</th>
-          <th data-field="sorumlu_personel">Sorumlu</th>
-          <th data-field="bagli_envanter_no">Bağlı Env.</th>
-          <th data-field="durum">Durum</th>
-          <th style="width: 220px">İşlemler</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for p in printers %}
-        <tr
-          data-id="{{ p.id }}"
-          data-label="{{ p.hostname or p.envanter_no or ('Yazıcı #' ~ p.id) }}"
-          data-fabrika="{{ p.fabrika or '' }}"
-          data-kullanim="{{ p.kullanim_alani or '' }}"
-          data-personel="{{ p.sorumlu_personel or '' }}"
-          data-bagli="{{ p.bagli_envanter_no or '' }}"
-          {%
-          if
-          p.durum=""
-          ="arızalı"
-          %}class="table-warning"
-          {%
-          endif
-          %}
-        >
-          <td>#{{ p.id }}</td>
-          <td>{{ p.marka or '-' }}</td>
-          <td>{{ p.model or '-' }}</td>
-          <td>{{ p.seri_no or '-' }}</td>
-          <td>{{ p.fabrika or '-' }}</td>
-          <td>{{ p.kullanim_alani or '-' }}</td>
-          <td>{{ p.sorumlu_personel or '-' }}</td>
-          <td>{{ p.bagli_envanter_no or '-' }}</td>
-          <td>
-            {% if p.durum == 'hurda' %}
-            <span class="badge text-bg-secondary">Hurda</span>
-            {% elif p.durum == 'arızalı' %}
-            <span class="badge text-bg-warning text-dark">Arızalı</span>
-            {% else %}
-            <span class="badge text-bg-success">Aktif</span>
-            {% endif %}
-          </td>
-          <td class="text-nowrap">
-            {% set entity = 'printers' %} {% set row_id = p.id %} {% set
-            fault_mode = True %} {% set fault_device = p.envanter_no or ('Yazıcı
-            #' ~ p.id) %} {% set fault_title = (p.marka ~ ' ' ~ p.model)|trim %}
-            {% set fault_entity_key = p.envanter_no or p.id %} {% set
-            fault_status = p.durum %} {% with edit_modal_size='md' %} {% include
-            'partials/_actions_menu.html' %} {% endwith %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
+          <thead class="table-light">
+            <tr>
+              <th data-field="id">ID</th>
+              <th data-field="marka">Marka</th>
+              <th data-field="model">Model</th>
+              <th data-field="seri_no">Seri No</th>
+              <th data-field="fabrika">Fabrika</th>
+              <th data-field="kullanim_alani">Kullanım Alanı</th>
+              <th data-field="sorumlu_personel">Sorumlu</th>
+              <th data-field="bagli_envanter_no">Bağlı Env.</th>
+              <th data-field="durum">Durum</th>
+              <th style="width: 220px">İşlemler</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for p in printers %}
+            <tr
+              data-id="{{ p.id }}"
+              data-label="{{ p.hostname or p.envanter_no or ('Yazıcı #' ~ p.id) }}"
+              data-fabrika="{{ p.fabrika or '' }}"
+              data-kullanim="{{ p.kullanim_alani or '' }}"
+              data-personel="{{ p.sorumlu_personel or '' }}"
+              data-bagli="{{ p.bagli_envanter_no or '' }}"
+              {%
+              if
+              p.durum=""
+              ="arızalı"
+              %}class="table-warning"
+              {%
+              endif
+              %}
+            >
+              <td>#{{ p.id }}</td>
+              <td>{{ p.marka or '-' }}</td>
+              <td>{{ p.model or '-' }}</td>
+              <td>{{ p.seri_no or '-' }}</td>
+              <td>{{ p.fabrika or '-' }}</td>
+              <td>{{ p.kullanim_alani or '-' }}</td>
+              <td>{{ p.sorumlu_personel or '-' }}</td>
+              <td>{{ p.bagli_envanter_no or '-' }}</td>
+              <td>
+                {% if p.durum == 'hurda' %}
+                <span class="badge text-bg-secondary">Hurda</span>
+                {% elif p.durum == 'arızalı' %}
+                <span class="badge text-bg-warning text-dark">Arızalı</span>
+                {% else %}
+                <span class="badge text-bg-success">Aktif</span>
+                {% endif %}
+              </td>
+              <td class="text-nowrap">
+                {% set entity = 'printers' %} {% set row_id = p.id %} {% set
+                fault_mode = True %} {% set fault_device = p.envanter_no or
+                ('Yazıcı #' ~ p.id) %} {% set fault_title = (p.marka ~ ' ' ~
+                p.model)|trim %} {% set fault_entity_key = p.envanter_no or p.id
+                %} {% set fault_status = p.durum %} {% with edit_modal_size='md'
+                %} {% include 'partials/_actions_menu.html' %} {% endwith %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
         </table>
       </div>
     </div>
@@ -151,7 +152,9 @@ content %}
 
 <!-- Yeni Ekle Modal -->
 <div class="modal fade" id="addModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+  <div
+    class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable"
+  >
     <form
       method="post"
       action="/printers/create"
@@ -163,7 +166,8 @@ content %}
           <div class="modal-shell__heading">
             <h5 class="modal-shell__title">Yazıcı Ekle</h5>
             <p class="modal-shell__subtitle">
-              Yeni bir yazıcıyı envantere ekleyin ve temel yapılandırmasını belirleyin.
+              Yeni bir yazıcıyı envantere ekleyin ve temel yapılandırmasını
+              belirleyin.
             </p>
           </div>
           <div class="modal-shell__header-actions">
@@ -179,7 +183,9 @@ content %}
         <div class="modal-shell__body">
           <div class="modal-form-grid">
             <div class="form-group">
-              <label class="form-label" for="printerEnvanter">Envanter No</label>
+              <label class="form-label" for="printerEnvanter"
+                >Envanter No</label
+              >
               <input
                 id="printerEnvanter"
                 name="envanter_no"
@@ -191,7 +197,9 @@ content %}
             </div>
 
             <div class="form-group">
-              <label class="form-label" for="selYaziciMarka">Yazıcı Markası</label>
+              <label class="form-label" for="selYaziciMarka"
+                >Yazıcı Markası</label
+              >
               <select
                 name="yazici_markasi"
                 class="form-select"
@@ -206,7 +214,9 @@ content %}
             </div>
 
             <div class="form-group">
-              <label class="form-label" for="selYaziciModel">Yazıcı Modeli</label>
+              <label class="form-label" for="selYaziciModel"
+                >Yazıcı Modeli</label
+              >
               <select
                 name="yazici_modeli"
                 class="form-select"
@@ -222,8 +232,15 @@ content %}
             </div>
 
             <div class="form-group">
-              <label class="form-label" for="printerUsage">Kullanım Alanı</label>
-              <select id="printerUsage" name="kullanim_alani" class="form-select" required>
+              <label class="form-label" for="printerUsage"
+                >Kullanım Alanı</label
+              >
+              <select
+                id="printerUsage"
+                name="kullanim_alani"
+                class="form-select"
+                required
+              >
                 <option value="">Seçiniz...</option>
                 {% for k in kullanim_alanlari %}
                 <option value="{{ k.name }}">{{ k.name }}</option>
@@ -355,7 +372,8 @@ content %}
               Yazıcıyı Ata — <span id="assignPrinterLabel"></span>
             </h5>
             <p class="modal-shell__subtitle">
-              Yazıcı için fabrika, kullanım alanı ve sorumlu bilgilerini güncelleyin.
+              Yazıcı için fabrika, kullanım alanı ve sorumlu bilgilerini
+              güncelleyin.
             </p>
           </div>
           <div class="modal-shell__header-actions">
@@ -384,7 +402,11 @@ content %}
 
             <div class="form-group">
               <label class="form-label" for="selKullanim">Kullanım Alanı</label>
-              <select id="selKullanim" name="kullanim_alani" class="form-select">
+              <select
+                id="selKullanim"
+                name="kullanim_alani"
+                class="form-select"
+              >
                 <option value="">Seçiniz</option>
                 {% for a in areas %}
                 <option value="{{ a }}">{{ a }}</option>
@@ -393,8 +415,14 @@ content %}
             </div>
 
             <div class="form-group">
-              <label class="form-label" for="selPersonel">Sorumlu Personel</label>
-              <select id="selPersonel" name="sorumlu_personel" class="form-select">
+              <label class="form-label" for="selPersonel"
+                >Sorumlu Personel</label
+              >
+              <select
+                id="selPersonel"
+                name="sorumlu_personel"
+                class="form-select"
+              >
                 <option value="">Seçiniz</option>
                 {% for u in users %}
                 <option value="{{ u }}">{{ u }}</option>
@@ -403,8 +431,14 @@ content %}
             </div>
 
             <div class="form-group">
-              <label class="form-label" for="selBagliEnv">Bağlı Olduğu Envanter</label>
-              <select id="selBagliEnv" name="bagli_envanter_no" class="form-select">
+              <label class="form-label" for="selBagliEnv"
+                >Bağlı Olduğu Envanter</label
+              >
+              <select
+                id="selBagliEnv"
+                name="bagli_envanter_no"
+                class="form-select"
+              >
                 <option value="">Seçiniz</option>
                 {% for inv in inventory_nos %}
                 <option value="{{ inv }}">{{ inv }}</option>
@@ -416,10 +450,16 @@ content %}
 
         <div class="modal-shell__footer">
           <div class="modal-shell__actions">
-            <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="modal">
+            <button
+              class="btn btn-outline-secondary"
+              type="button"
+              data-bs-dismiss="modal"
+            >
               İptal
             </button>
-            <button class="btn btn-success" type="submit">Atamayı Kaydet</button>
+            <button class="btn btn-success" type="submit">
+              Atamayı Kaydet
+            </button>
           </div>
         </div>
       </div>
@@ -454,7 +494,9 @@ content %}
           <p class="mb-2">Bu envanter hurdaya ayrılacak. Onaylıyor musunuz?</p>
           <div class="modal-form-grid">
             <div class="form-group modal-form-grid--full">
-              <label class="form-label" for="scrapReason">Açıklama (opsiyonel)</label>
+              <label class="form-label" for="scrapReason"
+                >Açıklama (opsiyonel)</label
+              >
               <textarea
                 id="scrapReason"
                 name="reason"
@@ -468,7 +510,11 @@ content %}
 
         <div class="modal-shell__footer">
           <div class="modal-shell__actions">
-            <button class="btn btn-outline-secondary" data-bs-dismiss="modal" type="button">
+            <button
+              class="btn btn-outline-secondary"
+              data-bs-dismiss="modal"
+              type="button"
+            >
               Vazgeç
             </button>
             <button class="btn btn-danger" type="submit">Hurdaya Ayır</button>

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -1,75 +1,88 @@
 {% extends "base.html" %} {% block title %}Yazıcı Takip{% endblock %} {% block
 content %}
-<div class="container-fluid p-3">
-  <div class="d-flex align-items-center justify-content-between mb-3">
-    <h5 class="mb-0">Yazıcılar</h5>
-    <div class="d-flex align-items-center gap-2 flex-wrap">
-      <a
-        href="#"
-        class="btn btn-success btn-sm d-flex align-items-center gap-1"
-        title="Yeni Ekle"
-        data-bs-toggle="modal"
-        data-bs-target="#addModal"
-      >
-        <i class="bi bi-plus-lg"></i>
-        <span>Ekle</span>
-      </a>
-      {% with fault_entity='printer', fault_prefix='printer',
-      fault_label='Yazıcı Arızalı Durum' %} {% include
-      'partials/_fault_controls.html' %} {% endwith %}
-      <div class="dropdown">
-        <button
-          class="btn btn-outline-primary btn-sm dropdown-toggle"
-          type="button"
-          data-bs-toggle="dropdown"
-          aria-expanded="false"
-        >
-          Excel
-        </button>
-        <ul class="dropdown-menu dropdown-menu-end">
-          <li>
-            <a class="dropdown-item" href="/printers/export">Dışa Aktar</a>
-          </li>
-          <li>
-            <form
-              action="/printers/import"
-              method="post"
-              enctype="multipart/form-data"
-            >
-              <input
-                type="file"
-                name="file"
-                id="printerExcel"
-                class="d-none"
-                onchange="this.form.submit()"
-              />
-              <label for="printerExcel" class="dropdown-item mb-0"
-                >İçe Aktar</label
-              >
-            </form>
-          </li>
-        </ul>
+<div class="container-fluid py-4">
+  <div class="page-shell">
+    <header class="page-header">
+      <div class="page-header__heading">
+        <span class="eyebrow text-primary">Yazıcı Takip</span>
+        <h1 class="page-header__title">Yazıcılar</h1>
+        <p class="page-header__subtitle">
+          Tüm yazıcı envanterini görüntüleyin, durumlarını yönetin ve hızlıca aksiyon alın.
+        </p>
       </div>
-      <button class="btn btn-outline-secondary btn-sm" id="filterBtn">
-        Filtre
-      </button>
-      <button
-        class="btn btn-outline-secondary btn-sm d-none"
-        id="clearFilterBtn"
-      >
-        Temizle
-      </button>
-      <input
-        type="text"
-        id="searchInput"
-        class="form-control form-control-sm"
-        placeholder="Ara..."
-      />
-    </div>
-  </div>
+      <div class="page-header__actions page-actions">
+        <div class="page-actions__group">
+          <a
+            href="#"
+            class="btn btn-success btn-sm d-flex align-items-center gap-1"
+            title="Yeni Ekle"
+            data-bs-toggle="modal"
+            data-bs-target="#addModal"
+          >
+            <i class="bi bi-plus-lg"></i>
+            <span>Ekle</span>
+          </a>
+          {% with fault_entity='printer', fault_prefix='printer',
+          fault_label='Yazıcı Arızalı Durum' %} {% include
+          'partials/_fault_controls.html' %} {% endwith %}
+          <div class="dropdown">
+            <button
+              class="btn btn-outline-primary btn-sm dropdown-toggle"
+              type="button"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+            >
+              Excel
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              <li>
+                <a class="dropdown-item" href="/printers/export">Dışa Aktar</a>
+              </li>
+              <li>
+                <form
+                  action="/printers/import"
+                  method="post"
+                  enctype="multipart/form-data"
+                >
+                  <input
+                    type="file"
+                    name="file"
+                    id="printerExcel"
+                    class="d-none"
+                    onchange="this.form.submit()"
+                  />
+                  <label for="printerExcel" class="dropdown-item mb-0"
+                    >İçe Aktar</label
+                  >
+                </form>
+              </li>
+            </ul>
+          </div>
+          <button class="btn btn-outline-secondary btn-sm" id="filterBtn">
+            Filtre
+          </button>
+          <button
+            class="btn btn-outline-secondary btn-sm d-none"
+            id="clearFilterBtn"
+          >
+            Temizle
+          </button>
+        </div>
+        <div class="page-actions__group page-actions__group--grow">
+          <label for="searchInput" class="visually-hidden">Ara</label>
+          <input
+            type="text"
+            id="searchInput"
+            class="form-control form-control-sm"
+            placeholder="Ara..."
+          />
+        </div>
+      </div>
+    </header>
 
-  <div class="table-responsive">
-    <table class="table table-sm align-middle table-rounded">
+    <div class="page-card soft-card">
+      <div class="table-responsive">
+        <table class="table table-sm align-middle table-rounded">
       <thead class="table-light">
         <tr>
           <th data-field="id">ID</th>
@@ -130,33 +143,45 @@ content %}
         </tr>
         {% endfor %}
       </tbody>
-    </table>
+        </table>
+      </div>
+    </div>
   </div>
 </div>
 
 <!-- Yeni Ekle Modal -->
 <div class="modal fade" id="addModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Yazıcı Ekle</h5>
-        <button
-          type="button"
-          class="btn-close"
-          data-bs-dismiss="modal"
-        ></button>
-      </div>
-      <div class="modal-body">
-        <form
-          method="post"
-          action="/printers/create"
-          class="needs-validation"
-          novalidate
-        >
-          <div class="row g-3">
-            <div class="col-md-6">
-              <label class="form-label">Envanter No</label>
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+    <form
+      method="post"
+      action="/printers/create"
+      class="modal-content border-0 bg-transparent p-0 needs-validation"
+      novalidate
+    >
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Yazıcı Ekle</h5>
+            <p class="modal-shell__subtitle">
+              Yeni bir yazıcıyı envantere ekleyin ve temel yapılandırmasını belirleyin.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
+          </div>
+        </div>
+
+        <div class="modal-shell__body">
+          <div class="modal-form-grid">
+            <div class="form-group">
+              <label class="form-label" for="printerEnvanter">Envanter No</label>
               <input
+                id="printerEnvanter"
                 name="envanter_no"
                 type="text"
                 class="form-control"
@@ -165,8 +190,8 @@ content %}
               />
             </div>
 
-            <div class="col-md-6">
-              <label class="form-label">Yazıcı Markası</label>
+            <div class="form-group">
+              <label class="form-label" for="selYaziciMarka">Yazıcı Markası</label>
               <select
                 name="yazici_markasi"
                 class="form-select"
@@ -180,8 +205,8 @@ content %}
               </select>
             </div>
 
-            <div class="col-md-6">
-              <label class="form-label">Yazıcı Modeli</label>
+            <div class="form-group">
+              <label class="form-label" for="selYaziciModel">Yazıcı Modeli</label>
               <select
                 name="yazici_modeli"
                 class="form-select"
@@ -196,9 +221,9 @@ content %}
               >
             </div>
 
-            <div class="col-md-6">
-              <label class="form-label">Kullanım Alanı</label>
-              <select name="kullanim_alani" class="form-select" required>
+            <div class="form-group">
+              <label class="form-label" for="printerUsage">Kullanım Alanı</label>
+              <select id="printerUsage" name="kullanim_alani" class="form-select" required>
                 <option value="">Seçiniz...</option>
                 {% for k in kullanim_alanlari %}
                 <option value="{{ k.name }}">{{ k.name }}</option>
@@ -206,9 +231,10 @@ content %}
               </select>
             </div>
 
-            <div class="col-md-4">
-              <label class="form-label">IP Adresi</label>
+            <div class="form-group">
+              <label class="form-label" for="printerIp">IP Adresi</label>
               <input
+                id="printerIp"
                 name="ip_adresi"
                 type="text"
                 class="form-control"
@@ -216,9 +242,10 @@ content %}
                 placeholder="10.0.0.10"
               />
             </div>
-            <div class="col-md-4">
-              <label class="form-label">MAC</label>
+            <div class="form-group">
+              <label class="form-label" for="printerMac">MAC</label>
               <input
+                id="printerMac"
                 name="mac"
                 type="text"
                 class="form-control"
@@ -226,9 +253,10 @@ content %}
                 placeholder="AA:BB:CC:DD:EE:FF"
               />
             </div>
-            <div class="col-md-4">
-              <label class="form-label">Hostname</label>
+            <div class="form-group">
+              <label class="form-label" for="printerHostname">Hostname</label>
               <input
+                id="printerHostname"
                 name="hostname"
                 type="text"
                 class="form-control"
@@ -237,11 +265,12 @@ content %}
               />
             </div>
 
-            <div class="col-md-6">
-              <label class="form-label"
-                >IFS No <small class="text-muted">(zorunlu değil)</small></label
-              >
+            <div class="form-group">
+              <label class="form-label" for="printerIfs">
+                IFS No <small class="text-muted">(opsiyonel)</small>
+              </label>
               <input
+                id="printerIfs"
                 name="ifs_no"
                 type="text"
                 class="form-control"
@@ -249,20 +278,22 @@ content %}
               />
             </div>
           </div>
+        </div>
 
-          <div class="mt-3 d-flex gap-2">
-            <button type="submit" class="btn btn-primary">Kaydet</button>
+        <div class="modal-shell__footer">
+          <div class="modal-shell__actions">
             <button
               type="button"
-              class="btn btn-secondary"
+              class="btn btn-outline-secondary"
               data-bs-dismiss="modal"
             >
               İptal
             </button>
+            <button type="submit" class="btn btn-primary">Kaydet</button>
           </div>
-        </form>
+        </div>
       </div>
-    </div>
+    </form>
   </div>
 </div>
 
@@ -272,28 +303,42 @@ content %}
 
 <!-- Filtre Modal -->
 <div class="modal fade" id="filterModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form id="filterForm" class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Filtrele</h5>
-        <button
-          type="button"
-          class="btn-close"
-          data-bs-dismiss="modal"
-        ></button>
-      </div>
-      <div class="modal-body">
-        <div id="filterRows"></div>
-      </div>
-      <div class="modal-footer">
-        <button
-          type="button"
-          class="btn btn-secondary btn-sm"
-          data-bs-dismiss="modal"
-        >
-          Kapat
-        </button>
-        <button type="submit" class="btn btn-primary btn-sm">Uygula</button>
+  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+    <form id="filterForm" class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Yazıcıları Filtrele</h5>
+            <p class="modal-shell__subtitle">
+              Marka, model veya sorumlu gibi kriterlerle listeyi daraltın.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
+          </div>
+        </div>
+
+        <div class="modal-shell__body">
+          <div id="filterRows" class="stack-sm"></div>
+        </div>
+
+        <div class="modal-shell__footer">
+          <div class="modal-shell__actions">
+            <button
+              type="button"
+              class="btn btn-outline-secondary btn-sm"
+              data-bs-dismiss="modal"
+            >
+              Vazgeç
+            </button>
+            <button type="submit" class="btn btn-primary btn-sm">Uygula</button>
+          </div>
+        </div>
       </div>
     </form>
   </div>
@@ -301,66 +346,82 @@ content %}
 
 <!-- ATAMA MODAL -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-scrollable">
-    <form class="modal-content" id="assignForm">
-      <div class="modal-header">
-        <h6 class="modal-title">
-          Atama Yap — <span id="assignPrinterLabel"></span>
-        </h6>
-        <button
-          type="button"
-          class="btn-close"
-          data-bs-dismiss="modal"
-        ></button>
-      </div>
-      <div class="modal-body">
-        <input type="hidden" id="assignPrinterId" name="printer_id" />
-
-        <div class="mb-2">
-          <label class="form-label">Fabrika</label>
-          <select id="selFabrika" name="fabrika" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for f in factories %}
-            <option value="{{ f }}">{{ f }}</option>
-            {% endfor %}
-          </select>
+  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+    <form class="modal-content border-0 bg-transparent p-0" id="assignForm">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">
+              Yazıcıyı Ata — <span id="assignPrinterLabel"></span>
+            </h5>
+            <p class="modal-shell__subtitle">
+              Yazıcı için fabrika, kullanım alanı ve sorumlu bilgilerini güncelleyin.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
+          </div>
         </div>
 
-        <div class="mb-2">
-          <label class="form-label">Kullanım Alanı</label>
-          <select id="selKullanim" name="kullanim_alani" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for a in areas %}
-            <option value="{{ a }}">{{ a }}</option>
-            {% endfor %}
-          </select>
+        <div class="modal-shell__body">
+          <input type="hidden" id="assignPrinterId" name="printer_id" />
+
+          <div class="modal-form-grid">
+            <div class="form-group">
+              <label class="form-label" for="selFabrika">Fabrika</label>
+              <select id="selFabrika" name="fabrika" class="form-select">
+                <option value="">Seçiniz</option>
+                {% for f in factories %}
+                <option value="{{ f }}">{{ f }}</option>
+                {% endfor %}
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="selKullanim">Kullanım Alanı</label>
+              <select id="selKullanim" name="kullanim_alani" class="form-select">
+                <option value="">Seçiniz</option>
+                {% for a in areas %}
+                <option value="{{ a }}">{{ a }}</option>
+                {% endfor %}
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="selPersonel">Sorumlu Personel</label>
+              <select id="selPersonel" name="sorumlu_personel" class="form-select">
+                <option value="">Seçiniz</option>
+                {% for u in users %}
+                <option value="{{ u }}">{{ u }}</option>
+                {% endfor %}
+              </select>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label" for="selBagliEnv">Bağlı Olduğu Envanter</label>
+              <select id="selBagliEnv" name="bagli_envanter_no" class="form-select">
+                <option value="">Seçiniz</option>
+                {% for inv in inventory_nos %}
+                <option value="{{ inv }}">{{ inv }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
         </div>
 
-        <div class="mb-2">
-          <label class="form-label">Sorumlu Personel</label>
-          <select id="selPersonel" name="sorumlu_personel" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for u in users %}
-            <option value="{{ u }}">{{ u }}</option>
-            {% endfor %}
-          </select>
+        <div class="modal-shell__footer">
+          <div class="modal-shell__actions">
+            <button class="btn btn-outline-secondary" type="button" data-bs-dismiss="modal">
+              İptal
+            </button>
+            <button class="btn btn-success" type="submit">Atamayı Kaydet</button>
+          </div>
         </div>
-
-        <div class="mb-2">
-          <label class="form-label">Bağlı Olduğu Envanter</label>
-          <select id="selBagliEnv" name="bagli_envanter_no" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for inv in inventory_nos %}
-            <option value="{{ inv }}">{{ inv }}</option>
-            {% endfor %}
-          </select>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-secondary" type="button" data-bs-dismiss="modal">
-          İptal
-        </button>
-        <button class="btn btn-success" type="submit">Atamayı Kaydet</button>
       </div>
     </form>
   </div>
@@ -368,34 +429,51 @@ content %}
 
 <!-- HURDA MODAL -->
 <div class="modal fade" id="scrapModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form id="scrapForm" class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Hurdaya Ayır</h5>
-        <button
-          type="button"
-          class="btn-close"
-          data-bs-dismiss="modal"
-        ></button>
-      </div>
-      <div class="modal-body">
-        <input type="hidden" id="scrapPrinterId" />
-        <p>Bu envanter hurdaya ayrılacak. Onaylıyor musunuz?</p>
-        <div class="mb-2">
-          <label class="form-label">Açıklama (opsiyonel)</label>
-          <textarea
-            name="reason"
-            class="form-control"
-            rows="3"
-            placeholder="Hurda sebebi / not"
-          ></textarea>
+  <div class="modal-dialog modal-dialog-centered">
+    <form id="scrapForm" class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Hurdaya Ayır</h5>
+            <p class="modal-shell__subtitle">
+              Yazıcı hurdaya ayrılmadan önce kısa bir açıklama ekleyin.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
+          </div>
         </div>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-secondary" data-bs-dismiss="modal" type="button">
-          Vazgeç
-        </button>
-        <button class="btn btn-danger" type="submit">Hurdaya Ayır</button>
+
+        <div class="modal-shell__body">
+          <input type="hidden" id="scrapPrinterId" />
+          <p class="mb-2">Bu envanter hurdaya ayrılacak. Onaylıyor musunuz?</p>
+          <div class="modal-form-grid">
+            <div class="form-group modal-form-grid--full">
+              <label class="form-label" for="scrapReason">Açıklama (opsiyonel)</label>
+              <textarea
+                id="scrapReason"
+                name="reason"
+                class="form-control"
+                rows="3"
+                placeholder="Hurda sebebi / not"
+              ></textarea>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-shell__footer">
+          <div class="modal-shell__actions">
+            <button class="btn btn-outline-secondary" data-bs-dismiss="modal" type="button">
+              Vazgeç
+            </button>
+            <button class="btn btn-danger" type="submit">Hurdaya Ayır</button>
+          </div>
+        </div>
       </div>
     </form>
   </div>

--- a/templates/printers_scrap.html
+++ b/templates/printers_scrap.html
@@ -15,73 +15,75 @@ content %}
     <div class="page-card soft-card">
       <div class="table-responsive">
         <table class="table table-sm align-middle table-rounded">
-        <thead class="table-light">
-          <tr>
-            <th>ID</th>
-            <th>Marka/Model</th>
-            <th>Seri</th>
-            <th>Fabrika</th>
-            <th>Kullanım Alanı</th>
-            <th>Sorumlu</th>
-            <th>Bağlı Env.</th>
-            <th>Not</th>
-            <th>Tarih</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% if mode == "table" %} {% for r in rows %}
-          <tr>
-            <td>#{{ r.printer_id }}</td>
-            <td>{{ r.snapshot.marka }} {{ r.snapshot.model }}</td>
-            <td>{{ r.snapshot.seri_no }}</td>
-            <td>{{ r.snapshot.fabrika or '-' }}</td>
-            <td>{{ r.snapshot.kullanim_alani or '-' }}</td>
-            <td>{{ r.snapshot.sorumlu_personel or '-' }}</td>
-            <td>{{ r.snapshot.bagli_envanter_no or '-' }}</td>
-            <td>{{ r.reason or '-' }}</td>
-            <td>{{ r.created_at.strftime("%d.%m.%Y %H:%M") }}</td>
-            <td>
-              <button
-                class="btn btn-outline-secondary btn-sm view-btn"
-                data-id="{{ r.printer_id }}"
-                title="Detayı Göster"
-              >
-                <i class="bi bi-eye"></i>
-              </button>
-            </td>
-          </tr>
-          {% endfor %} {% else %} {% for p in rows %}
-          <tr>
-            <td>#{{ p.id }}</td>
-            <td>{{ p.marka }} {{ p.model }}</td>
-            <td>{{ p.seri_no }}</td>
-            <td>{{ p.fabrika or '-' }}</td>
-            <td>{{ p.kullanim_alani or '-' }}</td>
-            <td>{{ p.sorumlu_personel or '-' }}</td>
-            <td>{{ p.bagli_envanter_no or '-' }}</td>
-            <td>-</td>
-            <td>-</td>
-            <td>
-              <button
-                class="btn btn-outline-secondary btn-sm view-btn"
-                data-id="{{ p.id }}"
-                title="Detayı Göster"
-              >
-                <i class="bi bi-eye"></i>
-              </button>
-            </td>
-          </tr>
-          {% endfor %} {% endif %}
-        </tbody>
-      </table>
+          <thead class="table-light">
+            <tr>
+              <th>ID</th>
+              <th>Marka/Model</th>
+              <th>Seri</th>
+              <th>Fabrika</th>
+              <th>Kullanım Alanı</th>
+              <th>Sorumlu</th>
+              <th>Bağlı Env.</th>
+              <th>Not</th>
+              <th>Tarih</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% if mode == "table" %} {% for r in rows %}
+            <tr>
+              <td>#{{ r.printer_id }}</td>
+              <td>{{ r.snapshot.marka }} {{ r.snapshot.model }}</td>
+              <td>{{ r.snapshot.seri_no }}</td>
+              <td>{{ r.snapshot.fabrika or '-' }}</td>
+              <td>{{ r.snapshot.kullanim_alani or '-' }}</td>
+              <td>{{ r.snapshot.sorumlu_personel or '-' }}</td>
+              <td>{{ r.snapshot.bagli_envanter_no or '-' }}</td>
+              <td>{{ r.reason or '-' }}</td>
+              <td>{{ r.created_at.strftime("%d.%m.%Y %H:%M") }}</td>
+              <td>
+                <button
+                  class="btn btn-outline-secondary btn-sm view-btn"
+                  data-id="{{ r.printer_id }}"
+                  title="Detayı Göster"
+                >
+                  <i class="bi bi-eye"></i>
+                </button>
+              </td>
+            </tr>
+            {% endfor %} {% else %} {% for p in rows %}
+            <tr>
+              <td>#{{ p.id }}</td>
+              <td>{{ p.marka }} {{ p.model }}</td>
+              <td>{{ p.seri_no }}</td>
+              <td>{{ p.fabrika or '-' }}</td>
+              <td>{{ p.kullanim_alani or '-' }}</td>
+              <td>{{ p.sorumlu_personel or '-' }}</td>
+              <td>{{ p.bagli_envanter_no or '-' }}</td>
+              <td>-</td>
+              <td>-</td>
+              <td>
+                <button
+                  class="btn btn-outline-secondary btn-sm view-btn"
+                  data-id="{{ p.id }}"
+                  title="Detayı Göster"
+                >
+                  <i class="bi bi-eye"></i>
+                </button>
+              </td>
+            </tr>
+            {% endfor %} {% endif %}
+          </tbody>
+        </table>
       </div>
     </div>
   </div>
 </div>
 
 <div class="modal fade" id="hurdaDetayModal" tabindex="-1">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+  <div
+    class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable"
+  >
     <div class="modal-content border-0 bg-transparent p-0">
       <div class="modal-shell">
         <div class="modal-shell__header">

--- a/templates/printers_scrap.html
+++ b/templates/printers_scrap.html
@@ -1,10 +1,20 @@
 {% extends "base.html" %} {% block title %}Hurdalar{% endblock %} {% block
 content %}
-<div class="container-fluid p-3">
-  <h5 class="mb-3">Hurdalar</h5>
-  <div class="page-section">
-    <div class="table-responsive">
-      <table class="table table-sm align-middle table-rounded">
+<div class="container-fluid py-4">
+  <div class="page-shell">
+    <header class="page-header">
+      <div class="page-header__heading">
+        <span class="eyebrow text-primary">Yazıcı Takip</span>
+        <h1 class="page-header__title">Hurdaya Ayrılan Yazıcılar</h1>
+        <p class="page-header__subtitle">
+          Hurdaya ayrılan yazıcı kayıtlarını inceleyin ve detaylara erişin.
+        </p>
+      </div>
+    </header>
+
+    <div class="page-card soft-card">
+      <div class="table-responsive">
+        <table class="table table-sm align-middle table-rounded">
         <thead class="table-light">
           <tr>
             <th>ID</th>
@@ -65,22 +75,32 @@ content %}
           {% endfor %} {% endif %}
         </tbody>
       </table>
+      </div>
     </div>
   </div>
 </div>
 
 <div class="modal fade" id="hurdaDetayModal" tabindex="-1">
-  <div class="modal-dialog modal-lg">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Hurda Detayı</h5>
-        <button
-          class="btn-close"
-          data-bs-dismiss="modal"
-          aria-label="Kapat"
-        ></button>
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+    <div class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Hurda Detayı</h5>
+            <p class="modal-shell__subtitle">
+              Hurdaya ayrılan yazıcıya ilişkin ayrıntılı bilgileri görüntüleyin.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
+          </div>
+        </div>
+        <div class="modal-shell__body" id="hurdaDetayBody">Yükleniyor...</div>
       </div>
-      <div class="modal-body" id="hurdaDetayBody">Yükleniyor...</div>
     </div>
   </div>
 </div>

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -27,105 +27,105 @@ block title %}Talep Takip{% endblock %} {% block content %}
     </header>
 
     {% macro render_table(rows, empty_msg, show_actions=False) %}
-  <div class="table-responsive">
-    <table class="table table-striped table-hover table-sm align-middle">
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Tür</th>
-          <th>Donanım Tipi</th>
-          <th>Marka</th>
-          <th>Model</th>
-          <th>İstenen</th>
-          <th>Karşılanan</th>
-          <th>Kalan</th>
-          <th>Envanter No</th>
-          <th>Lisans Adı</th>
-          <th>Sorumlu</th>
-          <th>Açıklama</th>
-          <th>Tarih</th>
-          {% if show_actions %}
-          <th>İşlem</th>
-          {% endif %}
-        </tr>
-      </thead>
-      <tbody>
-        {% for t in rows %} {% set current_ifs = t.ifs_no or '-' %} {% if
-        loop.changed(current_ifs) %}
-        <tr class="table-light">
-          <td colspan="{{ 14 if show_actions else 13 }}">
-            IFS No: {{ current_ifs }}
-          </td>
-        </tr>
-        {% endif %}
-        <tr>
-          <td>{{ t.id }}</td>
-          <td>{{ t.tur }}</td>
-          <td>{{ t.donanim_tipi or '-' }}</td>
-          <td>{{ t.marka or '-' }}</td>
-          <td>{{ t.model or '-' }}</td>
-          <td>{{ t.miktar or '-' }}</td>
-          <td>{{ t.karsilanan_miktar or '-' }}</td>
-          <td>{{ t.kalan_miktar or '-' }}</td>
-          <td>{{ t.envanter_no or t.bagli_envanter_no or '-' }}</td>
-          <td>{{ t.lisans_adi or '-' }}</td>
-          <td>{{ t.sorumlu_personel or '-' }}</td>
-          <td>{{ t.aciklama or '-' }}</td>
-          <td>
-            {{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }} {% if t.durum !=
-            'acik' and t.kapanma_tarihi %}
-            <br />
-            <small class="text-muted">
-              {{ 'Kapanma: ' if t.durum == 'tamamlandi' else 'İptal: ' }}{{
-              t.kapanma_tarihi.strftime('%Y-%m-%d %H:%M') }}
-            </small>
+    <div class="table-responsive">
+      <table class="table table-striped table-hover table-sm align-middle">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Tür</th>
+            <th>Donanım Tipi</th>
+            <th>Marka</th>
+            <th>Model</th>
+            <th>İstenen</th>
+            <th>Karşılanan</th>
+            <th>Kalan</th>
+            <th>Envanter No</th>
+            <th>Lisans Adı</th>
+            <th>Sorumlu</th>
+            <th>Açıklama</th>
+            <th>Tarih</th>
+            {% if show_actions %}
+            <th>İşlem</th>
             {% endif %}
-          </td>
-          {% if show_actions %}
-          <td>
-            <div class="btn-group">
-              <button
-                class="btn btn-outline-secondary btn-sm dropdown-toggle"
-                data-bs-toggle="dropdown"
-              >
-                İşlem
-              </button>
-              <ul class="dropdown-menu">
-                <li>
-                  <a
-                    class="dropdown-item"
-                    href="#"
-                    onclick="talepIptal({{ t.id }}, {{ t.kalan_miktar }}); return false;"
-                    >İptal Et</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item"
-                    href="#"
-                    onclick="talepKapat({{ t.id }}, {{ t.kalan_miktar }}); return false;"
-                    >Stok Gir</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </td>
+          </tr>
+        </thead>
+        <tbody>
+          {% for t in rows %} {% set current_ifs = t.ifs_no or '-' %} {% if
+          loop.changed(current_ifs) %}
+          <tr class="table-light">
+            <td colspan="{{ 14 if show_actions else 13 }}">
+              IFS No: {{ current_ifs }}
+            </td>
+          </tr>
           {% endif %}
-        </tr>
-        {% endfor %} {% if rows|length == 0 %}
-        <tr>
-          <td
-            colspan="{{ 14 if show_actions else 13 }}"
-            class="text-center text-muted"
-          >
-            {{ empty_msg }}
-          </td>
-        </tr>
-        {% endif %}
-      </tbody>
-    </table>
-  </div>
-  {% endmacro %}
+          <tr>
+            <td>{{ t.id }}</td>
+            <td>{{ t.tur }}</td>
+            <td>{{ t.donanim_tipi or '-' }}</td>
+            <td>{{ t.marka or '-' }}</td>
+            <td>{{ t.model or '-' }}</td>
+            <td>{{ t.miktar or '-' }}</td>
+            <td>{{ t.karsilanan_miktar or '-' }}</td>
+            <td>{{ t.kalan_miktar or '-' }}</td>
+            <td>{{ t.envanter_no or t.bagli_envanter_no or '-' }}</td>
+            <td>{{ t.lisans_adi or '-' }}</td>
+            <td>{{ t.sorumlu_personel or '-' }}</td>
+            <td>{{ t.aciklama or '-' }}</td>
+            <td>
+              {{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }} {% if t.durum
+              != 'acik' and t.kapanma_tarihi %}
+              <br />
+              <small class="text-muted">
+                {{ 'Kapanma: ' if t.durum == 'tamamlandi' else 'İptal: ' }}{{
+                t.kapanma_tarihi.strftime('%Y-%m-%d %H:%M') }}
+              </small>
+              {% endif %}
+            </td>
+            {% if show_actions %}
+            <td>
+              <div class="btn-group">
+                <button
+                  class="btn btn-outline-secondary btn-sm dropdown-toggle"
+                  data-bs-toggle="dropdown"
+                >
+                  İşlem
+                </button>
+                <ul class="dropdown-menu">
+                  <li>
+                    <a
+                      class="dropdown-item"
+                      href="#"
+                      onclick="talepIptal({{ t.id }}, {{ t.kalan_miktar }}); return false;"
+                      >İptal Et</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="dropdown-item"
+                      href="#"
+                      onclick="talepKapat({{ t.id }}, {{ t.kalan_miktar }}); return false;"
+                      >Stok Gir</a
+                    >
+                  </li>
+                </ul>
+              </div>
+            </td>
+            {% endif %}
+          </tr>
+          {% endfor %} {% if rows|length == 0 %}
+          <tr>
+            <td
+              colspan="{{ 14 if show_actions else 13 }}"
+              class="text-center text-muted"
+            >
+              {{ empty_msg }}
+            </td>
+          </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+    {% endmacro %}
     <div class="page-card soft-card stack-md">
       <ul class="nav nav-tabs" id="talepTabs" role="tablist">
         <li class="nav-item" role="presentation">

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -1,23 +1,32 @@
 {% extends "base.html" %} {% from "components/modal.html" import modal %} {%
 block title %}Talep Takip{% endblock %} {% block content %}
-<div class="container-fluid p-3">
-  <div class="d-flex justify-content-between align-items-center mb-3">
-    <h5 class="mb-0">Talepler</h5>
-    <div class="d-flex gap-2">
-      <a href="/requests/export" class="btn btn-outline-secondary btn-sm"
-        >Excel</a
-      >
-      <button
-        class="btn btn-primary btn-sm"
-        data-bs-toggle="modal"
-        data-bs-target="#talepModal"
-      >
-        Talep Aç
-      </button>
-    </div>
-  </div>
+<div class="container-fluid py-4">
+  <div class="page-shell">
+    <header class="page-header">
+      <div class="page-header__heading">
+        <span class="eyebrow text-primary">Talep Takip</span>
+        <h1 class="page-header__title">Talepler</h1>
+        <p class="page-header__subtitle">
+          Talepleri durumlarına göre inceleyin ve hızlıca işlem yapın.
+        </p>
+      </div>
+      <div class="page-header__actions page-actions">
+        <div class="page-actions__group">
+          <a href="/requests/export" class="btn btn-outline-secondary btn-sm"
+            >Excel</a
+          >
+          <button
+            class="btn btn-primary btn-sm"
+            data-bs-toggle="modal"
+            data-bs-target="#talepModal"
+          >
+            Talep Aç
+          </button>
+        </div>
+      </div>
+    </header>
 
-  {% macro render_table(rows, empty_msg, show_actions=False) %}
+    {% macro render_table(rows, empty_msg, show_actions=False) %}
   <div class="table-responsive">
     <table class="table table-striped table-hover table-sm align-middle">
       <thead>
@@ -117,70 +126,74 @@ block title %}Talep Takip{% endblock %} {% block content %}
     </table>
   </div>
   {% endmacro %}
+    <div class="page-card soft-card stack-md">
+      <ul class="nav nav-tabs" id="talepTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button
+            class="nav-link active"
+            id="acik-tab"
+            data-bs-toggle="tab"
+            data-bs-target="#acik"
+            type="button"
+            role="tab"
+          >
+            Açık
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button
+            class="nav-link"
+            id="kapali-tab"
+            data-bs-toggle="tab"
+            data-bs-target="#kapali"
+            type="button"
+            role="tab"
+          >
+            Tamamlandı
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button
+            class="nav-link"
+            id="iptal-tab"
+            data-bs-toggle="tab"
+            data-bs-target="#iptal"
+            type="button"
+            role="tab"
+          >
+            İptal
+          </button>
+        </li>
+      </ul>
 
-  <ul class="nav nav-tabs" id="talepTabs" role="tablist">
-    <li class="nav-item" role="presentation">
-      <button
-        class="nav-link active"
-        id="acik-tab"
-        data-bs-toggle="tab"
-        data-bs-target="#acik"
-        type="button"
-        role="tab"
-      >
-        Açık
-      </button>
-    </li>
-    <li class="nav-item" role="presentation">
-      <button
-        class="nav-link"
-        id="kapali-tab"
-        data-bs-toggle="tab"
-        data-bs-target="#kapali"
-        type="button"
-        role="tab"
-      >
-        Tamamlandı
-      </button>
-    </li>
-    <li class="nav-item" role="presentation">
-      <button
-        class="nav-link"
-        id="iptal-tab"
-        data-bs-toggle="tab"
-        data-bs-target="#iptal"
-        type="button"
-        role="tab"
-      >
-        İptal
-      </button>
-    </li>
-  </ul>
-
-  <div class="tab-content mt-3" id="talepTabsContent">
-    <div
-      class="tab-pane fade show active"
-      id="acik"
-      role="tabpanel"
-      aria-labelledby="acik-tab"
-    >
-      {{ render_table(acik, "Açık talep bulunamadı.", True) }}
-    </div>
-    <div
-      class="tab-pane fade"
-      id="kapali"
-      role="tabpanel"
-      aria-labelledby="kapali-tab"
-    >
-      {{ render_table(kapali, "Tamamlanan talep bulunamadı.") }}
-    </div>
-    <div
-      class="tab-pane fade"
-      id="iptal"
-      role="tabpanel"
-      aria-labelledby="iptal-tab"
-    >
-      {{ render_table(iptal, "İptal talep bulunamadı.") }}
+      <div class="page-section">
+        <div class="tab-content" id="talepTabsContent">
+          <div
+            class="tab-pane fade show active"
+            id="acik"
+            role="tabpanel"
+            aria-labelledby="acik-tab"
+          >
+            {{ render_table(acik, "Açık talep bulunamadı.", True) }}
+          </div>
+          <div
+            class="tab-pane fade"
+            id="kapali"
+            role="tabpanel"
+            aria-labelledby="kapali-tab"
+          >
+            {{ render_table(kapali, "Tamamlanan talep bulunamadı.") }}
+          </div>
+          <div
+            class="tab-pane fade"
+            id="iptal"
+            role="tabpanel"
+            aria-labelledby="iptal-tab"
+          >
+            {{ render_table(iptal, "İptal talep bulunamadı.") }}
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -2,46 +2,59 @@
 {% block title %}Stok Takibi{% endblock %}
 
 {% block content %}
-<div class="container-fluid p-3">
-  <div class="d-flex align-items-center justify-content-between mb-3">
-    <h5 class="mb-0">Stok Takibi</h5>
-    <div class="d-flex gap-2 flex-wrap align-items-center">
-      <button class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#modalStockAdd">
-        <i class="bi bi-plus-lg"></i>
-        <span>Ekle</span>
-      </button>
-      {% with fault_entity='stock', fault_prefix='stock', fault_label='Stok Arızalı Durum' %}
-        {% include 'partials/_fault_controls.html' %}
-      {% endwith %}
-      <div class="dropdown">
-        <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-          Excel
-        </button>
-        <ul class="dropdown-menu dropdown-menu-end">
-          <li><a class="dropdown-item" href="/stock/export">Dışa Aktar</a></li>
-          <li>
-            <form action="/stock/import" method="post" enctype="multipart/form-data">
-              <input type="file" name="file" id="stockExcel" class="d-none" onchange="this.form.submit()">
-              <label for="stockExcel" class="dropdown-item mb-0">İçe Aktar</label>
-            </form>
+<div class="container-fluid py-4">
+  <div class="page-shell">
+    <header class="page-header">
+      <div class="page-header__heading">
+        <span class="eyebrow text-primary">Stok Takip</span>
+        <h1 class="page-header__title">Stok Yönetimi</h1>
+        <p class="page-header__subtitle">
+          Donanım, yazıcı ve lisans stok hareketlerini izleyin ve hızlıca işlem yapın.
+        </p>
+      </div>
+      <div class="page-header__actions page-actions">
+        <div class="page-actions__group">
+          <button class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#modalStockAdd">
+            <i class="bi bi-plus-lg"></i>
+            <span>Ekle</span>
+          </button>
+          {% with fault_entity='stock', fault_prefix='stock', fault_label='Stok Arızalı Durum' %}
+            {% include 'partials/_fault_controls.html' %}
+          {% endwith %}
+          <div class="dropdown">
+            <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+              Excel
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              <li><a class="dropdown-item" href="/stock/export">Dışa Aktar</a></li>
+              <li>
+                <form action="/stock/import" method="post" enctype="multipart/form-data">
+                  <input type="file" name="file" id="stockExcel" class="d-none" onchange="this.form.submit()">
+                  <label for="stockExcel" class="dropdown-item mb-0">İçe Aktar</label>
+                </form>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="page-actions__group page-actions__group--grow">
+          <label for="stockSearch" class="visually-hidden">Ara</label>
+          <input type="text" id="stockSearch" class="form-control form-control-sm" placeholder="Ara">
+        </div>
+      </div>
+    </header>
+
+    <div class="page-card soft-card stack-md">
+      <div class="tabs-wrap">
+        <ul class="nav nav-tabs" id="stockTabs" role="tablist">
+          <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="tab-log" data-bs-toggle="tab" data-bs-target="#pane-log" type="button" role="tab">Log</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link" id="tab-status" data-bs-toggle="tab" data-bs-target="#pane-status" type="button" role="tab">Stok Durumu</button>
           </li>
         </ul>
       </div>
-      <input type="text" id="stockSearch" class="form-control form-control-sm" placeholder="Ara" style="width:200px">
-    </div>
-  </div>
-
-  <div class="tabs-wrap">
-    <ul class="nav nav-tabs" id="stockTabs" role="tablist">
-      <li class="nav-item" role="presentation">
-        <button class="nav-link active" id="tab-log" data-bs-toggle="tab" data-bs-target="#pane-log" type="button" role="tab">Log</button>
-      </li>
-      <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-status" data-bs-toggle="tab" data-bs-target="#pane-status" type="button" role="tab">Stok Durumu</button>
-      </li>
-    </ul>
-  </div>
-  <div class="page-section">
+      <div class="page-section">
     <div class="tab-content" id="stockTabContent">
       <div class="tab-pane fade show active" id="pane-log" role="tabpanel">
         <div class="table-responsive">
@@ -188,15 +201,24 @@
 
 <div class="modal fade" id="stokDetailModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-sm">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Stok Detayı</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
-      </div>
-      <div class="modal-body">
-        <dl class="row mb-0 small" id="stokDetailList"></dl>
-        <div class="mt-3 d-none" id="stokDetailLinkWrap">
-          <a id="stokDetailLink" class="btn btn-link btn-sm ps-0" href="#" target="_blank" rel="noopener">Kaynağı aç</a>
+    <div class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Stok Detayı</h5>
+            <p class="modal-shell__subtitle">
+              Seçili hareket hakkında özet bilgileri görüntüleyin.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+          </div>
+        </div>
+        <div class="modal-shell__body">
+          <dl class="row mb-0 small" id="stokDetailList"></dl>
+          <div class="mt-3 d-none" id="stokDetailLinkWrap">
+            <a id="stokDetailLink" class="btn btn-link btn-sm ps-0" href="#" target="_blank" rel="noopener">Kaynağı aç</a>
+          </div>
         </div>
       </div>
     </div>
@@ -205,68 +227,82 @@
 
 <!-- STOK EKLE MODALI -->
 <div class="modal fade" id="modalStockAdd" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
-    <form id="frmStockAdd" class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Stok Ekle</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
-      </div>
-      <div class="modal-body row g-3">
-        <div class="col-12">
-          <ul class="nav nav-pills" id="stockAddType" role="tablist">
-            <li class="nav-item" role="presentation">
-              <button class="nav-link active" type="button" data-stock-add-type="inventory" aria-selected="true">Envanter</button>
-            </li>
-            <li class="nav-item" role="presentation">
-              <button class="nav-link" type="button" data-stock-add-type="license" aria-selected="false">Lisans</button>
-            </li>
-          </ul>
-        </div>
-
-        <div id="hardwareFields" class="col-12">
-          <div class="row g-3 stok-row">
-            <div class="col-md-3">
-              <label class="form-label">Donanım Tipi</label>
-              <select name="donanim_tipi" class="form-select" data-lookup="donanim_tipi" id="stok_donanim_tipi" required></select>
-            </div>
-            <div class="col-md-3">
-              <label class="form-label">Marka (ops.)</label>
-              <select name="marka" class="form-select" data-lookup="marka" id="stok_marka"></select>
-            </div>
-            <div class="col-md-2">
-              <label class="form-label">Model (ops.)</label>
-              <select name="model" class="form-select" data-lookup="model" data-depends="#stok_marka" id="stok_model"></select>
-            </div>
-            <div class="col-md-2" id="rowMiktar">
-              <label class="form-label">Miktar</label>
-              <input type="number" min="1" id="miktar" name="miktar" class="form-control" required>
-            </div>
-            <div class="col-md-2">
-              <label class="form-label">IFS No (opsiyonel)</label>
-              <input type="text" id="ifs_no" name="ifs_no" class="form-control">
-            </div>
+  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+    <form id="frmStockAdd" class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Stok Ekle</h5>
+            <p class="modal-shell__subtitle">
+              Envanter veya lisans stok hareketlerini sisteme ekleyin.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
           </div>
         </div>
 
-        <div id="licenseFields" class="col-12 row g-3 d-none">
-          <div class="col-md-4">
-            <label class="form-label">Lisans Adı</label>
-            <select id="lisans_adi" name="lisans_adi" class="form-select" data-lookup="lisans_adi" required></select>
+        <div class="modal-shell__body stack-md">
+          <div>
+            <ul class="nav nav-pills" id="stockAddType" role="tablist">
+              <li class="nav-item" role="presentation">
+                <button class="nav-link active" type="button" data-stock-add-type="inventory" aria-selected="true">Envanter</button>
+              </li>
+              <li class="nav-item" role="presentation">
+                <button class="nav-link" type="button" data-stock-add-type="license" aria-selected="false">Lisans</button>
+              </li>
+            </ul>
           </div>
-          <div class="col-md-4">
-            <label class="form-label">Lisans Anahtarı</label>
-            <input type="text" id="lisans_anahtari" name="lisans_anahtari" class="form-control" required>
+
+          <div id="hardwareFields">
+            <div class="form-grid form-grid--compact stok-row">
+              <div class="form-group">
+                <label class="form-label" for="stok_donanim_tipi">Donanım Tipi</label>
+                <select name="donanim_tipi" class="form-select" data-lookup="donanim_tipi" id="stok_donanim_tipi" required></select>
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="stok_marka">Marka (ops.)</label>
+                <select name="marka" class="form-select" data-lookup="marka" id="stok_marka"></select>
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="stok_model">Model (ops.)</label>
+                <select name="model" class="form-select" data-lookup="model" data-depends="#stok_marka" id="stok_model"></select>
+              </div>
+              <div class="form-group" id="rowMiktar">
+                <label class="form-label" for="miktar">Miktar</label>
+                <input type="number" min="1" id="miktar" name="miktar" class="form-control" required>
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="ifs_no">IFS No (opsiyonel)</label>
+                <input type="text" id="ifs_no" name="ifs_no" class="form-control">
+              </div>
+            </div>
           </div>
-          <div class="col-md-4">
-            <label class="form-label">E-posta (opsiyonel)</label>
-            <input type="email" id="mail_adresi" name="mail_adresi" class="form-control">
+
+          <div id="licenseFields" class="d-none">
+            <div class="form-grid form-grid--compact">
+              <div class="form-group">
+                <label class="form-label" for="lisans_adi">Lisans Adı</label>
+                <select id="lisans_adi" name="lisans_adi" class="form-select" data-lookup="lisans_adi" required></select>
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="lisans_anahtari">Lisans Anahtarı</label>
+                <input type="text" id="lisans_anahtari" name="lisans_anahtari" class="form-control" required>
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="mail_adresi">E-posta (opsiyonel)</label>
+                <input type="email" id="mail_adresi" name="mail_adresi" class="form-control">
+              </div>
+            </div>
           </div>
         </div>
 
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-        <button class="btn btn-primary" type="submit">Kaydet</button>
+        <div class="modal-shell__footer">
+          <div class="modal-shell__actions">
+            <button class="btn btn-outline-secondary" data-bs-dismiss="modal" type="button">Kapat</button>
+            <button class="btn btn-primary" type="submit">Kaydet</button>
+          </div>
+        </div>
       </div>
     </form>
   </div>
@@ -274,235 +310,122 @@
 
 <!-- STOK ATAMA MODALI -->
 <div class="modal fade" id="stokAtamaModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-lg">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Stok Atama</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+  <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
+    <div class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <div class="modal-shell__heading">
+            <h5 class="modal-shell__title">Stok Atama</h5>
+            <p class="modal-shell__subtitle">
+              Stok durumu tablosundan seçtiğiniz kalemi envantere, yazıcıya veya lisansa atayın.
+            </p>
+          </div>
+          <div class="modal-shell__header-actions">
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+          </div>
+        </div>
+
+        <div class="modal-shell__body">
+          <form id="stockAssignForm" class="vstack gap-3">
+            <div>
+              <p class="form-label fw-semibold mb-2">Seçilen Stok</p>
+              <div id="sa_stock_alert" class="alert alert-warning py-2 px-3 small mb-0" role="alert">
+                Atama yapmak için stok durumu tablosundaki <strong>Atama</strong> düğmesini kullanınız.
+              </div>
+              <div id="sa_stock_meta" class="mt-2 d-none">
+                <div class="border rounded p-2 small bg-light-subtle">
+                  <div class="d-flex flex-wrap gap-3 align-items-center mb-1">
+                    <span class="fw-semibold" id="sa_meta_tip">-</span>
+                    <span id="sa_meta_brand_wrap" class="d-none"><span class="text-muted">Marka:</span> <span id="sa_meta_brand">-</span></span>
+                    <span id="sa_meta_model_wrap" class="d-none"><span class="text-muted">Model:</span> <span id="sa_meta_model">-</span></span>
+                    <span><span class="text-muted">IFS:</span> <span id="sa_meta_ifs">-</span></span>
+                    <span><span class="text-muted">Mevcut:</span> <span id="sa_meta_qty">0</span></span>
+                  </div>
+                  <div class="d-flex flex-wrap gap-3" id="sa_meta_license_row">
+                    <span id="sa_meta_license_wrap" class="d-none"><span class="text-muted">Lisans:</span> <span id="sa_meta_license">-</span></span>
+                    <span id="sa_meta_mail_wrap" class="d-none"><span class="text-muted">Mail:</span> <span id="sa_meta_mail">-</span></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <label class="form-label fw-semibold">Atama Türü</label>
+              <ul class="nav nav-tabs" id="sa_tabs" role="tablist">
+                <li class="nav-item" role="presentation">
+                  <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#sa_tab_lisans" type="button" role="tab">Lisans</button>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <button class="nav-link" data-bs-toggle="tab" data-bs-target="#sa_tab_envanter" type="button" role="tab">Envanter</button>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <button class="nav-link" data-bs-toggle="tab" data-bs-target="#sa_tab_yazici" type="button" role="tab">Yazıcı</button>
+                </li>
+              </ul>
+
+              <div class="tab-content border border-top-0 p-3 rounded-bottom">
+                <div class="tab-pane fade show active" id="sa_tab_lisans" role="tabpanel">
+                  <div class="form-grid form-grid--compact">
+                    <div class="form-group">
+                      <label class="form-label">Lisans Adı</label>
+                      <select class="form-select" id="sa_license_select" data-stock-assign="license"></select>
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">Sorumlu</label>
+                      <select class="form-select" id="sa_license_owner"></select>
+                    </div>
+                    <div class="form-group form-grid__full">
+                      <label class="form-label">Açıklama</label>
+                      <textarea class="form-control" rows="2" id="sa_license_note" placeholder="Opsiyonel"></textarea>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="tab-pane fade" id="sa_tab_envanter" role="tabpanel">
+                  <div class="form-grid form-grid--compact">
+                    <div class="form-group">
+                      <label class="form-label">Envanter No</label>
+                      <select class="form-select" id="sa_inventory_select" data-stock-assign="inventory"></select>
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">Sorumlu</label>
+                      <select class="form-select" id="sa_inventory_owner"></select>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="tab-pane fade" id="sa_tab_yazici" role="tabpanel">
+                  <div class="form-grid form-grid--compact">
+                    <div class="form-group">
+                      <label class="form-label">Yazıcı</label>
+                      <select class="form-select" id="sa_printer_select" data-stock-assign="printer"></select>
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">Atama Notu</label>
+                      <input type="text" class="form-control" id="sa_printer_note" placeholder="Opsiyonel">
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <label class="form-label" for="sa_general_note">Genel Not (opsiyonel)</label>
+              <textarea class="form-control" rows="3" id="sa_general_note" placeholder="İşlem için genel açıklama..."></textarea>
+            </div>
+          </form>
+        </div>
+
+        <div class="modal-shell__footer">
+          <div class="modal-shell__actions">
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">İptal</button>
+            <button type="submit" form="stockAssignForm" class="btn btn-primary">Atamayı Kaydet</button>
+          </div>
+        </div>
       </div>
-
-      <div class="modal-body">
-        <form id="stockAssignForm" class="vstack gap-3">
-          <!-- 1) STOK SEÇ (Stok Durumu'ndan) -->
-          <div>
-            <p class="form-label fw-semibold mb-2">Seçilen Stok</p>
-            <div id="sa_stock_alert" class="alert alert-warning py-2 px-3 small mb-0" role="alert">
-              Atama yapmak için stok durumu tablosundaki <strong>Atama</strong> düğmesini kullanınız.
-            </div>
-            <div id="sa_stock_meta" class="mt-2 d-none">
-              <div class="border rounded p-2 small bg-light-subtle">
-                <div class="d-flex flex-wrap gap-3 align-items-center mb-1">
-                  <span class="fw-semibold" id="sa_meta_tip">-</span>
-                  <span id="sa_meta_brand_wrap" class="d-none"><span class="text-muted">Marka:</span> <span id="sa_meta_brand">-</span></span>
-                  <span id="sa_meta_model_wrap" class="d-none"><span class="text-muted">Model:</span> <span id="sa_meta_model">-</span></span>
-                  <span><span class="text-muted">IFS:</span> <span id="sa_meta_ifs">-</span></span>
-                  <span><span class="text-muted">Mevcut:</span> <span id="sa_meta_qty">0</span></span>
-                </div>
-                <div class="d-flex flex-wrap gap-3" id="sa_meta_license_row">
-                  <span id="sa_meta_license_wrap" class="d-none"><span class="text-muted">Lisans:</span> <span id="sa_meta_license">-</span></span>
-                  <span id="sa_meta_mail_wrap" class="d-none"><span class="text-muted">Mail:</span> <span id="sa_meta_mail">-</span></span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- 2) Atama Türü -->
-          <div>
-            <label class="form-label fw-semibold">Atama Türü</label>
-            <ul class="nav nav-tabs" id="sa_tabs" role="tablist">
-              <li class="nav-item" role="presentation">
-                <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#sa_tab_lisans" type="button" role="tab">Lisans</button>
-              </li>
-              <li class="nav-item" role="presentation">
-                <button class="nav-link" data-bs-toggle="tab" data-bs-target="#sa_tab_envanter" type="button" role="tab">Envanter</button>
-              </li>
-              <li class="nav-item" role="presentation">
-                <button class="nav-link" data-bs-toggle="tab" data-bs-target="#sa_tab_yazici" type="button" role="tab">Yazıcı</button>
-              </li>
-            </ul>
-
-            <div class="tab-content border border-top-0 p-3 rounded-bottom">
-              <!-- LISANS -->
-              <div class="tab-pane fade show active" id="sa_tab_lisans" role="tabpanel">
-                <div class="row g-3" id="sa_license_form">
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">Lisans Adı</label>
-                    <input id="sa_license_name" class="form-control" data-auto-key="lisans_adi|donanim_tipi" data-auto-source="lisans" placeholder="Lisans adı" required>
-                  </div>
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">Lisans Anahtarı</label>
-                    <input id="sa_license_key" class="form-control" data-auto-key="lisans_anahtari" data-auto-source="lisans" placeholder="Lisans anahtarı">
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Sorumlu Personel</label>
-                    <select id="sa_license_person" class="form-select" data-no-search data-auto-key="sorumlu_personel" data-auto-source="lisans">
-                      <option value="">Seçiniz...</option>
-                    </select>
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Bağlı Envanter (opsiyonel)</label>
-                    <select id="sa_license_inventory" class="form-select" data-no-search data-auto-key="bagli_envanter_no" data-auto-source="lisans">
-                      <option value="">Seçiniz...</option>
-                    </select>
-                  </div>
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">IFS No</label>
-                    <input id="sa_license_ifs" class="form-control" data-auto-key="ifs_no" data-auto-source="lisans" placeholder="IFS No">
-                  </div>
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">Mail Adresi</label>
-                    <input id="sa_license_mail" type="email" class="form-control" data-auto-key="mail_adresi" data-auto-source="lisans" placeholder="ornek@firma.com">
-                  </div>
-                </div>
-              </div>
-
-              <!-- ENVANTER -->
-              <div class="tab-pane fade" id="sa_tab_envanter" role="tabpanel">
-                <div class="row g-3" id="sa_inventory_form">
-                  <div class="col-md-6">
-                    <label class="form-label">Envanter No</label>
-                    <input id="sa_inv_no" class="form-control" data-auto-key="envanter_no" data-auto-source="envanter" placeholder="ENV-000123" required>
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Bilgisayar Adı</label>
-                    <input id="sa_inv_pc" class="form-control" data-auto-key="bilgisayar_adi" data-auto-source="envanter" placeholder="PC-OFIS-01">
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Fabrika</label>
-                    <select id="sa_inv_factory" class="form-select" data-no-search data-auto-key="fabrika" data-auto-source="envanter">
-                      <option value="">Seçiniz...</option>
-                    </select>
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Departman</label>
-                    <select id="sa_inv_department" class="form-select" data-no-search data-auto-key="departman" data-auto-source="envanter">
-                      <option value="">Seçiniz...</option>
-                    </select>
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Kullanım Alanı</label>
-                    <select id="sa_inv_usage" class="form-select" data-no-search data-auto-key="kullanim_alani" data-auto-source="envanter">
-                      <option value="">Seçiniz...</option>
-                    </select>
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Sorumlu Personel</label>
-                    <select id="sa_inv_person" class="form-select" data-no-search data-auto-key="sorumlu_personel" data-auto-source="envanter">
-                      <option value="">Seçiniz...</option>
-                    </select>
-                  </div>
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">Donanım Tipi</label>
-                    <input id="sa_inv_hardware" class="form-control" data-auto-key="donanim_tipi" placeholder="Donanım tipi">
-                  </div>
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">Marka</label>
-                    <input id="sa_inv_brand" class="form-control" data-auto-key="marka" placeholder="Marka">
-                  </div>
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">Model</label>
-                    <input id="sa_inv_model" class="form-control" data-auto-key="model" placeholder="Model">
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Seri No</label>
-                    <input id="sa_inv_serial" class="form-control" data-auto-key="seri_no" data-auto-source="envanter" placeholder="Seri no">
-                  </div>
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">IFS No</label>
-                    <input id="sa_inv_ifs" class="form-control" data-auto-key="ifs_no" placeholder="IFS No">
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Bağlı Makina No</label>
-                    <input id="sa_inv_machine" class="form-control" data-auto-key="bagli_envanter_no" data-auto-source="envanter" placeholder="Makina no">
-                  </div>
-                  <div class="col-12">
-                    <label class="form-label">Notlar (opsiyonel)</label>
-                    <textarea id="sa_inv_note" class="form-control" rows="2" data-auto-key="notlar" data-auto-source="envanter" placeholder="Ek bilgi"></textarea>
-                  </div>
-                </div>
-              </div>
-
-              <!-- YAZICI -->
-              <div class="tab-pane fade" id="sa_tab_yazici" role="tabpanel">
-                <div class="row g-3" id="sa_printer_form">
-                  <div class="col-md-6">
-                    <label class="form-label">Envanter No</label>
-                    <input id="sa_prn_no" class="form-control" data-auto-key="envanter_no" data-auto-source="yazici" placeholder="PRN-000123" required>
-                  </div>
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">Marka</label>
-                    <input id="sa_prn_brand" class="form-control" data-auto-key="marka" placeholder="Marka">
-                  </div>
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">Model</label>
-                    <input id="sa_prn_model" class="form-control" data-auto-key="model" placeholder="Model">
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Kullanım Alanı</label>
-                    <select id="sa_prn_usage" class="form-select" data-no-search data-auto-key="kullanim_alani" data-auto-source="yazici">
-                      <option value="">Seçiniz...</option>
-                    </select>
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">IP Adresi</label>
-                    <input id="sa_prn_ip" class="form-control" data-auto-key="ip_adresi" data-auto-source="yazici" placeholder="192.168.x.x">
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">MAC</label>
-                    <input id="sa_prn_mac" class="form-control" data-auto-key="mac" data-auto-source="yazici" placeholder="AA:BB:CC:DD:EE:FF">
-                  </div>
-                  <div class="col-md-6">
-                    <label class="form-label">Hostname</label>
-                    <input id="sa_prn_host" class="form-control" data-auto-key="hostname" data-auto-source="yazici" placeholder="Yazıcı adı">
-                  </div>
-                  <div class="col-md-6" data-auto-field>
-                    <label class="form-label">IFS No</label>
-                    <input id="sa_prn_ifs" class="form-control" data-auto-key="ifs_no" placeholder="IFS No">
-                  </div>
-                  <div class="col-12">
-                    <label class="form-label">Notlar (opsiyonel)</label>
-                    <textarea id="sa_prn_note" class="form-control" rows="2" data-auto-key="notlar" data-auto-source="yazici" placeholder="Ek bilgi"></textarea>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- 3) Genel Alanlar -->
-          <div class="row g-3">
-            <div class="col-md-4">
-              <label class="form-label">Miktar</label>
-              <input id="sa_miktar" type="number" class="form-control" value="1" min="1" readonly>
-              <div class="form-text">Atamalar tekil kayıt oluşturur.</div>
-            </div>
-            <div class="col-md-8">
-              <label class="form-label">Notlar (opsiyonel)</label>
-              <input id="sa_not" type="text" class="form-control" placeholder="İsteğe bağlı açıklama">
-            </div>
-          </div>
-        </form>
-      </div>
-
-      <div class="modal-footer">
-        <button class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-        <button id="sa_submit" class="btn btn-primary">Atamayı Yap</button>
-  </div>
+    </div>
   </div>
 </div>
-</div>
-</div>
-
-<!-- Lookup ile doldurulacak örnek selectler -->
-<div class="d-none" id="lookup-demo-selects">
-  <select id="stok_durumu_select" class="form-select" name="stok_durumu"></select>
-  <select id="islem_select" class="form-select" name="islem"></select>
-  <select id="donanim_tipi_select" class="form-select" name="donanim_tipi"></select>
-  <!-- <select id="ifs_no_select" class="form-select" name="ifs_no"></select> -->
-</div>
-{% endblock %}
-
-{% block scripts %}
-<script src="/static/js/stock.js"></script>
 <script>
 async function fillSelect(id, entity) {
   const el = document.getElementById(id);

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -1,7 +1,5 @@
-{% extends "base.html" %}
-{% block title %}Stok Takibi{% endblock %}
-
-{% block content %}
+{% extends "base.html" %} {% block title %}Stok Takibi{% endblock %} {% block
+content %}
 <div class="container-fluid py-4">
   <div class="page-shell">
     <header class="page-header">
@@ -9,28 +7,53 @@
         <span class="eyebrow text-primary">Stok Takip</span>
         <h1 class="page-header__title">Stok Yönetimi</h1>
         <p class="page-header__subtitle">
-          Donanım, yazıcı ve lisans stok hareketlerini izleyin ve hızlıca işlem yapın.
+          Donanım, yazıcı ve lisans stok hareketlerini izleyin ve hızlıca işlem
+          yapın.
         </p>
       </div>
       <div class="page-header__actions page-actions">
         <div class="page-actions__group">
-          <button class="btn btn-success btn-sm d-flex align-items-center gap-1" title="Yeni Ekle" data-bs-toggle="modal" data-bs-target="#modalStockAdd">
+          <button
+            class="btn btn-success btn-sm d-flex align-items-center gap-1"
+            title="Yeni Ekle"
+            data-bs-toggle="modal"
+            data-bs-target="#modalStockAdd"
+          >
             <i class="bi bi-plus-lg"></i>
             <span>Ekle</span>
           </button>
-          {% with fault_entity='stock', fault_prefix='stock', fault_label='Stok Arızalı Durum' %}
-            {% include 'partials/_fault_controls.html' %}
-          {% endwith %}
+          {% with fault_entity='stock', fault_prefix='stock', fault_label='Stok
+          Arızalı Durum' %} {% include 'partials/_fault_controls.html' %} {%
+          endwith %}
           <div class="dropdown">
-            <button class="btn btn-outline-primary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <button
+              class="btn btn-outline-primary btn-sm dropdown-toggle"
+              type="button"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+            >
               Excel
             </button>
             <ul class="dropdown-menu dropdown-menu-end">
-              <li><a class="dropdown-item" href="/stock/export">Dışa Aktar</a></li>
               <li>
-                <form action="/stock/import" method="post" enctype="multipart/form-data">
-                  <input type="file" name="file" id="stockExcel" class="d-none" onchange="this.form.submit()">
-                  <label for="stockExcel" class="dropdown-item mb-0">İçe Aktar</label>
+                <a class="dropdown-item" href="/stock/export">Dışa Aktar</a>
+              </li>
+              <li>
+                <form
+                  action="/stock/import"
+                  method="post"
+                  enctype="multipart/form-data"
+                >
+                  <input
+                    type="file"
+                    name="file"
+                    id="stockExcel"
+                    class="d-none"
+                    onchange="this.form.submit()"
+                  />
+                  <label for="stockExcel" class="dropdown-item mb-0"
+                    >İçe Aktar</label
+                  >
                 </form>
               </li>
             </ul>
@@ -38,7 +61,12 @@
         </div>
         <div class="page-actions__group page-actions__group--grow">
           <label for="stockSearch" class="visually-hidden">Ara</label>
-          <input type="text" id="stockSearch" class="form-control form-control-sm" placeholder="Ara">
+          <input
+            type="text"
+            id="stockSearch"
+            class="form-control form-control-sm"
+            placeholder="Ara"
+          />
         </div>
       </div>
     </header>
@@ -47,422 +75,803 @@
       <div class="tabs-wrap">
         <ul class="nav nav-tabs" id="stockTabs" role="tablist">
           <li class="nav-item" role="presentation">
-            <button class="nav-link active" id="tab-log" data-bs-toggle="tab" data-bs-target="#pane-log" type="button" role="tab">Log</button>
+            <button
+              class="nav-link active"
+              id="tab-log"
+              data-bs-toggle="tab"
+              data-bs-target="#pane-log"
+              type="button"
+              role="tab"
+            >
+              Log
+            </button>
           </li>
           <li class="nav-item" role="presentation">
-            <button class="nav-link" id="tab-status" data-bs-toggle="tab" data-bs-target="#pane-status" type="button" role="tab">Stok Durumu</button>
+            <button
+              class="nav-link"
+              id="tab-status"
+              data-bs-toggle="tab"
+              data-bs-target="#pane-status"
+              type="button"
+              role="tab"
+            >
+              Stok Durumu
+            </button>
           </li>
         </ul>
       </div>
       <div class="page-section">
-    <div class="tab-content" id="stockTabContent">
-      <div class="tab-pane fade show active" id="pane-log" role="tabpanel">
-        <div class="table-responsive">
-          <table class="table table-sm align-middle table-rounded">
-            <thead class="table-light">
-              <tr>
-                <th style="width:72px;">ID</th>
-                <th>Donanım Tipi</th>
-                <th>Miktar</th>
-                <th>IFS No</th>
-                <th>Tarih</th>
-                <th>İşlem</th>
-                <th>İşlem Yapan</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for r in logs %}
-              <tr>
-                <td>#{{ r.id }}</td>
-                <td>{{ hardware_map.get(r.donanim_tipi) or license_map.get(r.donanim_tipi) or r.donanim_tipi }}</td>
-                <td>{{ r.miktar }}</td>
-                <td>{{ r.ifs_no or '-' }}</td>
-                <td>{{ (r.tarih).strftime("%d.%m.%Y %H:%M") if r.tarih else '-' }}</td>
-                <td>
-                  {% if r.islem == 'girdi' %}<span class="badge text-bg-success">Girdi</span>
-                  {% elif r.islem == 'cikti' %}<span class="badge text-bg-warning">Çıktı</span>
-                  {% else %}<span class="badge text-bg-secondary">Atama</span>{% endif %}
-                </td>
-                <td>{{ r.actor or '-' }}</td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <div class="tab-pane fade" id="pane-status" role="tabpanel">
-        <div class="tabs-wrap mt-3">
-          <ul class="nav nav-tabs" id="stockStatusTabs" role="tablist">
-            <li class="nav-item" role="presentation">
-              <button class="nav-link active" id="status-tab-inventory" data-bs-toggle="tab" data-bs-target="#stock-status-inventory" type="button" role="tab" aria-controls="stock-status-inventory" aria-selected="true">Envanter</button>
-            </li>
-            <li class="nav-item" role="presentation">
-              <button class="nav-link" id="status-tab-printer" data-bs-toggle="tab" data-bs-target="#stock-status-printer" type="button" role="tab" aria-controls="stock-status-printer" aria-selected="false">Yazıcı</button>
-            </li>
-            <li class="nav-item" role="presentation">
-              <button class="nav-link" id="status-tab-license" data-bs-toggle="tab" data-bs-target="#stock-status-license" type="button" role="tab" aria-controls="stock-status-license" aria-selected="false">Yazılım</button>
-            </li>
-            <li class="nav-item" role="presentation">
-              <button class="nav-link" id="status-tab-system-room" data-bs-toggle="tab" data-bs-target="#stock-status-system-room" type="button" role="tab" aria-controls="stock-status-system-room" aria-selected="false">Sistem Odası</button>
-            </li>
-          </ul>
-        </div>
-        <div class="d-flex justify-content-end gap-2 mt-3">
-          <button type="button" class="btn btn-outline-secondary btn-sm" id="btnSystemRoomAdd" disabled>Seçilenleri Sistem Odasına Ata</button>
-          <button type="button" class="btn btn-outline-danger btn-sm" id="btnSystemRoomRemove" disabled>Seçilenleri Sistem Odasından Çıkar</button>
-        </div>
-        <div class="tab-content mt-3" id="stockStatusTabContent">
-          <div class="tab-pane fade show active" id="stock-status-inventory" role="tabpanel" aria-labelledby="status-tab-inventory">
+        <div class="tab-content" id="stockTabContent">
+          <div class="tab-pane fade show active" id="pane-log" role="tabpanel">
             <div class="table-responsive">
-              <table class="table table-sm stock-status-table table-rounded" id="tblStockStatusInventory">
+              <table class="table table-sm align-middle table-rounded">
                 <thead class="table-light">
                   <tr>
-                    <th class="text-center" style="width: 42px;"><span class="visually-hidden">Seç</span></th>
+                    <th style="width: 72px">ID</th>
                     <th>Donanım Tipi</th>
-                    <th>Marka</th>
-                    <th>Model</th>
+                    <th>Miktar</th>
                     <th>IFS No</th>
-                    <th class="text-end">Stok</th>
-                    <th>Son İşlem</th>
-                    <th class="text-center">İşlemler</th>
-                    <th class="text-center">Sistem Odası</th>
+                    <th>Tarih</th>
+                    <th>İşlem</th>
+                    <th>İşlem Yapan</th>
                   </tr>
                 </thead>
-                <tbody></tbody>
+                <tbody>
+                  {% for r in logs %}
+                  <tr>
+                    <td>#{{ r.id }}</td>
+                    <td>
+                      {{ hardware_map.get(r.donanim_tipi) or
+                      license_map.get(r.donanim_tipi) or r.donanim_tipi }}
+                    </td>
+                    <td>{{ r.miktar }}</td>
+                    <td>{{ r.ifs_no or '-' }}</td>
+                    <td>
+                      {{ (r.tarih).strftime("%d.%m.%Y %H:%M") if r.tarih else
+                      '-' }}
+                    </td>
+                    <td>
+                      {% if r.islem == 'girdi' %}<span
+                        class="badge text-bg-success"
+                        >Girdi</span
+                      >
+                      {% elif r.islem == 'cikti' %}<span
+                        class="badge text-bg-warning"
+                        >Çıktı</span
+                      >
+                      {% else %}<span class="badge text-bg-secondary"
+                        >Atama</span
+                      >{% endif %}
+                    </td>
+                    <td>{{ r.actor or '-' }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
               </table>
             </div>
           </div>
-          <div class="tab-pane fade" id="stock-status-printer" role="tabpanel" aria-labelledby="status-tab-printer">
-            <div class="table-responsive">
-              <table class="table table-sm stock-status-table table-rounded" id="tblStockStatusPrinters">
-                <thead class="table-light">
-                  <tr>
-                    <th class="text-center" style="width: 42px;"><span class="visually-hidden">Seç</span></th>
-                    <th>Donanım Tipi</th>
-                    <th>Marka</th>
-                    <th>Model</th>
-                    <th>IFS No</th>
-                    <th class="text-end">Stok</th>
-                    <th>Son İşlem</th>
-                    <th class="text-center">İşlemler</th>
-                    <th class="text-center">Sistem Odası</th>
-                  </tr>
-                </thead>
-                <tbody></tbody>
-              </table>
-            </div>
-          </div>
-          <div class="tab-pane fade" id="stock-status-license" role="tabpanel" aria-labelledby="status-tab-license">
-            <div class="table-responsive">
-              <table class="table table-sm stock-status-table table-rounded" id="tblStockStatusLicense">
-                <thead class="table-light">
-                  <tr>
-                    <th class="text-center" style="width: 42px;"><span class="visually-hidden">Seç</span></th>
-                    <th>Donanım Tipi</th>
-                    <th>Marka</th>
-                    <th>Model</th>
-                    <th>IFS No</th>
-                    <th class="text-end">Stok</th>
-                    <th>Son İşlem</th>
-                    <th class="text-center">İşlemler</th>
-                    <th class="text-center">Sistem Odası</th>
-                  </tr>
-                </thead>
-                <tbody></tbody>
-              </table>
-            </div>
-          </div>
-          <div class="tab-pane fade" id="stock-status-system-room" role="tabpanel" aria-labelledby="status-tab-system-room">
-            <div class="table-responsive">
-              <table class="table table-sm stock-status-table table-rounded" id="tblStockStatusSystemRoom">
-                <thead class="table-light">
-                  <tr>
-                    <th class="text-center" style="width: 42px;"><span class="visually-hidden">Seç</span></th>
-                    <th>Tür</th>
-                    <th>Donanım Tipi</th>
-                    <th>Marka</th>
-                    <th>Model</th>
-                    <th>IFS No</th>
-                    <th class="text-end">Stok</th>
-                    <th>Son İşlem</th>
-                    <th>Atayan</th>
-                    <th class="text-center">İşlem</th>
-                  </tr>
-                </thead>
-                <tbody></tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="modal fade" id="stokDetailModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-sm">
-    <div class="modal-content border-0 bg-transparent p-0">
-      <div class="modal-shell">
-        <div class="modal-shell__header">
-          <div class="modal-shell__heading">
-            <h5 class="modal-shell__title">Stok Detayı</h5>
-            <p class="modal-shell__subtitle">
-              Seçili hareket hakkında özet bilgileri görüntüleyin.
-            </p>
-          </div>
-          <div class="modal-shell__header-actions">
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
-          </div>
-        </div>
-        <div class="modal-shell__body">
-          <dl class="row mb-0 small" id="stokDetailList"></dl>
-          <div class="mt-3 d-none" id="stokDetailLinkWrap">
-            <a id="stokDetailLink" class="btn btn-link btn-sm ps-0" href="#" target="_blank" rel="noopener">Kaynağı aç</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<!-- STOK EKLE MODALI -->
-<div class="modal fade" id="modalStockAdd" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
-    <form id="frmStockAdd" class="modal-content border-0 bg-transparent p-0">
-      <div class="modal-shell">
-        <div class="modal-shell__header">
-          <div class="modal-shell__heading">
-            <h5 class="modal-shell__title">Stok Ekle</h5>
-            <p class="modal-shell__subtitle">
-              Envanter veya lisans stok hareketlerini sisteme ekleyin.
-            </p>
-          </div>
-          <div class="modal-shell__header-actions">
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
-          </div>
-        </div>
-
-        <div class="modal-shell__body stack-md">
-          <div>
-            <ul class="nav nav-pills" id="stockAddType" role="tablist">
-              <li class="nav-item" role="presentation">
-                <button class="nav-link active" type="button" data-stock-add-type="inventory" aria-selected="true">Envanter</button>
-              </li>
-              <li class="nav-item" role="presentation">
-                <button class="nav-link" type="button" data-stock-add-type="license" aria-selected="false">Lisans</button>
-              </li>
-            </ul>
-          </div>
-
-          <div id="hardwareFields">
-            <div class="form-grid form-grid--compact stok-row">
-              <div class="form-group">
-                <label class="form-label" for="stok_donanim_tipi">Donanım Tipi</label>
-                <select name="donanim_tipi" class="form-select" data-lookup="donanim_tipi" id="stok_donanim_tipi" required></select>
-              </div>
-              <div class="form-group">
-                <label class="form-label" for="stok_marka">Marka (ops.)</label>
-                <select name="marka" class="form-select" data-lookup="marka" id="stok_marka"></select>
-              </div>
-              <div class="form-group">
-                <label class="form-label" for="stok_model">Model (ops.)</label>
-                <select name="model" class="form-select" data-lookup="model" data-depends="#stok_marka" id="stok_model"></select>
-              </div>
-              <div class="form-group" id="rowMiktar">
-                <label class="form-label" for="miktar">Miktar</label>
-                <input type="number" min="1" id="miktar" name="miktar" class="form-control" required>
-              </div>
-              <div class="form-group">
-                <label class="form-label" for="ifs_no">IFS No (opsiyonel)</label>
-                <input type="text" id="ifs_no" name="ifs_no" class="form-control">
-              </div>
-            </div>
-          </div>
-
-          <div id="licenseFields" class="d-none">
-            <div class="form-grid form-grid--compact">
-              <div class="form-group">
-                <label class="form-label" for="lisans_adi">Lisans Adı</label>
-                <select id="lisans_adi" name="lisans_adi" class="form-select" data-lookup="lisans_adi" required></select>
-              </div>
-              <div class="form-group">
-                <label class="form-label" for="lisans_anahtari">Lisans Anahtarı</label>
-                <input type="text" id="lisans_anahtari" name="lisans_anahtari" class="form-control" required>
-              </div>
-              <div class="form-group">
-                <label class="form-label" for="mail_adresi">E-posta (opsiyonel)</label>
-                <input type="email" id="mail_adresi" name="mail_adresi" class="form-control">
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="modal-shell__footer">
-          <div class="modal-shell__actions">
-            <button class="btn btn-outline-secondary" data-bs-dismiss="modal" type="button">Kapat</button>
-            <button class="btn btn-primary" type="submit">Kaydet</button>
-          </div>
-        </div>
-      </div>
-    </form>
-  </div>
-</div>
-
-<!-- STOK ATAMA MODALI -->
-<div class="modal fade" id="stokAtamaModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
-    <div class="modal-content border-0 bg-transparent p-0">
-      <div class="modal-shell">
-        <div class="modal-shell__header">
-          <div class="modal-shell__heading">
-            <h5 class="modal-shell__title">Stok Atama</h5>
-            <p class="modal-shell__subtitle">
-              Stok durumu tablosundan seçtiğiniz kalemi envantere, yazıcıya veya lisansa atayın.
-            </p>
-          </div>
-          <div class="modal-shell__header-actions">
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
-          </div>
-        </div>
-
-        <div class="modal-shell__body">
-          <form id="stockAssignForm" class="vstack gap-3">
-            <div>
-              <p class="form-label fw-semibold mb-2">Seçilen Stok</p>
-              <div id="sa_stock_alert" class="alert alert-warning py-2 px-3 small mb-0" role="alert">
-                Atama yapmak için stok durumu tablosundaki <strong>Atama</strong> düğmesini kullanınız.
-              </div>
-              <div id="sa_stock_meta" class="mt-2 d-none">
-                <div class="border rounded p-2 small bg-light-subtle">
-                  <div class="d-flex flex-wrap gap-3 align-items-center mb-1">
-                    <span class="fw-semibold" id="sa_meta_tip">-</span>
-                    <span id="sa_meta_brand_wrap" class="d-none"><span class="text-muted">Marka:</span> <span id="sa_meta_brand">-</span></span>
-                    <span id="sa_meta_model_wrap" class="d-none"><span class="text-muted">Model:</span> <span id="sa_meta_model">-</span></span>
-                    <span><span class="text-muted">IFS:</span> <span id="sa_meta_ifs">-</span></span>
-                    <span><span class="text-muted">Mevcut:</span> <span id="sa_meta_qty">0</span></span>
-                  </div>
-                  <div class="d-flex flex-wrap gap-3" id="sa_meta_license_row">
-                    <span id="sa_meta_license_wrap" class="d-none"><span class="text-muted">Lisans:</span> <span id="sa_meta_license">-</span></span>
-                    <span id="sa_meta_mail_wrap" class="d-none"><span class="text-muted">Mail:</span> <span id="sa_meta_mail">-</span></span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div>
-              <label class="form-label fw-semibold">Atama Türü</label>
-              <ul class="nav nav-tabs" id="sa_tabs" role="tablist">
+          <div class="tab-pane fade" id="pane-status" role="tabpanel">
+            <div class="tabs-wrap mt-3">
+              <ul class="nav nav-tabs" id="stockStatusTabs" role="tablist">
                 <li class="nav-item" role="presentation">
-                  <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#sa_tab_lisans" type="button" role="tab">Lisans</button>
+                  <button
+                    class="nav-link active"
+                    id="status-tab-inventory"
+                    data-bs-toggle="tab"
+                    data-bs-target="#stock-status-inventory"
+                    type="button"
+                    role="tab"
+                    aria-controls="stock-status-inventory"
+                    aria-selected="true"
+                  >
+                    Envanter
+                  </button>
                 </li>
                 <li class="nav-item" role="presentation">
-                  <button class="nav-link" data-bs-toggle="tab" data-bs-target="#sa_tab_envanter" type="button" role="tab">Envanter</button>
+                  <button
+                    class="nav-link"
+                    id="status-tab-printer"
+                    data-bs-toggle="tab"
+                    data-bs-target="#stock-status-printer"
+                    type="button"
+                    role="tab"
+                    aria-controls="stock-status-printer"
+                    aria-selected="false"
+                  >
+                    Yazıcı
+                  </button>
                 </li>
                 <li class="nav-item" role="presentation">
-                  <button class="nav-link" data-bs-toggle="tab" data-bs-target="#sa_tab_yazici" type="button" role="tab">Yazıcı</button>
+                  <button
+                    class="nav-link"
+                    id="status-tab-license"
+                    data-bs-toggle="tab"
+                    data-bs-target="#stock-status-license"
+                    type="button"
+                    role="tab"
+                    aria-controls="stock-status-license"
+                    aria-selected="false"
+                  >
+                    Yazılım
+                  </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <button
+                    class="nav-link"
+                    id="status-tab-system-room"
+                    data-bs-toggle="tab"
+                    data-bs-target="#stock-status-system-room"
+                    type="button"
+                    role="tab"
+                    aria-controls="stock-status-system-room"
+                    aria-selected="false"
+                  >
+                    Sistem Odası
+                  </button>
                 </li>
               </ul>
+            </div>
+            <div class="d-flex justify-content-end gap-2 mt-3">
+              <button
+                type="button"
+                class="btn btn-outline-secondary btn-sm"
+                id="btnSystemRoomAdd"
+                disabled
+              >
+                Seçilenleri Sistem Odasına Ata
+              </button>
+              <button
+                type="button"
+                class="btn btn-outline-danger btn-sm"
+                id="btnSystemRoomRemove"
+                disabled
+              >
+                Seçilenleri Sistem Odasından Çıkar
+              </button>
+            </div>
+            <div class="tab-content mt-3" id="stockStatusTabContent">
+              <div
+                class="tab-pane fade show active"
+                id="stock-status-inventory"
+                role="tabpanel"
+                aria-labelledby="status-tab-inventory"
+              >
+                <div class="table-responsive">
+                  <table
+                    class="table table-sm stock-status-table table-rounded"
+                    id="tblStockStatusInventory"
+                  >
+                    <thead class="table-light">
+                      <tr>
+                        <th class="text-center" style="width: 42px">
+                          <span class="visually-hidden">Seç</span>
+                        </th>
+                        <th>Donanım Tipi</th>
+                        <th>Marka</th>
+                        <th>Model</th>
+                        <th>IFS No</th>
+                        <th class="text-end">Stok</th>
+                        <th>Son İşlem</th>
+                        <th class="text-center">İşlemler</th>
+                        <th class="text-center">Sistem Odası</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </div>
+              <div
+                class="tab-pane fade"
+                id="stock-status-printer"
+                role="tabpanel"
+                aria-labelledby="status-tab-printer"
+              >
+                <div class="table-responsive">
+                  <table
+                    class="table table-sm stock-status-table table-rounded"
+                    id="tblStockStatusPrinters"
+                  >
+                    <thead class="table-light">
+                      <tr>
+                        <th class="text-center" style="width: 42px">
+                          <span class="visually-hidden">Seç</span>
+                        </th>
+                        <th>Donanım Tipi</th>
+                        <th>Marka</th>
+                        <th>Model</th>
+                        <th>IFS No</th>
+                        <th class="text-end">Stok</th>
+                        <th>Son İşlem</th>
+                        <th class="text-center">İşlemler</th>
+                        <th class="text-center">Sistem Odası</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </div>
+              <div
+                class="tab-pane fade"
+                id="stock-status-license"
+                role="tabpanel"
+                aria-labelledby="status-tab-license"
+              >
+                <div class="table-responsive">
+                  <table
+                    class="table table-sm stock-status-table table-rounded"
+                    id="tblStockStatusLicense"
+                  >
+                    <thead class="table-light">
+                      <tr>
+                        <th class="text-center" style="width: 42px">
+                          <span class="visually-hidden">Seç</span>
+                        </th>
+                        <th>Donanım Tipi</th>
+                        <th>Marka</th>
+                        <th>Model</th>
+                        <th>IFS No</th>
+                        <th class="text-end">Stok</th>
+                        <th>Son İşlem</th>
+                        <th class="text-center">İşlemler</th>
+                        <th class="text-center">Sistem Odası</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </div>
+              <div
+                class="tab-pane fade"
+                id="stock-status-system-room"
+                role="tabpanel"
+                aria-labelledby="status-tab-system-room"
+              >
+                <div class="table-responsive">
+                  <table
+                    class="table table-sm stock-status-table table-rounded"
+                    id="tblStockStatusSystemRoom"
+                  >
+                    <thead class="table-light">
+                      <tr>
+                        <th class="text-center" style="width: 42px">
+                          <span class="visually-hidden">Seç</span>
+                        </th>
+                        <th>Tür</th>
+                        <th>Donanım Tipi</th>
+                        <th>Marka</th>
+                        <th>Model</th>
+                        <th>IFS No</th>
+                        <th class="text-end">Stok</th>
+                        <th>Son İşlem</th>
+                        <th>Atayan</th>
+                        <th class="text-center">İşlem</th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
 
-              <div class="tab-content border border-top-0 p-3 rounded-bottom">
-                <div class="tab-pane fade show active" id="sa_tab_lisans" role="tabpanel">
-                  <div class="form-grid form-grid--compact">
-                    <div class="form-group">
-                      <label class="form-label">Lisans Adı</label>
-                      <select class="form-select" id="sa_license_select" data-stock-assign="license"></select>
-                    </div>
-                    <div class="form-group">
-                      <label class="form-label">Sorumlu</label>
-                      <select class="form-select" id="sa_license_owner"></select>
-                    </div>
-                    <div class="form-group form-grid__full">
-                      <label class="form-label">Açıklama</label>
-                      <textarea class="form-control" rows="2" id="sa_license_note" placeholder="Opsiyonel"></textarea>
-                    </div>
+    <div
+      class="modal fade"
+      id="stokDetailModal"
+      tabindex="-1"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog modal-dialog-centered modal-sm">
+        <div class="modal-content border-0 bg-transparent p-0">
+          <div class="modal-shell">
+            <div class="modal-shell__header">
+              <div class="modal-shell__heading">
+                <h5 class="modal-shell__title">Stok Detayı</h5>
+                <p class="modal-shell__subtitle">
+                  Seçili hareket hakkında özet bilgileri görüntüleyin.
+                </p>
+              </div>
+              <div class="modal-shell__header-actions">
+                <button
+                  type="button"
+                  class="btn-close"
+                  data-bs-dismiss="modal"
+                  aria-label="Kapat"
+                ></button>
+              </div>
+            </div>
+            <div class="modal-shell__body">
+              <dl class="row mb-0 small" id="stokDetailList"></dl>
+              <div class="mt-3 d-none" id="stokDetailLinkWrap">
+                <a
+                  id="stokDetailLink"
+                  class="btn btn-link btn-sm ps-0"
+                  href="#"
+                  target="_blank"
+                  rel="noopener"
+                  >Kaynağı aç</a
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- STOK EKLE MODALI -->
+    <div class="modal fade" id="modalStockAdd" tabindex="-1" aria-hidden="true">
+      <div
+        class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable"
+      >
+        <form
+          id="frmStockAdd"
+          class="modal-content border-0 bg-transparent p-0"
+        >
+          <div class="modal-shell">
+            <div class="modal-shell__header">
+              <div class="modal-shell__heading">
+                <h5 class="modal-shell__title">Stok Ekle</h5>
+                <p class="modal-shell__subtitle">
+                  Envanter veya lisans stok hareketlerini sisteme ekleyin.
+                </p>
+              </div>
+              <div class="modal-shell__header-actions">
+                <button
+                  type="button"
+                  class="btn-close"
+                  data-bs-dismiss="modal"
+                  aria-label="Kapat"
+                ></button>
+              </div>
+            </div>
+
+            <div class="modal-shell__body stack-md">
+              <div>
+                <ul class="nav nav-pills" id="stockAddType" role="tablist">
+                  <li class="nav-item" role="presentation">
+                    <button
+                      class="nav-link active"
+                      type="button"
+                      data-stock-add-type="inventory"
+                      aria-selected="true"
+                    >
+                      Envanter
+                    </button>
+                  </li>
+                  <li class="nav-item" role="presentation">
+                    <button
+                      class="nav-link"
+                      type="button"
+                      data-stock-add-type="license"
+                      aria-selected="false"
+                    >
+                      Lisans
+                    </button>
+                  </li>
+                </ul>
+              </div>
+
+              <div id="hardwareFields">
+                <div class="form-grid form-grid--compact stok-row">
+                  <div class="form-group">
+                    <label class="form-label" for="stok_donanim_tipi"
+                      >Donanım Tipi</label
+                    >
+                    <select
+                      name="donanim_tipi"
+                      class="form-select"
+                      data-lookup="donanim_tipi"
+                      id="stok_donanim_tipi"
+                      required
+                    ></select>
+                  </div>
+                  <div class="form-group">
+                    <label class="form-label" for="stok_marka"
+                      >Marka (ops.)</label
+                    >
+                    <select
+                      name="marka"
+                      class="form-select"
+                      data-lookup="marka"
+                      id="stok_marka"
+                    ></select>
+                  </div>
+                  <div class="form-group">
+                    <label class="form-label" for="stok_model"
+                      >Model (ops.)</label
+                    >
+                    <select
+                      name="model"
+                      class="form-select"
+                      data-lookup="model"
+                      data-depends="#stok_marka"
+                      id="stok_model"
+                    ></select>
+                  </div>
+                  <div class="form-group" id="rowMiktar">
+                    <label class="form-label" for="miktar">Miktar</label>
+                    <input
+                      type="number"
+                      min="1"
+                      id="miktar"
+                      name="miktar"
+                      class="form-control"
+                      required
+                    />
+                  </div>
+                  <div class="form-group">
+                    <label class="form-label" for="ifs_no"
+                      >IFS No (opsiyonel)</label
+                    >
+                    <input
+                      type="text"
+                      id="ifs_no"
+                      name="ifs_no"
+                      class="form-control"
+                    />
                   </div>
                 </div>
+              </div>
 
-                <div class="tab-pane fade" id="sa_tab_envanter" role="tabpanel">
-                  <div class="form-grid form-grid--compact">
-                    <div class="form-group">
-                      <label class="form-label">Envanter No</label>
-                      <select class="form-select" id="sa_inventory_select" data-stock-assign="inventory"></select>
-                    </div>
-                    <div class="form-group">
-                      <label class="form-label">Sorumlu</label>
-                      <select class="form-select" id="sa_inventory_owner"></select>
-                    </div>
+              <div id="licenseFields" class="d-none">
+                <div class="form-grid form-grid--compact">
+                  <div class="form-group">
+                    <label class="form-label" for="lisans_adi"
+                      >Lisans Adı</label
+                    >
+                    <select
+                      id="lisans_adi"
+                      name="lisans_adi"
+                      class="form-select"
+                      data-lookup="lisans_adi"
+                      required
+                    ></select>
                   </div>
-                </div>
-
-                <div class="tab-pane fade" id="sa_tab_yazici" role="tabpanel">
-                  <div class="form-grid form-grid--compact">
-                    <div class="form-group">
-                      <label class="form-label">Yazıcı</label>
-                      <select class="form-select" id="sa_printer_select" data-stock-assign="printer"></select>
-                    </div>
-                    <div class="form-group">
-                      <label class="form-label">Atama Notu</label>
-                      <input type="text" class="form-control" id="sa_printer_note" placeholder="Opsiyonel">
-                    </div>
+                  <div class="form-group">
+                    <label class="form-label" for="lisans_anahtari"
+                      >Lisans Anahtarı</label
+                    >
+                    <input
+                      type="text"
+                      id="lisans_anahtari"
+                      name="lisans_anahtari"
+                      class="form-control"
+                      required
+                    />
+                  </div>
+                  <div class="form-group">
+                    <label class="form-label" for="mail_adresi"
+                      >E-posta (opsiyonel)</label
+                    >
+                    <input
+                      type="email"
+                      id="mail_adresi"
+                      name="mail_adresi"
+                      class="form-control"
+                    />
                   </div>
                 </div>
               </div>
             </div>
 
-            <div>
-              <label class="form-label" for="sa_general_note">Genel Not (opsiyonel)</label>
-              <textarea class="form-control" rows="3" id="sa_general_note" placeholder="İşlem için genel açıklama..."></textarea>
+            <div class="modal-shell__footer">
+              <div class="modal-shell__actions">
+                <button
+                  class="btn btn-outline-secondary"
+                  data-bs-dismiss="modal"
+                  type="button"
+                >
+                  Kapat
+                </button>
+                <button class="btn btn-primary" type="submit">Kaydet</button>
+              </div>
             </div>
-          </form>
-        </div>
+          </div>
+        </form>
+      </div>
+    </div>
 
-        <div class="modal-shell__footer">
-          <div class="modal-shell__actions">
-            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">İptal</button>
-            <button type="submit" form="stockAssignForm" class="btn btn-primary">Atamayı Kaydet</button>
+    <!-- STOK ATAMA MODALI -->
+    <div
+      class="modal fade"
+      id="stokAtamaModal"
+      tabindex="-1"
+      aria-hidden="true"
+    >
+      <div
+        class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable"
+      >
+        <div class="modal-content border-0 bg-transparent p-0">
+          <div class="modal-shell">
+            <div class="modal-shell__header">
+              <div class="modal-shell__heading">
+                <h5 class="modal-shell__title">Stok Atama</h5>
+                <p class="modal-shell__subtitle">
+                  Stok durumu tablosundan seçtiğiniz kalemi envantere, yazıcıya
+                  veya lisansa atayın.
+                </p>
+              </div>
+              <div class="modal-shell__header-actions">
+                <button
+                  type="button"
+                  class="btn-close"
+                  data-bs-dismiss="modal"
+                  aria-label="Kapat"
+                ></button>
+              </div>
+            </div>
+
+            <div class="modal-shell__body">
+              <form id="stockAssignForm" class="vstack gap-3">
+                <div>
+                  <p class="form-label fw-semibold mb-2">Seçilen Stok</p>
+                  <div
+                    id="sa_stock_alert"
+                    class="alert alert-warning py-2 px-3 small mb-0"
+                    role="alert"
+                  >
+                    Atama yapmak için stok durumu tablosundaki
+                    <strong>Atama</strong> düğmesini kullanınız.
+                  </div>
+                  <div id="sa_stock_meta" class="mt-2 d-none">
+                    <div class="border rounded p-2 small bg-light-subtle">
+                      <div
+                        class="d-flex flex-wrap gap-3 align-items-center mb-1"
+                      >
+                        <span class="fw-semibold" id="sa_meta_tip">-</span>
+                        <span id="sa_meta_brand_wrap" class="d-none"
+                          ><span class="text-muted">Marka:</span>
+                          <span id="sa_meta_brand">-</span></span
+                        >
+                        <span id="sa_meta_model_wrap" class="d-none"
+                          ><span class="text-muted">Model:</span>
+                          <span id="sa_meta_model">-</span></span
+                        >
+                        <span
+                          ><span class="text-muted">IFS:</span>
+                          <span id="sa_meta_ifs">-</span></span
+                        >
+                        <span
+                          ><span class="text-muted">Mevcut:</span>
+                          <span id="sa_meta_qty">0</span></span
+                        >
+                      </div>
+                      <div
+                        class="d-flex flex-wrap gap-3"
+                        id="sa_meta_license_row"
+                      >
+                        <span id="sa_meta_license_wrap" class="d-none"
+                          ><span class="text-muted">Lisans:</span>
+                          <span id="sa_meta_license">-</span></span
+                        >
+                        <span id="sa_meta_mail_wrap" class="d-none"
+                          ><span class="text-muted">Mail:</span>
+                          <span id="sa_meta_mail">-</span></span
+                        >
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <label class="form-label fw-semibold">Atama Türü</label>
+                  <ul class="nav nav-tabs" id="sa_tabs" role="tablist">
+                    <li class="nav-item" role="presentation">
+                      <button
+                        class="nav-link active"
+                        data-bs-toggle="tab"
+                        data-bs-target="#sa_tab_lisans"
+                        type="button"
+                        role="tab"
+                      >
+                        Lisans
+                      </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                      <button
+                        class="nav-link"
+                        data-bs-toggle="tab"
+                        data-bs-target="#sa_tab_envanter"
+                        type="button"
+                        role="tab"
+                      >
+                        Envanter
+                      </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                      <button
+                        class="nav-link"
+                        data-bs-toggle="tab"
+                        data-bs-target="#sa_tab_yazici"
+                        type="button"
+                        role="tab"
+                      >
+                        Yazıcı
+                      </button>
+                    </li>
+                  </ul>
+
+                  <div
+                    class="tab-content border border-top-0 p-3 rounded-bottom"
+                  >
+                    <div
+                      class="tab-pane fade show active"
+                      id="sa_tab_lisans"
+                      role="tabpanel"
+                    >
+                      <div class="form-grid form-grid--compact">
+                        <div class="form-group">
+                          <label class="form-label">Lisans Adı</label>
+                          <select
+                            class="form-select"
+                            id="sa_license_select"
+                            data-stock-assign="license"
+                          ></select>
+                        </div>
+                        <div class="form-group">
+                          <label class="form-label">Sorumlu</label>
+                          <select
+                            class="form-select"
+                            id="sa_license_owner"
+                          ></select>
+                        </div>
+                        <div class="form-group form-grid__full">
+                          <label class="form-label">Açıklama</label>
+                          <textarea
+                            class="form-control"
+                            rows="2"
+                            id="sa_license_note"
+                            placeholder="Opsiyonel"
+                          ></textarea>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div
+                      class="tab-pane fade"
+                      id="sa_tab_envanter"
+                      role="tabpanel"
+                    >
+                      <div class="form-grid form-grid--compact">
+                        <div class="form-group">
+                          <label class="form-label">Envanter No</label>
+                          <select
+                            class="form-select"
+                            id="sa_inventory_select"
+                            data-stock-assign="inventory"
+                          ></select>
+                        </div>
+                        <div class="form-group">
+                          <label class="form-label">Sorumlu</label>
+                          <select
+                            class="form-select"
+                            id="sa_inventory_owner"
+                          ></select>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div
+                      class="tab-pane fade"
+                      id="sa_tab_yazici"
+                      role="tabpanel"
+                    >
+                      <div class="form-grid form-grid--compact">
+                        <div class="form-group">
+                          <label class="form-label">Yazıcı</label>
+                          <select
+                            class="form-select"
+                            id="sa_printer_select"
+                            data-stock-assign="printer"
+                          ></select>
+                        </div>
+                        <div class="form-group">
+                          <label class="form-label">Atama Notu</label>
+                          <input
+                            type="text"
+                            class="form-control"
+                            id="sa_printer_note"
+                            placeholder="Opsiyonel"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <label class="form-label" for="sa_general_note"
+                    >Genel Not (opsiyonel)</label
+                  >
+                  <textarea
+                    class="form-control"
+                    rows="3"
+                    id="sa_general_note"
+                    placeholder="İşlem için genel açıklama..."
+                  ></textarea>
+                </div>
+              </form>
+            </div>
+
+            <div class="modal-shell__footer">
+              <div class="modal-shell__actions">
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary"
+                  data-bs-dismiss="modal"
+                >
+                  İptal
+                </button>
+                <button
+                  type="submit"
+                  form="stockAssignForm"
+                  class="btn btn-primary"
+                >
+                  Atamayı Kaydet
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </div>
+    <script>
+      async function fillSelect(id, entity) {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.innerHTML = '<option value="">Yükleniyor...</option>';
+        try {
+          const r = await fetch(`/api/lookup/${entity}`);
+          if (!r.ok) throw new Error(await r.text());
+          const data = await r.json();
+          el.innerHTML =
+            '<option value="">Seçiniz…</option>' +
+            (data || [])
+              .map((v) => {
+                const text =
+                  typeof v === "string" ? v : v.name || v.text || v.id;
+                return `<option value="${text}">${text}</option>`;
+              })
+              .join("");
+        } catch (e) {
+          console.error(e);
+          el.innerHTML = '<option value="">(Veri Yok)</option>';
+        }
+      }
+
+      document.addEventListener("DOMContentLoaded", () => {
+        fillSelect("stok_durumu_select", "stok_durumu");
+        fillSelect("islem_select", "islem");
+        fillSelect("donanim_tipi_select", "donanim_tipi");
+        // fillSelect('ifs_no_select', 'ifs_no');
+      });
+    </script>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        const modal = document.getElementById("modalStockAdd");
+        if (!modal) return;
+        modal.addEventListener("shown.bs.modal", async () => {
+          await _selects.fillChoices({
+            endpoint: "/api/lookup/donanim_tipi",
+            selectId: "stok_donanim_tipi",
+            placeholder: "Donanım tipi seçiniz…",
+          });
+          await _selects.fillChoices({
+            endpoint: "/api/lookup/marka",
+            selectId: "stok_marka",
+            placeholder: "Marka seçiniz…",
+          });
+          await _selects.fillChoices({
+            endpoint: "/api/lookup/lisans_adi",
+            selectId: "lisans_adi",
+            placeholder: "Lisans adı seçiniz…",
+          });
+          _selects.bindMarkaModel("stok_marka", "stok_model");
+        });
+      });
+    </script>
+    {% endblock %}
   </div>
 </div>
-<script>
-async function fillSelect(id, entity) {
-  const el = document.getElementById(id);
-  if (!el) return;
-  el.innerHTML = '<option value="">Yükleniyor...</option>';
-  try {
-    const r = await fetch(`/api/lookup/${entity}`);
-    if (!r.ok) throw new Error(await r.text());
-    const data = await r.json();
-    el.innerHTML = '<option value="">Seçiniz…</option>' + (data || []).map(v => {
-      const text = typeof v === 'string' ? v : (v.name || v.text || v.id);
-      return `<option value="${text}">${text}</option>`;
-    }).join('');
-  } catch (e) {
-    console.error(e);
-    el.innerHTML = '<option value="">(Veri Yok)</option>';
-  }
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-  fillSelect('stok_durumu_select', 'stok_durumu');
-  fillSelect('islem_select', 'islem');
-  fillSelect('donanim_tipi_select', 'donanim_tipi');
-  // fillSelect('ifs_no_select', 'ifs_no');
-});
-</script>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const modal = document.getElementById('modalStockAdd');
-  if (!modal) return;
-  modal.addEventListener('shown.bs.modal', async () => {
-    await _selects.fillChoices({ endpoint: '/api/lookup/donanim_tipi', selectId: 'stok_donanim_tipi', placeholder: 'Donanım tipi seçiniz…' });
-    await _selects.fillChoices({ endpoint: '/api/lookup/marka', selectId: 'stok_marka', placeholder: 'Marka seçiniz…' });
-    await _selects.fillChoices({ endpoint: '/api/lookup/lisans_adi', selectId: 'lisans_adi', placeholder: 'Lisans adı seçiniz…' });
-    _selects.bindMarkaModel('stok_marka', 'stok_model');
-  });
-});
-</script>
-{% endblock %}
-

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -41,99 +41,99 @@ endblock %} {% block content %}
       </div>
 
       {% macro render_table(rows, empty_msg, show_actions=False) %}
-  <div class="table-responsive">
-    <table class="table table-striped table-hover table-sm align-middle">
-      <thead>
-        <tr>
-          <th>#</th>
-          <th>Donanım Tipi</th>
-          <th>Marka</th>
-          <th>Model</th>
-          <th>İstenen</th>
-          <th>Karşılanan</th>
-          <th>Kalan</th>
-          <th>Açıklama</th>
-          <th>Tarih</th>
-          {% if show_actions %}
-          <th>İşlem</th>
-          {% endif %}
-        </tr>
-      </thead>
-      <tbody>
-        {% for t in rows %} {% set current_ifs = t.ifs_no or '-' %} {% if
-        loop.changed(current_ifs) %}
-        <tr class="table-light">
-          <td colspan="{{ 10 if show_actions else 9 }}">
-            IFS No: {{ current_ifs }}
-          </td>
-        </tr>
-        {% endif %}
-        <tr data-tur="{{ t.tur.value if t.tur else '' }}">
-          <td>{{ t.id }}</td>
-          <td>{{ t.donanim_tipi or '-' }}</td>
-          <td>{{ t.marka or '-' }}</td>
-          <td>{{ t.model or '-' }}</td>
-          <td>{{ t.miktar or '-' }}</td>
-          <td>{{ t.karsilanan_miktar or '-' }}</td>
-          <td>{{ t.kalan_miktar or '-' }}</td>
-          <td>{{ t.aciklama or '-' }}</td>
-          <td>
-            {{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }} {% if t.durum !=
-            'acik' and t.kapanma_tarihi %}
-            <br />
-            <small class="text-muted">
-              {{ 'Kapanma: ' if t.durum == 'tamamlandi' else 'İptal: ' }}{{
-              t.kapanma_tarihi.strftime('%Y-%m-%d %H:%M') }}
-            </small>
+      <div class="table-responsive">
+        <table class="table table-striped table-hover table-sm align-middle">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Donanım Tipi</th>
+              <th>Marka</th>
+              <th>Model</th>
+              <th>İstenen</th>
+              <th>Karşılanan</th>
+              <th>Kalan</th>
+              <th>Açıklama</th>
+              <th>Tarih</th>
+              {% if show_actions %}
+              <th>İşlem</th>
+              {% endif %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for t in rows %} {% set current_ifs = t.ifs_no or '-' %} {% if
+            loop.changed(current_ifs) %}
+            <tr class="table-light">
+              <td colspan="{{ 10 if show_actions else 9 }}">
+                IFS No: {{ current_ifs }}
+              </td>
+            </tr>
             {% endif %}
-          </td>
-          {% if show_actions %}
-          <td>
-            <div class="btn-group">
-              <button
-                class="btn btn-sm btn-outline-secondary dropdown-toggle"
-                data-bs-toggle="dropdown"
+            <tr data-tur="{{ t.tur.value if t.tur else '' }}">
+              <td>{{ t.id }}</td>
+              <td>{{ t.donanim_tipi or '-' }}</td>
+              <td>{{ t.marka or '-' }}</td>
+              <td>{{ t.model or '-' }}</td>
+              <td>{{ t.miktar or '-' }}</td>
+              <td>{{ t.karsilanan_miktar or '-' }}</td>
+              <td>{{ t.kalan_miktar or '-' }}</td>
+              <td>{{ t.aciklama or '-' }}</td>
+              <td>
+                {{ t.olusturma_tarihi.strftime('%Y-%m-%d %H:%M') }} {% if
+                t.durum != 'acik' and t.kapanma_tarihi %}
+                <br />
+                <small class="text-muted">
+                  {{ 'Kapanma: ' if t.durum == 'tamamlandi' else 'İptal: ' }}{{
+                  t.kapanma_tarihi.strftime('%Y-%m-%d %H:%M') }}
+                </small>
+                {% endif %}
+              </td>
+              {% if show_actions %}
+              <td>
+                <div class="btn-group">
+                  <button
+                    class="btn btn-sm btn-outline-secondary dropdown-toggle"
+                    data-bs-toggle="dropdown"
+                  >
+                    İşlem
+                  </button>
+                  <ul class="dropdown-menu">
+                    <li>
+                      <a
+                        class="dropdown-item"
+                        href="#"
+                        onclick="talepIptal({{ t.id }}, {{ t.kalan_miktar }}); return false;"
+                        >İptal Et</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        class="dropdown-item"
+                        href="#"
+                        onclick="talepKapat({{ t.id }}, {{ t.kalan_miktar }}); return false;"
+                        >Stok Gir</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </td>
+              {% endif %}
+            </tr>
+            {% endfor %} {% if rows|length == 0 %}
+            <tr>
+              <td
+                colspan="{{ 10 if show_actions else 9 }}"
+                class="text-center text-muted"
               >
-                İşlem
-              </button>
-              <ul class="dropdown-menu">
-                <li>
-                  <a
-                    class="dropdown-item"
-                    href="#"
-                    onclick="talepIptal({{ t.id }}, {{ t.kalan_miktar }}); return false;"
-                    >İptal Et</a
-                  >
-                </li>
-                <li>
-                  <a
-                    class="dropdown-item"
-                    href="#"
-                    onclick="talepKapat({{ t.id }}, {{ t.kalan_miktar }}); return false;"
-                    >Stok Gir</a
-                  >
-                </li>
-              </ul>
-            </div>
-          </td>
-          {% endif %}
-        </tr>
-        {% endfor %} {% if rows|length == 0 %}
-        <tr>
-          <td
-            colspan="{{ 10 if show_actions else 9 }}"
-            class="text-center text-muted"
-          >
-            {{ empty_msg }}
-          </td>
-        </tr>
-        {% endif %}
-      </tbody>
-    </table>
-  </div>
-  {% endmacro %} {% set msg_map = {'acik':'Açık talep
-  bulunamadı.','tamamlandi':'Tamamlanan talep bulunamadı.','iptal':'İptal talep
-  bulunamadı.'} %}
+                {{ empty_msg }}
+              </td>
+            </tr>
+            {% endif %}
+          </tbody>
+        </table>
+      </div>
+      {% endmacro %} {% set msg_map = {'acik':'Açık talep
+      bulunamadı.','tamamlandi':'Tamamlanan talep bulunamadı.','iptal':'İptal
+      talep bulunamadı.'} %}
       <div class="page-section">
         {{ render_table(rows, msg_map.get(active_key), active_key == 'acik') }}
       </div>

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -2,32 +2,45 @@
 "components/modal.html" import modal %} {% set active_key =
 request.query_params.get("durum") or "acik" %} {% block title %}Talep Takip{%
 endblock %} {% block content %}
-<div class="container-fluid p-3">
-  {% set right_slot %}
-  <a
-    href="{{ url_for('talep_export_excel') }}"
-    class="btn btn-outline-secondary btn-sm"
-    >Excel</a
-  >
-  <button
-    class="btn btn-primary btn-sm"
-    data-bs-toggle="modal"
-    data-bs-target="#talepModal"
-  >
-    Talep Aç
-  </button>
-  {% endset %}
+<div class="container-fluid py-4">
+  <div class="page-shell">
+    <header class="page-header">
+      <div class="page-header__heading">
+        <span class="eyebrow text-primary">Talep Takip</span>
+        <h1 class="page-header__title">Talepler</h1>
+        <p class="page-header__subtitle">
+          Açık, tamamlanan ve iptal edilen tüm talepleri tek noktadan yönetin.
+        </p>
+      </div>
+      <div class="page-header__actions page-actions">
+        <div class="page-actions__group">
+          <a
+            href="{{ url_for('talep_export_excel') }}"
+            class="btn btn-outline-secondary btn-sm"
+          >
+            Excel
+          </a>
+          <button
+            class="btn btn-primary btn-sm"
+            data-bs-toggle="modal"
+            data-bs-target="#talepModal"
+          >
+            Talep Aç
+          </button>
+        </div>
+      </div>
+    </header>
 
-  <div class="tabs-wrap">
-    {{ tabs( items=[ {"label":"Açık","href": url_for('talep_list') ~
-    "?durum=acik", "key":"acik"}, {"label":"Tamamlandı","href":
-    url_for('talep_list') ~ "?durum=tamamlandi","key":"tamamlandi"},
-    {"label":"İptal","href": url_for('talep_list') ~
-    "?durum=iptal","key":"iptal"}, ], active_key=active_key,
-    right_slot=right_slot ) }}
-  </div>
+    <div class="page-card soft-card stack-md">
+      <div class="tabs-wrap">
+        {{ tabs( items=[ {"label":"Açık","href": url_for('talep_list') ~
+        "?durum=acik", "key":"acik"}, {"label":"Tamamlandı","href":
+        url_for('talep_list') ~ "?durum=tamamlandi","key":"tamamlandi"},
+        {"label":"İptal","href": url_for('talep_list') ~
+        "?durum=iptal","key":"iptal"}, ], active_key=active_key ) }}
+      </div>
 
-  {% macro render_table(rows, empty_msg, show_actions=False) %}
+      {% macro render_table(rows, empty_msg, show_actions=False) %}
   <div class="table-responsive">
     <table class="table table-striped table-hover table-sm align-middle">
       <thead>
@@ -121,8 +134,10 @@ endblock %} {% block content %}
   {% endmacro %} {% set msg_map = {'acik':'Açık talep
   bulunamadı.','tamamlandi':'Tamamlanan talep bulunamadı.','iptal':'İptal talep
   bulunamadı.'} %}
-  <div class="page-section">
-    {{ render_table(rows, msg_map.get(active_key), active_key == 'acik') }}
+      <div class="page-section">
+        {{ render_table(rows, msg_map.get(active_key), active_key == 'acik') }}
+      </div>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add shared page shell, modal shell, and responsive form utilities to the shared CSS and modal component
- restyle license, printer, stock, and request tracking templates to use the new page shell and soft cards
- refresh all related modals to use the elevated modal shell and unified action bars

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d63ad6db90832bbda0ebe19cc70c5a