### PR TITLE
Fix Jinja condition in printers list template

### DIFF
--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -107,14 +107,7 @@ content %}
               data-kullanim="{{ p.kullanim_alani or '' }}"
               data-personel="{{ p.sorumlu_personel or '' }}"
               data-bagli="{{ p.bagli_envanter_no or '' }}"
-              {%
-              if
-              p.durum=""
-              ="arızalı"
-              %}class="table-warning"
-              {%
-              endif
-              %}
+              {% if p.durum == 'arızalı' %}class="table-warning"{% endif %}
             >
               <td>#{{ p.id }}</td>
               <td>{{ p.marka or '-' }}</td>


### PR DESCRIPTION
## Summary
- fix the conditional class binding in the printers list row markup
- ensure the template parses successfully to avoid TemplateSyntaxError

## Testing
- python - <<'PY'
from jinja2 import Environment, FileSystemLoader
loader = FileSystemLoader('templates')
env = Environment(loader=loader)
# Attempt to load printers_list template to ensure no syntax errors
env.get_template('printers_list.html')
print('Template loaded successfully')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d66dbe17b8832bbb641fb09f4e7e01