### PR TITLE
Fix printer status row highlighting template syntax

### DIFF
--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -107,14 +107,7 @@ content %}
               data-kullanim="{{ p.kullanim_alani or '' }}"
               data-personel="{{ p.sorumlu_personel or '' }}"
               data-bagli="{{ p.bagli_envanter_no or '' }}"
-              {%
-              if
-              p.durum=""
-              ="arızalı"
-              %}class="table-warning"
-              {%
-              endif
-              %}
+              {% if p.durum == 'arızalı' %}class="table-warning"{% endif %}
             >
               <td>#{{ p.id }}</td>
               <td>{{ p.marka or '-' }}</td>


### PR DESCRIPTION
## Summary
- fix the Jinja condition that flags faulty printers so the template renders

## Testing
- pytest *(fails: TypeError: sqlalchemy.engine.create.create_engine() got multiple values for keyword argument 'poolclass')*


------
https://chatgpt.com/codex/tasks/task_e_68d6533bb6cc832b92972724581ab05d