### PR TITLE
Align stock assignment modal fields with new selectors

### DIFF
--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -707,6 +707,7 @@ content %}
                           <select
                             class="form-select"
                             id="sa_license_select"
+                            name="sa_license_select"
                             data-stock-assign="license"
                           ></select>
                         </div>
@@ -715,6 +716,7 @@ content %}
                           <select
                             class="form-select"
                             id="sa_license_owner"
+                            name="sa_license_owner"
                           ></select>
                         </div>
                         <div class="form-group form-grid__full">
@@ -723,6 +725,7 @@ content %}
                             class="form-control"
                             rows="2"
                             id="sa_license_note"
+                            name="sa_license_note"
                             placeholder="Opsiyonel"
                           ></textarea>
                         </div>
@@ -740,6 +743,7 @@ content %}
                           <select
                             class="form-select"
                             id="sa_inventory_select"
+                            name="sa_inventory_select"
                             data-stock-assign="inventory"
                           ></select>
                         </div>
@@ -748,6 +752,7 @@ content %}
                           <select
                             class="form-select"
                             id="sa_inventory_owner"
+                            name="sa_inventory_owner"
                           ></select>
                         </div>
                       </div>
@@ -764,6 +769,7 @@ content %}
                           <select
                             class="form-select"
                             id="sa_printer_select"
+                            name="sa_printer_select"
                             data-stock-assign="printer"
                           ></select>
                         </div>
@@ -773,6 +779,7 @@ content %}
                             type="text"
                             class="form-control"
                             id="sa_printer_note"
+                            name="sa_printer_note"
                             placeholder="Opsiyonel"
                           />
                         </div>
@@ -789,6 +796,7 @@ content %}
                     class="form-control"
                     rows="3"
                     id="sa_general_note"
+                    name="sa_general_note"
                     placeholder="İşlem için genel açıklama..."
                   ></textarea>
                 </div>


### PR DESCRIPTION
## Summary
- update the stock assignment helper to read and populate the new modal field IDs while combining license/printer notes
- sync the stock assignment modal inputs with matching name attributes for the new selectors

## Testing
- pytest tests/test_stock_assign.py

------
https://chatgpt.com/codex/tasks/task_e_68d656092478832b923ddcc34bd84c08