### PR TITLE
Fix lookup dropdown rendering and align header controls

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -235,6 +235,26 @@ small,
   min-width: 0;
 }
 
+.page-actions .btn,
+.page-actions .form-control,
+.page-actions .form-select {
+  min-height: var(--page-action-control-height, 2.35rem);
+}
+
+.page-actions .btn-sm,
+.page-actions .form-control-sm,
+.page-actions .form-select-sm {
+  min-height: var(--page-action-control-height-sm, 2.35rem);
+  padding-top: 0.35rem;
+  padding-bottom: 0.35rem;
+}
+
+.page-actions .form-control,
+.page-actions .form-select {
+  padding-top: 0.4rem;
+  padding-bottom: 0.4rem;
+}
+
 .page-card {
   background: var(--color-surface);
   border-radius: var(--radius-lg);

--- a/static/js/choices_helpers.js
+++ b/static/js/choices_helpers.js
@@ -82,10 +82,25 @@ async function fillChoices({
     throw e;
   }
 
-  const choices = data.map((x) => ({
-    value: x.id,
-    label: x.name ?? x.ad ?? x.adi ?? x.text,
-  }));
+  const choices = (Array.isArray(data) ? data : []).map((item) => {
+    if (item == null) {
+      return { value: "", label: "" };
+    }
+    if (typeof item === "string" || typeof item === "number") {
+      const text = String(item);
+      return { value: text, label: text };
+    }
+    const value =
+      item.id ?? item.value ?? (item.text != null ? item.text : "");
+    const label =
+      item.name ??
+      item.text ??
+      item.ad ??
+      item.adi ??
+      item.label ??
+      (value !== undefined && value !== null ? String(value) : "");
+    return { value, label };
+  });
   setChoicesSafe(sel, choices, true, { placeholderValue: placeholder });
 }
 

--- a/static/js/choices_helpers.js
+++ b/static/js/choices_helpers.js
@@ -90,8 +90,7 @@ async function fillChoices({
       const text = String(item);
       return { value: text, label: text };
     }
-    const value =
-      item.id ?? item.value ?? (item.text != null ? item.text : "");
+    const value = item.id ?? item.value ?? (item.text != null ? item.text : "");
     const label =
       item.name ??
       item.text ??

--- a/static/js/talep.js
+++ b/static/js/talep.js
@@ -38,12 +38,30 @@
     const head = `<option value="">${placeholder}</option>`;
     if (!Array.isArray(arr) || !arr.length)
       return head + '<option value="">Seçenek yok</option>';
-    return (
-      head +
-      arr
-        .map((x) => `<option value="${x.id}">${x.name || x.adi || ""}</option>`)
-        .join("")
-    );
+
+    const options = arr.map((item) => {
+      if (item == null) {
+        return '<option value=""></option>';
+      }
+
+      if (typeof item === "string" || typeof item === "number") {
+        const text = String(item);
+        return `<option value="${text}">${text}</option>`;
+      }
+
+      const value =
+        item.id ?? item.value ?? (item.text != null ? item.text : "");
+      const label =
+        item.name ||
+        item.text ||
+        item.ad ||
+        item.adi ||
+        item.label ||
+        (value !== undefined && value !== null ? String(value) : "");
+      return `<option value="${value}">${label}</option>`;
+    });
+
+    return head + options.join("");
   }
 
   function rowTemplate() {

--- a/templates/base.html
+++ b/templates/base.html
@@ -342,18 +342,28 @@ window.addEventListener("message", (e) => {
     first.value = ''; first.textContent = 'Seçiniz…';
     el.appendChild(first);
 
-    const list = (items || []).map(v => {
+    const list = (items || []).map((v) => {
       if (v && typeof v === 'object') {
-        return { id: v.id ?? '', text: v.name ?? v.ad ?? v.text ?? v.value ?? '' };
+        const text =
+          v.name ?? v.ad ?? v.adi ?? v.text ?? v.label ?? v.value ?? '';
+        const value =
+          v.id ??
+          v.value ??
+          (v.text !== undefined && v.text !== null ? v.text : text);
+        return { id: v.id ?? null, value: value ?? '', text: text ?? '' };
       }
-      return { id: '', text: v };
+      const text = v == null ? '' : String(v);
+      return { id: null, value: text, text };
     });
 
     for (const v of list) {
       const opt = document.createElement('option');
-      opt.value = v.text;
-      opt.textContent = v.text;
-      if (v.id) opt.dataset.id = v.id;
+      opt.value = v.value ?? '';
+      opt.textContent = v.text ?? '';
+      if (v.id !== null && v.id !== undefined && v.id !== '') {
+        opt.dataset.id = v.id;
+      }
+      opt.dataset.label = v.text ?? '';
       el.appendChild(opt);
     }
 
@@ -372,14 +382,21 @@ window.addEventListener("message", (e) => {
     // TomSelect
     if (el.tomselect) {
       el.tomselect.clearOptions();
-      el.tomselect.addOptions(list.map(v => ({ value: v.text, text: v.text })));
+      el.tomselect.addOptions(
+        list.map((v) => ({ value: v.value ?? v.text, text: v.text })),
+      );
     }
 
     // Choices.js
     if (window.Choices && el.classList.contains('choices')) {
       if (el._choices && el._choices.destroy) el._choices.destroy();
       el._choices = new Choices(el, { searchEnabled: true, itemSelectText: '' });
-      el._choices.setChoices(list.map(v => ({ value: v.text, label: v.text })), 'value', 'label', true);
+      el._choices.setChoices(
+        list.map((v) => ({ value: v.value ?? v.text, label: v.text })),
+        'value',
+        'label',
+        true,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- normalise lookup option rendering so string-based responses populate Talep form and other dropdowns correctly
- ensure the shared modal lookup helper keeps option IDs when updating native selects, TomSelect, and Choices.js instances
- align the action buttons, Excel, filter, and search controls to a consistent height in header toolbars

## Testing
- pytest tests/test_lookup_model_alias.py

------
https://chatgpt.com/codex/tasks/task_e_68d64416a14c832b9f3e8689357c1d20