### PR TITLE
Create product storage table for admin product creation

### DIFF
--- a/alembic/versions/2d7a2f6f1c3e_create_products_table.py
+++ b/alembic/versions/2d7a2f6f1c3e_create_products_table.py
@@ -1,0 +1,42 @@
+"""create products table
+
+Revision ID: 2d7a2f6f1c3e
+Revises: 1e4c12f4b1b9
+Create Date: 2025-03-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "2d7a2f6f1c3e"
+down_revision = "1e4c12f4b1b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "products",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("donanim_tipi", sa.String(length=100), nullable=False),
+        sa.Column("marka", sa.String(length=150), nullable=True),
+        sa.Column("model", sa.String(length=150), nullable=True),
+        sa.Column("kullanim_alani", sa.String(length=150), nullable=True),
+        sa.Column("lisans_adi", sa.String(length=150), nullable=True),
+        sa.Column("fabrika", sa.String(length=150), nullable=True),
+    )
+    op.create_index("ix_products_donanim_tipi", "products", ["donanim_tipi"])
+    op.create_index("ix_products_marka", "products", ["marka"])
+    op.create_index("ix_products_model", "products", ["model"])
+    op.create_index("ix_products_kullanim_alani", "products", ["kullanim_alani"])
+    op.create_index("ix_products_fabrika", "products", ["fabrika"])
+
+
+def downgrade():
+    op.drop_index("ix_products_fabrika", table_name="products")
+    op.drop_index("ix_products_kullanim_alani", table_name="products")
+    op.drop_index("ix_products_model", table_name="products")
+    op.drop_index("ix_products_marka", table_name="products")
+    op.drop_index("ix_products_donanim_tipi", table_name="products")
+    op.drop_table("products")

--- a/models.py
+++ b/models.py
@@ -34,6 +34,7 @@ from sqlalchemy.orm import (
     sessionmaker,
     synonym,
 )
+from sqlalchemy.pool import StaticPool
 
 load_dotenv()
 
@@ -68,7 +69,11 @@ def _is_sqlite_url(url: str | URL) -> bool:
 
 def engine_kwargs_for_url(url: str | URL) -> dict[str, Any]:
     if _is_sqlite_url(url):
-        return {"connect_args": {"check_same_thread": False}}
+        parsed = url if isinstance(url, URL) else make_url(url)
+        kwargs: dict[str, Any] = {"connect_args": {"check_same_thread": False}}
+        if parsed.database in (None, "", ":memory:"):
+            kwargs["poolclass"] = StaticPool
+        return kwargs
     return {}
 
 
@@ -132,6 +137,22 @@ class Setting(Base):
     id = Column(Integer, primary_key=True)
     key = Column(String, unique=True, index=True)
     value = Column(String)
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id: Mapped[int | None] = mapped_column(
+        Integer, primary_key=True, autoincrement=True
+    )
+    donanim_tipi: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    marka: Mapped[str | None] = mapped_column(String(150), nullable=True, index=True)
+    model: Mapped[str | None] = mapped_column(String(150), nullable=True, index=True)
+    kullanim_alani: Mapped[str | None] = mapped_column(
+        String(150), nullable=True, index=True
+    )
+    lisans_adi: Mapped[str | None] = mapped_column(String(150), nullable=True)
+    fabrika: Mapped[str | None] = mapped_column(String(150), nullable=True, index=True)
 
 
 class Inventory(Base):

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -96,23 +96,24 @@ def create_product(
     fabrika: str = Form(""),
     db: Session = Depends(get_db),
 ):
-    # Uygun veri modeli seç (Product tanımlı değilse Inventory kullan)
-    model_cls = getattr(models, "Product", models.Inventory)
-
-    if not donanim_tipi:
+    normalized_type = donanim_tipi.strip()
+    if not normalized_type:
         raise HTTPException(status_code=400, detail="Donanım tipi gerekli")
 
-    data = {
-        "donanim_tipi": donanim_tipi,
-        "marka": marka or None,
-        "model": model or None,
-        "kullanim_alani": kullanim_alani or None,
-        "fabrika": fabrika or None,
-    }
-    if hasattr(model_cls, "__table__") and "lisans_adi" in model_cls.__table__.columns:
-        data["lisans_adi"] = lisans_adi or None
+    product_table = models.Product.__table__
+    bind = db.get_bind()
+    if bind is None:
+        bind = db.connection()
+    product_table.create(bind=bind, checkfirst=True)
 
-    item = model_cls(**data)
+    item = models.Product(
+        donanim_tipi=normalized_type,
+        marka=marka or None,
+        model=model or None,
+        kullanim_alani=kullanim_alani or None,
+        lisans_adi=lisans_adi or None,
+        fabrika=fabrika or None,
+    )
     db.add(item)
     db.commit()
     return RedirectResponse(url="/admin#products", status_code=303)

--- a/tests/test_admin_create_product.py
+++ b/tests/test_admin_create_product.py
@@ -1,0 +1,126 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import pytest
+import anyio
+from fastapi import FastAPI
+from sqlalchemy import inspect
+from urllib.parse import urlencode
+
+import models
+from database import get_db
+from routes.admin import router as admin_router
+
+
+def _call_app(app: FastAPI, method: str, path: str, data: dict[str, str]) -> tuple[int, dict[bytes, bytes], bytes]:
+    body = urlencode(data or {}).encode()
+
+    async def _request() -> tuple[int, dict[bytes, bytes], bytes]:
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": method.upper(),
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": [
+                (b"host", b"testserver"),
+                (b"content-type", b"application/x-www-form-urlencoded"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "scheme": "http",
+        }
+
+        response_status = 500
+        response_headers: dict[bytes, bytes] = {}
+        response_body = bytearray()
+        sent = False
+
+        async def receive():
+            nonlocal sent
+            if sent:
+                return {"type": "http.disconnect"}
+            sent = True
+            return {
+                "type": "http.request",
+                "body": body,
+                "more_body": False,
+            }
+
+        async def send(message):
+            nonlocal response_status, response_headers, response_body
+            if message["type"] == "http.response.start":
+                response_status = message["status"]
+                response_headers = dict(message.get("headers", []))
+            elif message["type"] == "http.response.body":
+                response_body.extend(message.get("body", b""))
+
+        await app(scope, receive, send)
+        return response_status, response_headers, bytes(response_body)
+
+    return anyio.run(_request)
+
+
+@pytest.fixture()
+def client():
+    models.Base.metadata.drop_all(models.engine)
+    models.Base.metadata.create_all(models.engine)
+    models.Product.__table__.drop(models.engine, checkfirst=True)
+    assert not inspect(models.engine).has_table("products")
+
+    app = FastAPI()
+    app.include_router(admin_router)
+
+    def override_get_db():
+        db = models.SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        yield lambda method, path, data=None: _call_app(app, method, path, data or {})
+    finally:
+        app.dependency_overrides.clear()
+        models.Base.metadata.drop_all(models.engine)
+
+
+def test_create_product_without_products_table(client):
+    status_code, headers, _ = client(
+        "POST",
+        "/admin/products/create",
+        data={
+            "donanim_tipi": "   Laptop   ",
+            "marka": "Dell",
+            "model": "XPS 15",
+            "kullanim_alani": "Ofis",
+            "lisans_adi": "Windows 11",
+            "fabrika": "Merkez",
+        },
+    )
+
+    assert status_code == 303
+    assert headers.get(b"location") == b"/admin#products"
+
+    inspector = inspect(models.engine)
+    assert inspector.has_table("products")
+
+    with models.SessionLocal() as session:
+        products = session.query(models.Product).all()
+
+    assert len(products) == 1
+    stored = products[0]
+    assert stored.donanim_tipi == "Laptop"
+    assert stored.marka == "Dell"
+    assert stored.model == "XPS 15"
+    assert stored.kullanim_alani == "Ofis"
+    assert stored.lisans_adi == "Windows 11"
+    assert stored.fabrika == "Merkez"


### PR DESCRIPTION
## Summary
- add a dedicated Product ORM plus migration that matches the admin form fields and stabilises in-memory SQLite usage
- update the /admin/products/create handler to always persist into the Product table, auto-creating it if necessary
- add a regression test that posts to the admin product endpoint against a schema without the Product table and verifies persistence

## Testing
- pytest tests/test_admin_create_product.py

------
https://chatgpt.com/codex/tasks/task_e_68d64f8592d0832b9a9a08691bed332a