### PR TITLE
feat: adopt unified layout and shared filters

### DIFF
--- a/static/css/unified-design.css
+++ b/static/css/unified-design.css
@@ -1,0 +1,203 @@
+/* Unified Design System helpers */
+
+.eyebrow {
+  display: inline-block;
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.page-header__title {
+  color: var(--color-heading);
+}
+
+.page-header__subtitle {
+  color: var(--color-muted);
+}
+
+.page-header__actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.filter-search-bar {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: clamp(0.85rem, 0.65rem + 0.6vw, 1.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.filter-search-bar__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.filter-search-bar__main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+  flex: 1 1 320px;
+}
+
+.filter-search-bar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  justify-content: flex-end;
+}
+
+@media (max-width: 575.98px) {
+  .filter-search-bar__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  flex: 0 1 200px;
+}
+
+.filter-group label {
+  margin-bottom: 0;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-muted);
+}
+
+.search-wrapper {
+  position: relative;
+  flex: 1 1 260px;
+}
+
+.search-wrapper .bi {
+  position: absolute;
+  left: 0.85rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-muted);
+  pointer-events: none;
+}
+
+.search-wrapper .form-control {
+  padding-left: 2.2rem;
+}
+
+.active-filters-section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.active-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.active-filters__label {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-muted);
+}
+
+.filter-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary-strong);
+  padding: 0.25rem 0.75rem;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+}
+
+.filter-badge__remove {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.filter-search-bar .form-control-sm,
+.filter-search-bar .form-select-sm,
+.filter-search-bar .btn-sm {
+  min-height: 2.35rem;
+}
+
+.filter-search-bar .btn-sm {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.page-card {
+  border: 1px solid var(--color-border);
+}
+
+.table thead th[data-field] {
+  white-space: nowrap;
+}
+
+.filter-modal-body {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.filter-rows-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.filter-row-shell {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(160px, 1fr) auto;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+@media (max-width: 575.98px) {
+  .filter-row-shell {
+    grid-template-columns: 1fr;
+  }
+}
+
+.filter-row-shell__actions {
+  display: inline-flex;
+  gap: var(--space-2xs);
+}
+
+.filter-empty-state {
+  text-align: center;
+  padding: var(--space-md);
+  color: var(--color-muted);
+  font-size: var(--font-size-sm);
+}
+
+.badge[data-filter-value] {
+  cursor: pointer;
+}

--- a/static/js/unified-filters.js
+++ b/static/js/unified-filters.js
@@ -1,8 +1,8 @@
 (() => {
-  const API_DISTINCT_PREFIX = '/api/lookup/distinct/';
+  const API_DISTINCT_PREFIX = "/api/lookup/distinct/";
 
   function normaliseValue(value) {
-    if (value === null || value === undefined) return '';
+    if (value === null || value === undefined) return "";
     return String(value).trim();
   }
 
@@ -13,7 +13,7 @@
   function buildColumnIndexMap(tableEl) {
     if (!tableEl) return {};
     const map = {};
-    const headers = tableEl.querySelectorAll('thead th');
+    const headers = tableEl.querySelectorAll("thead th");
     headers.forEach((th, idx) => {
       const field = th.dataset.field;
       if (field) {
@@ -25,19 +25,24 @@
 
   function getOptionLabel(selectEl, value) {
     if (!selectEl) return value;
-    const option = Array.from(selectEl.options).find((opt) => opt.value === value);
+    const option = Array.from(selectEl.options).find(
+      (opt) => opt.value === value,
+    );
     return option ? option.textContent : value;
   }
 
-  async function populateDistinctValues(selectId, entity, column, options = {}) {
+  async function populateDistinctValues(
+    selectId,
+    entity,
+    column,
+    options = {},
+  ) {
     const selectEl = document.getElementById(selectId);
     if (!selectEl) return;
-    const {
-      placeholder = 'Tümü',
-      includeEmpty = true,
-      distinctUrl,
-    } = options;
-    const endpoint = distinctUrl || `${API_DISTINCT_PREFIX}${encodeURIComponent(entity)}/${encodeURIComponent(column)}`;
+    const { placeholder = "Tümü", includeEmpty = true, distinctUrl } = options;
+    const endpoint =
+      distinctUrl ||
+      `${API_DISTINCT_PREFIX}${encodeURIComponent(entity)}/${encodeURIComponent(column)}`;
     try {
       const response = await fetch(endpoint);
       if (!response.ok) {
@@ -47,24 +52,26 @@
       const values = Array.isArray(data) ? data : [];
       const fragment = document.createDocumentFragment();
       if (includeEmpty) {
-        const emptyOpt = document.createElement('option');
-        emptyOpt.value = '';
+        const emptyOpt = document.createElement("option");
+        emptyOpt.value = "";
         emptyOpt.textContent = placeholder;
         fragment.appendChild(emptyOpt);
       }
       values
-        .map((item) => (typeof item === 'object' ? item.value ?? item.text ?? '' : item))
-        .filter((item) => item !== null && item !== undefined && item !== '')
+        .map((item) =>
+          typeof item === "object" ? (item.value ?? item.text ?? "") : item,
+        )
+        .filter((item) => item !== null && item !== undefined && item !== "")
         .forEach((item) => {
-          const opt = document.createElement('option');
+          const opt = document.createElement("option");
           opt.value = item;
           opt.textContent = item;
           fragment.appendChild(opt);
         });
-      selectEl.innerHTML = '';
+      selectEl.innerHTML = "";
       selectEl.appendChild(fragment);
     } catch (error) {
-      console.warn('populateDistinctValues failed', { entity, column, error });
+      console.warn("populateDistinctValues failed", { entity, column, error });
     }
   }
 
@@ -72,22 +79,23 @@
     constructor(options = {}) {
       this.options = Object.assign(
         {
-          tableSelector: 'table',
+          tableSelector: "table",
           searchInputId: null,
           filters: [],
-          filterButtonId: 'filterBtn',
-          clearButtonId: 'clearFilterBtn',
-          activeFiltersContainerId: 'activeFilterBadges',
-          activeFiltersSectionId: 'activeFiltersSection',
+          filterButtonId: "filterBtn",
+          clearButtonId: "clearFilterBtn",
+          activeFiltersContainerId: "activeFilterBadges",
+          activeFiltersSectionId: "activeFiltersSection",
         },
         options,
       );
 
-      this.table = typeof this.options.tableSelector === 'string'
-        ? document.querySelector(this.options.tableSelector)
-        : this.options.tableSelector;
+      this.table =
+        typeof this.options.tableSelector === "string"
+          ? document.querySelector(this.options.tableSelector)
+          : this.options.tableSelector;
       this.tbodyRows = this.table
-        ? Array.from(this.table.querySelectorAll('tbody tr'))
+        ? Array.from(this.table.querySelectorAll("tbody tr"))
         : [];
       this.columnIndexMap = buildColumnIndexMap(this.table);
       this.searchInput = this.options.searchInputId
@@ -121,16 +129,17 @@
 
     _bindEvents() {
       if (this.searchInput) {
-        this.searchInput.addEventListener('input', () => this.applyFilters());
+        this.searchInput.addEventListener("input", () => this.applyFilters());
       }
 
       this.filters.forEach((filter) => {
-        const eventName = filter.element.tagName === 'SELECT' ? 'change' : 'input';
+        const eventName =
+          filter.element.tagName === "SELECT" ? "change" : "input";
         filter.element.addEventListener(eventName, () => this.applyFilters());
       });
 
       if (this.filterButton) {
-        this.filterButton.addEventListener('click', (event) => {
+        this.filterButton.addEventListener("click", (event) => {
           if (this.advancedFilterModal) {
             event.preventDefault();
             this.advancedFilterModal.open();
@@ -141,34 +150,36 @@
       }
 
       if (this.clearButton) {
-        this.clearButton.addEventListener('click', (event) => {
+        this.clearButton.addEventListener("click", (event) => {
           event.preventDefault();
           this.clearFilters();
         });
       }
 
       if (this.activeFiltersContainer) {
-        this.activeFiltersContainer.addEventListener('click', (event) => {
-          const badge = event.target.closest('[data-filter-id]');
+        this.activeFiltersContainer.addEventListener("click", (event) => {
+          const badge = event.target.closest("[data-filter-id]");
           if (!badge) return;
           const filterId = badge.dataset.filterId;
-          const filterType = badge.dataset.filterType || 'simple';
-          if (filterType === 'search') {
+          const filterType = badge.dataset.filterType || "simple";
+          if (filterType === "search") {
             if (this.searchInput) {
-              this.searchInput.value = '';
+              this.searchInput.value = "";
             }
-          } else if (filterType === 'advanced') {
-            this.advancedFilters = this.advancedFilters.filter((f) => f.id !== filterId);
+          } else if (filterType === "advanced") {
+            this.advancedFilters = this.advancedFilters.filter(
+              (f) => f.id !== filterId,
+            );
             if (this.advancedFilterModal) {
               this.advancedFilterModal.setCurrentFilters(this.advancedFilters);
             }
           } else {
             const filter = this.filters.find((item) => item.id === filterId);
             if (filter) {
-              if (filter.element.tagName === 'SELECT') {
+              if (filter.element.tagName === "SELECT") {
                 filter.element.selectedIndex = 0;
               } else {
-                filter.element.value = '';
+                filter.element.value = "";
               }
             }
           }
@@ -207,36 +218,36 @@
 
     clearFilters() {
       if (this.searchInput) {
-        this.searchInput.value = '';
+        this.searchInput.value = "";
       }
       this.filters.forEach((filter) => {
-        if (filter.element.tagName === 'SELECT') {
+        if (filter.element.tagName === "SELECT") {
           filter.element.selectedIndex = 0;
         } else {
-          filter.element.value = '';
+          filter.element.value = "";
         }
       });
       this.clearAdvancedFilters();
     }
 
     _getFilterValue(element) {
-      if (!element) return '';
-      if (element.tagName === 'SELECT') {
+      if (!element) return "";
+      if (element.tagName === "SELECT") {
         return normaliseValue(element.value);
       }
       return normaliseValue(element.value);
     }
 
     _getRowValue(row, field) {
-      if (!row) return '';
+      if (!row) return "";
       const directAttr = row.getAttribute(`data-${field}`);
       if (directAttr !== null && directAttr !== undefined) {
         return normaliseValue(directAttr);
       }
       const index = this.columnIndexMap[field];
-      if (index === undefined) return '';
+      if (index === undefined) return "";
       const cell = row.children[index];
-      if (!cell) return '';
+      if (!cell) return "";
       return normaliseValue(cell.textContent);
     }
 
@@ -249,7 +260,7 @@
     applyFilters() {
       const searchValue = this.searchInput
         ? normaliseForCompare(this.searchInput.value)
-        : '';
+        : "";
 
       const activeSimpleFilters = this.filters
         .map((filter) => {
@@ -269,7 +280,7 @@
       const activeFilters = [...activeSimpleFilters, ...this.advancedFilters];
 
       this.tbodyRows.forEach((row) => {
-        const rowText = normaliseForCompare(row.textContent || '');
+        const rowText = normaliseForCompare(row.textContent || "");
         let visible = true;
 
         if (searchValue) {
@@ -278,7 +289,10 @@
 
         if (visible) {
           for (const filter of activeFilters) {
-            const rowValue = this._getRowValue(row, filter.columnField || filter.field);
+            const rowValue = this._getRowValue(
+              row,
+              filter.columnField || filter.field,
+            );
             if (!this._matchRowValue(rowValue, filter.value)) {
               visible = false;
               break;
@@ -286,24 +300,32 @@
           }
         }
 
-        row.classList.toggle('d-none', !visible);
+        row.classList.toggle("d-none", !visible);
       });
 
-      this._renderBadges({ searchValue, activeSimpleFilters, advancedFilters: this.advancedFilters });
+      this._renderBadges({
+        searchValue,
+        activeSimpleFilters,
+        advancedFilters: this.advancedFilters,
+      });
     }
 
     _renderBadges({ searchValue, activeSimpleFilters, advancedFilters }) {
-      if (!this.activeFiltersContainer && !this.activeFiltersSection && !this.clearButton) {
+      if (
+        !this.activeFiltersContainer &&
+        !this.activeFiltersSection &&
+        !this.clearButton
+      ) {
         return;
       }
       const badges = [];
 
       if (searchValue) {
         badges.push({
-          id: '__search__',
-          label: 'Arama',
-          displayValue: this.searchInput ? this.searchInput.value : '',
-          type: 'search',
+          id: "__search__",
+          label: "Arama",
+          displayValue: this.searchInput ? this.searchInput.value : "",
+          type: "search",
         });
       }
 
@@ -312,7 +334,7 @@
           id: filter.id,
           label: filter.label,
           displayValue: filter.displayValue,
-          type: 'simple',
+          type: "simple",
         });
       });
 
@@ -321,21 +343,21 @@
           id: filter.id,
           label: filter.label,
           displayValue: filter.displayValue || filter.value,
-          type: 'advanced',
+          type: "advanced",
         });
       });
 
       if (this.activeFiltersContainer) {
-        this.activeFiltersContainer.innerHTML = '';
+        this.activeFiltersContainer.innerHTML = "";
         if (badges.length === 0) {
-          const empty = document.createElement('span');
-          empty.className = 'text-muted small';
-          empty.textContent = 'Aktif filtre yok';
+          const empty = document.createElement("span");
+          empty.className = "text-muted small";
+          empty.textContent = "Aktif filtre yok";
           this.activeFiltersContainer.appendChild(empty);
         } else {
           badges.forEach((badge) => {
-            const badgeEl = document.createElement('span');
-            badgeEl.className = 'filter-badge';
+            const badgeEl = document.createElement("span");
+            badgeEl.className = "filter-badge";
             badgeEl.dataset.filterId = badge.id;
             badgeEl.dataset.filterType = badge.type;
             badgeEl.innerHTML = `
@@ -352,10 +374,10 @@
 
       const hasActive = badges.length > 0;
       if (this.activeFiltersSection) {
-        this.activeFiltersSection.classList.toggle('d-none', !hasActive);
+        this.activeFiltersSection.classList.toggle("d-none", !hasActive);
       }
       if (this.clearButton) {
-        this.clearButton.classList.toggle('d-none', !hasActive);
+        this.clearButton.classList.toggle("d-none", !hasActive);
       }
     }
   }
@@ -366,7 +388,7 @@
         {
           modalId: null,
           formId: null,
-          triggerId: 'filterBtn',
+          triggerId: "filterBtn",
           columns: [],
           distinctUrl: null,
         },
@@ -379,7 +401,7 @@
         ? document.getElementById(this.options.formId)
         : null;
       this.rowsContainer = this.formEl
-        ? this.formEl.querySelector('#filterRows')
+        ? this.formEl.querySelector("#filterRows")
         : null;
       this.triggerEl = this.options.triggerId
         ? document.getElementById(this.options.triggerId)
@@ -391,23 +413,24 @@
       this.resetCallback = null;
       this.rowCounter = 0;
 
-      this.modalInstance = this.modalEl && window.bootstrap
-        ? bootstrap.Modal.getOrCreateInstance(this.modalEl)
-        : null;
+      this.modalInstance =
+        this.modalEl && window.bootstrap
+          ? bootstrap.Modal.getOrCreateInstance(this.modalEl)
+          : null;
 
       this._bindEvents();
     }
 
     _bindEvents() {
       if (this.triggerEl) {
-        this.triggerEl.addEventListener('click', (event) => {
+        this.triggerEl.addEventListener("click", (event) => {
           event.preventDefault();
           this.open();
         });
       }
 
       if (this.formEl) {
-        this.formEl.addEventListener('submit', (event) => {
+        this.formEl.addEventListener("submit", (event) => {
           event.preventDefault();
           const filters = this._collectFilters();
           this.currentFilters = filters;
@@ -417,16 +440,16 @@
           this.close();
         });
 
-        this.formEl.addEventListener('click', (event) => {
-          const addBtn = event.target.closest('[data-filter-add]');
-          const removeBtn = event.target.closest('[data-filter-remove]');
+        this.formEl.addEventListener("click", (event) => {
+          const addBtn = event.target.closest("[data-filter-add]");
+          const removeBtn = event.target.closest("[data-filter-remove]");
           if (addBtn) {
             event.preventDefault();
             this._appendRow();
           }
           if (removeBtn) {
             event.preventDefault();
-            const row = event.target.closest('.filter-row-shell');
+            const row = event.target.closest(".filter-row-shell");
             if (row) {
               row.remove();
             }
@@ -434,10 +457,10 @@
           }
         });
 
-        this.formEl.addEventListener('change', (event) => {
-          const select = event.target.closest('[data-filter-column]');
+        this.formEl.addEventListener("change", (event) => {
+          const select = event.target.closest("[data-filter-column]");
           if (select) {
-            const row = select.closest('.filter-row-shell');
+            const row = select.closest(".filter-row-shell");
             this._populateRowValues(row, select.value);
           }
         });
@@ -472,19 +495,23 @@
 
     clear() {
       this.currentFilters = [];
-      if (typeof this.resetCallback === 'function') {
+      if (typeof this.resetCallback === "function") {
         this.resetCallback();
       }
     }
 
     _renderFromCurrentFilters() {
       if (!this.rowsContainer) return;
-      this.rowsContainer.innerHTML = '';
+      this.rowsContainer.innerHTML = "";
       if (this.currentFilters.length === 0) {
         this._appendRow();
       } else {
         this.currentFilters.forEach((filter) => {
-          this._appendRow(filter.field || filter.columnField, filter.value, filter.displayValue);
+          this._appendRow(
+            filter.field || filter.columnField,
+            filter.value,
+            filter.displayValue,
+          );
         });
       }
       this._ensureAtLeastOneRow();
@@ -498,12 +525,15 @@
     }
 
     _createRowElement() {
-      const row = document.createElement('div');
-      row.className = 'filter-row-shell';
+      const row = document.createElement("div");
+      row.className = "filter-row-shell";
       row.dataset.rowId = `filter-row-${this.rowCounter++}`;
       const columnOptions = this.columns
-        .map((col) => `<option value="${col.field}" data-column-label="${col.name}">${col.name}</option>`)
-        .join('');
+        .map(
+          (col) =>
+            `<option value="${col.field}" data-column-label="${col.name}">${col.name}</option>`,
+        )
+        .join("");
       row.innerHTML = `
         <select class="form-select form-select-sm" data-filter-column>
           ${columnOptions}
@@ -525,15 +555,15 @@
 
     async _populateRowValues(row, field, presetValue) {
       if (!row) return;
-      const valueSelect = row.querySelector('[data-filter-value]');
+      const valueSelect = row.querySelector("[data-filter-value]");
       if (!valueSelect) return;
       valueSelect.innerHTML = '<option value="">Seçiniz</option>';
       if (!field) return;
       const column = this.columns.find((col) => col.field === field);
       if (!column) return;
-      const urlTemplate = this.options.distinctUrl || '';
+      const urlTemplate = this.options.distinctUrl || "";
       const endpoint = urlTemplate
-        ? urlTemplate.replace('__COL__', encodeURIComponent(field))
+        ? urlTemplate.replace("__COL__", encodeURIComponent(field))
         : `${API_DISTINCT_PREFIX}${encodeURIComponent(field)}`;
       try {
         const response = await fetch(endpoint);
@@ -543,10 +573,12 @@
         const data = await response.json();
         const values = Array.isArray(data) ? data : [];
         values
-          .map((item) => (typeof item === 'object' ? item.value ?? item.text ?? '' : item))
-          .filter((item) => item !== null && item !== undefined && item !== '')
+          .map((item) =>
+            typeof item === "object" ? (item.value ?? item.text ?? "") : item,
+          )
+          .filter((item) => item !== null && item !== undefined && item !== "")
           .forEach((value) => {
-            const option = document.createElement('option');
+            const option = document.createElement("option");
             option.value = value;
             option.textContent = value;
             valueSelect.appendChild(option);
@@ -555,7 +587,10 @@
           valueSelect.value = presetValue;
         }
       } catch (error) {
-        console.warn('AdvancedFilterModal: distinct fetch failed', { field, error });
+        console.warn("AdvancedFilterModal: distinct fetch failed", {
+          field,
+          error,
+        });
       }
     }
 
@@ -564,13 +599,13 @@
       const row = this._createRowElement();
       this.rowsContainer.appendChild(row);
       if (field) {
-        const columnSelect = row.querySelector('[data-filter-column]');
+        const columnSelect = row.querySelector("[data-filter-column]");
         if (columnSelect) {
           columnSelect.value = field;
         }
         this._populateRowValues(row, field, presetValue);
       } else {
-        const columnSelect = row.querySelector('[data-filter-column]');
+        const columnSelect = row.querySelector("[data-filter-column]");
         this._populateRowValues(row, columnSelect ? columnSelect.value : null);
       }
     }
@@ -578,11 +613,13 @@
     _collectFilters() {
       if (!this.rowsContainer) return [];
       const filters = [];
-      Array.from(this.rowsContainer.querySelectorAll('.filter-row-shell')).forEach((row, index) => {
-        const columnSelect = row.querySelector('[data-filter-column]');
-        const valueSelect = row.querySelector('[data-filter-value]');
-        const field = columnSelect ? columnSelect.value : '';
-        const value = valueSelect ? valueSelect.value : '';
+      Array.from(
+        this.rowsContainer.querySelectorAll(".filter-row-shell"),
+      ).forEach((row, index) => {
+        const columnSelect = row.querySelector("[data-filter-column]");
+        const valueSelect = row.querySelector("[data-filter-value]");
+        const field = columnSelect ? columnSelect.value : "";
+        const value = valueSelect ? valueSelect.value : "";
         if (!field || !value) return;
         const column = this.columns.find((col) => col.field === field);
         const label = column ? column.name : field;

--- a/static/js/unified-filters.js
+++ b/static/js/unified-filters.js
@@ -1,0 +1,606 @@
+(() => {
+  const API_DISTINCT_PREFIX = '/api/lookup/distinct/';
+
+  function normaliseValue(value) {
+    if (value === null || value === undefined) return '';
+    return String(value).trim();
+  }
+
+  function normaliseForCompare(value) {
+    return normaliseValue(value).toLowerCase();
+  }
+
+  function buildColumnIndexMap(tableEl) {
+    if (!tableEl) return {};
+    const map = {};
+    const headers = tableEl.querySelectorAll('thead th');
+    headers.forEach((th, idx) => {
+      const field = th.dataset.field;
+      if (field) {
+        map[field] = idx;
+      }
+    });
+    return map;
+  }
+
+  function getOptionLabel(selectEl, value) {
+    if (!selectEl) return value;
+    const option = Array.from(selectEl.options).find((opt) => opt.value === value);
+    return option ? option.textContent : value;
+  }
+
+  async function populateDistinctValues(selectId, entity, column, options = {}) {
+    const selectEl = document.getElementById(selectId);
+    if (!selectEl) return;
+    const {
+      placeholder = 'Tümü',
+      includeEmpty = true,
+      distinctUrl,
+    } = options;
+    const endpoint = distinctUrl || `${API_DISTINCT_PREFIX}${encodeURIComponent(entity)}/${encodeURIComponent(column)}`;
+    try {
+      const response = await fetch(endpoint);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      const values = Array.isArray(data) ? data : [];
+      const fragment = document.createDocumentFragment();
+      if (includeEmpty) {
+        const emptyOpt = document.createElement('option');
+        emptyOpt.value = '';
+        emptyOpt.textContent = placeholder;
+        fragment.appendChild(emptyOpt);
+      }
+      values
+        .map((item) => (typeof item === 'object' ? item.value ?? item.text ?? '' : item))
+        .filter((item) => item !== null && item !== undefined && item !== '')
+        .forEach((item) => {
+          const opt = document.createElement('option');
+          opt.value = item;
+          opt.textContent = item;
+          fragment.appendChild(opt);
+        });
+      selectEl.innerHTML = '';
+      selectEl.appendChild(fragment);
+    } catch (error) {
+      console.warn('populateDistinctValues failed', { entity, column, error });
+    }
+  }
+
+  class UnifiedFilterSystem {
+    constructor(options = {}) {
+      this.options = Object.assign(
+        {
+          tableSelector: 'table',
+          searchInputId: null,
+          filters: [],
+          filterButtonId: 'filterBtn',
+          clearButtonId: 'clearFilterBtn',
+          activeFiltersContainerId: 'activeFilterBadges',
+          activeFiltersSectionId: 'activeFiltersSection',
+        },
+        options,
+      );
+
+      this.table = typeof this.options.tableSelector === 'string'
+        ? document.querySelector(this.options.tableSelector)
+        : this.options.tableSelector;
+      this.tbodyRows = this.table
+        ? Array.from(this.table.querySelectorAll('tbody tr'))
+        : [];
+      this.columnIndexMap = buildColumnIndexMap(this.table);
+      this.searchInput = this.options.searchInputId
+        ? document.getElementById(this.options.searchInputId)
+        : null;
+      this.filterButton = this.options.filterButtonId
+        ? document.getElementById(this.options.filterButtonId)
+        : null;
+      this.clearButton = this.options.clearButtonId
+        ? document.getElementById(this.options.clearButtonId)
+        : null;
+      this.activeFiltersContainer = this.options.activeFiltersContainerId
+        ? document.getElementById(this.options.activeFiltersContainerId)
+        : null;
+      this.activeFiltersSection = this.options.activeFiltersSectionId
+        ? document.getElementById(this.options.activeFiltersSectionId)
+        : null;
+
+      this.filters = (this.options.filters || [])
+        .map((filter) => {
+          const element = document.getElementById(filter.id);
+          if (!element) return null;
+          return Object.assign({}, filter, { element });
+        })
+        .filter(Boolean);
+
+      this.advancedFilters = [];
+      this._bindEvents();
+      this.applyFilters();
+    }
+
+    _bindEvents() {
+      if (this.searchInput) {
+        this.searchInput.addEventListener('input', () => this.applyFilters());
+      }
+
+      this.filters.forEach((filter) => {
+        const eventName = filter.element.tagName === 'SELECT' ? 'change' : 'input';
+        filter.element.addEventListener(eventName, () => this.applyFilters());
+      });
+
+      if (this.filterButton) {
+        this.filterButton.addEventListener('click', (event) => {
+          if (this.advancedFilterModal) {
+            event.preventDefault();
+            this.advancedFilterModal.open();
+          } else {
+            this.applyFilters();
+          }
+        });
+      }
+
+      if (this.clearButton) {
+        this.clearButton.addEventListener('click', (event) => {
+          event.preventDefault();
+          this.clearFilters();
+        });
+      }
+
+      if (this.activeFiltersContainer) {
+        this.activeFiltersContainer.addEventListener('click', (event) => {
+          const badge = event.target.closest('[data-filter-id]');
+          if (!badge) return;
+          const filterId = badge.dataset.filterId;
+          const filterType = badge.dataset.filterType || 'simple';
+          if (filterType === 'search') {
+            if (this.searchInput) {
+              this.searchInput.value = '';
+            }
+          } else if (filterType === 'advanced') {
+            this.advancedFilters = this.advancedFilters.filter((f) => f.id !== filterId);
+            if (this.advancedFilterModal) {
+              this.advancedFilterModal.setCurrentFilters(this.advancedFilters);
+            }
+          } else {
+            const filter = this.filters.find((item) => item.id === filterId);
+            if (filter) {
+              if (filter.element.tagName === 'SELECT') {
+                filter.element.selectedIndex = 0;
+              } else {
+                filter.element.value = '';
+              }
+            }
+          }
+          this.applyFilters();
+        });
+      }
+    }
+
+    registerAdvancedFilter(modalInstance) {
+      if (!modalInstance) return;
+      this.advancedFilterModal = modalInstance;
+      modalInstance.setApplyCallback((filters) => {
+        this.setAdvancedFilters(filters);
+      });
+      modalInstance.setResetCallback(() => {
+        this.clearAdvancedFilters();
+      });
+      modalInstance.setCurrentFilters(this.advancedFilters);
+    }
+
+    setAdvancedFilters(filters = []) {
+      this.advancedFilters = Array.isArray(filters) ? filters : [];
+      if (this.advancedFilterModal) {
+        this.advancedFilterModal.setCurrentFilters(this.advancedFilters);
+      }
+      this.applyFilters();
+    }
+
+    clearAdvancedFilters() {
+      this.advancedFilters = [];
+      if (this.advancedFilterModal) {
+        this.advancedFilterModal.setCurrentFilters([]);
+      }
+      this.applyFilters();
+    }
+
+    clearFilters() {
+      if (this.searchInput) {
+        this.searchInput.value = '';
+      }
+      this.filters.forEach((filter) => {
+        if (filter.element.tagName === 'SELECT') {
+          filter.element.selectedIndex = 0;
+        } else {
+          filter.element.value = '';
+        }
+      });
+      this.clearAdvancedFilters();
+    }
+
+    _getFilterValue(element) {
+      if (!element) return '';
+      if (element.tagName === 'SELECT') {
+        return normaliseValue(element.value);
+      }
+      return normaliseValue(element.value);
+    }
+
+    _getRowValue(row, field) {
+      if (!row) return '';
+      const directAttr = row.getAttribute(`data-${field}`);
+      if (directAttr !== null && directAttr !== undefined) {
+        return normaliseValue(directAttr);
+      }
+      const index = this.columnIndexMap[field];
+      if (index === undefined) return '';
+      const cell = row.children[index];
+      if (!cell) return '';
+      return normaliseValue(cell.textContent);
+    }
+
+    _matchRowValue(rowValue, filterValue) {
+      if (!filterValue) return true;
+      if (!rowValue) return false;
+      return normaliseForCompare(rowValue) === normaliseForCompare(filterValue);
+    }
+
+    applyFilters() {
+      const searchValue = this.searchInput
+        ? normaliseForCompare(this.searchInput.value)
+        : '';
+
+      const activeSimpleFilters = this.filters
+        .map((filter) => {
+          const value = this._getFilterValue(filter.element);
+          if (!value) return null;
+          const displayValue = getOptionLabel(filter.element, value);
+          return {
+            id: filter.id,
+            label: filter.label || filter.id,
+            columnField: filter.columnField,
+            value,
+            displayValue,
+          };
+        })
+        .filter(Boolean);
+
+      const activeFilters = [...activeSimpleFilters, ...this.advancedFilters];
+
+      this.tbodyRows.forEach((row) => {
+        const rowText = normaliseForCompare(row.textContent || '');
+        let visible = true;
+
+        if (searchValue) {
+          visible = rowText.includes(searchValue);
+        }
+
+        if (visible) {
+          for (const filter of activeFilters) {
+            const rowValue = this._getRowValue(row, filter.columnField || filter.field);
+            if (!this._matchRowValue(rowValue, filter.value)) {
+              visible = false;
+              break;
+            }
+          }
+        }
+
+        row.classList.toggle('d-none', !visible);
+      });
+
+      this._renderBadges({ searchValue, activeSimpleFilters, advancedFilters: this.advancedFilters });
+    }
+
+    _renderBadges({ searchValue, activeSimpleFilters, advancedFilters }) {
+      if (!this.activeFiltersContainer && !this.activeFiltersSection && !this.clearButton) {
+        return;
+      }
+      const badges = [];
+
+      if (searchValue) {
+        badges.push({
+          id: '__search__',
+          label: 'Arama',
+          displayValue: this.searchInput ? this.searchInput.value : '',
+          type: 'search',
+        });
+      }
+
+      activeSimpleFilters.forEach((filter) => {
+        badges.push({
+          id: filter.id,
+          label: filter.label,
+          displayValue: filter.displayValue,
+          type: 'simple',
+        });
+      });
+
+      advancedFilters.forEach((filter) => {
+        badges.push({
+          id: filter.id,
+          label: filter.label,
+          displayValue: filter.displayValue || filter.value,
+          type: 'advanced',
+        });
+      });
+
+      if (this.activeFiltersContainer) {
+        this.activeFiltersContainer.innerHTML = '';
+        if (badges.length === 0) {
+          const empty = document.createElement('span');
+          empty.className = 'text-muted small';
+          empty.textContent = 'Aktif filtre yok';
+          this.activeFiltersContainer.appendChild(empty);
+        } else {
+          badges.forEach((badge) => {
+            const badgeEl = document.createElement('span');
+            badgeEl.className = 'filter-badge';
+            badgeEl.dataset.filterId = badge.id;
+            badgeEl.dataset.filterType = badge.type;
+            badgeEl.innerHTML = `
+              <span class="filter-badge__label">${badge.label}:</span>
+              <span class="filter-badge__value">${badge.displayValue}</span>
+              <button type="button" class="filter-badge__remove" aria-label="Filtreyi temizle">
+                <i class="bi bi-x"></i>
+              </button>
+            `;
+            this.activeFiltersContainer.appendChild(badgeEl);
+          });
+        }
+      }
+
+      const hasActive = badges.length > 0;
+      if (this.activeFiltersSection) {
+        this.activeFiltersSection.classList.toggle('d-none', !hasActive);
+      }
+      if (this.clearButton) {
+        this.clearButton.classList.toggle('d-none', !hasActive);
+      }
+    }
+  }
+
+  class AdvancedFilterModal {
+    constructor(options = {}) {
+      this.options = Object.assign(
+        {
+          modalId: null,
+          formId: null,
+          triggerId: 'filterBtn',
+          columns: [],
+          distinctUrl: null,
+        },
+        options,
+      );
+      this.modalEl = this.options.modalId
+        ? document.getElementById(this.options.modalId)
+        : null;
+      this.formEl = this.options.formId
+        ? document.getElementById(this.options.formId)
+        : null;
+      this.rowsContainer = this.formEl
+        ? this.formEl.querySelector('#filterRows')
+        : null;
+      this.triggerEl = this.options.triggerId
+        ? document.getElementById(this.options.triggerId)
+        : null;
+      this.columns = this.options.columns || [];
+      this.distinctUrl = this.options.distinctUrl || null;
+      this.currentFilters = [];
+      this.applyCallback = null;
+      this.resetCallback = null;
+      this.rowCounter = 0;
+
+      this.modalInstance = this.modalEl && window.bootstrap
+        ? bootstrap.Modal.getOrCreateInstance(this.modalEl)
+        : null;
+
+      this._bindEvents();
+    }
+
+    _bindEvents() {
+      if (this.triggerEl) {
+        this.triggerEl.addEventListener('click', (event) => {
+          event.preventDefault();
+          this.open();
+        });
+      }
+
+      if (this.formEl) {
+        this.formEl.addEventListener('submit', (event) => {
+          event.preventDefault();
+          const filters = this._collectFilters();
+          this.currentFilters = filters;
+          if (this.applyCallback) {
+            this.applyCallback(filters);
+          }
+          this.close();
+        });
+
+        this.formEl.addEventListener('click', (event) => {
+          const addBtn = event.target.closest('[data-filter-add]');
+          const removeBtn = event.target.closest('[data-filter-remove]');
+          if (addBtn) {
+            event.preventDefault();
+            this._appendRow();
+          }
+          if (removeBtn) {
+            event.preventDefault();
+            const row = event.target.closest('.filter-row-shell');
+            if (row) {
+              row.remove();
+            }
+            this._ensureAtLeastOneRow();
+          }
+        });
+
+        this.formEl.addEventListener('change', (event) => {
+          const select = event.target.closest('[data-filter-column]');
+          if (select) {
+            const row = select.closest('.filter-row-shell');
+            this._populateRowValues(row, select.value);
+          }
+        });
+      }
+    }
+
+    open() {
+      if (!this.modalEl || !this.rowsContainer) return;
+      this._renderFromCurrentFilters();
+      if (this.modalInstance) {
+        this.modalInstance.show();
+      }
+    }
+
+    close() {
+      if (this.modalInstance) {
+        this.modalInstance.hide();
+      }
+    }
+
+    setApplyCallback(callback) {
+      this.applyCallback = callback;
+    }
+
+    setResetCallback(callback) {
+      this.resetCallback = callback;
+    }
+
+    setCurrentFilters(filters = []) {
+      this.currentFilters = Array.isArray(filters) ? filters : [];
+    }
+
+    clear() {
+      this.currentFilters = [];
+      if (typeof this.resetCallback === 'function') {
+        this.resetCallback();
+      }
+    }
+
+    _renderFromCurrentFilters() {
+      if (!this.rowsContainer) return;
+      this.rowsContainer.innerHTML = '';
+      if (this.currentFilters.length === 0) {
+        this._appendRow();
+      } else {
+        this.currentFilters.forEach((filter) => {
+          this._appendRow(filter.field || filter.columnField, filter.value, filter.displayValue);
+        });
+      }
+      this._ensureAtLeastOneRow();
+    }
+
+    _ensureAtLeastOneRow() {
+      if (!this.rowsContainer) return;
+      if (this.rowsContainer.children.length === 0) {
+        this._appendRow();
+      }
+    }
+
+    _createRowElement() {
+      const row = document.createElement('div');
+      row.className = 'filter-row-shell';
+      row.dataset.rowId = `filter-row-${this.rowCounter++}`;
+      const columnOptions = this.columns
+        .map((col) => `<option value="${col.field}" data-column-label="${col.name}">${col.name}</option>`)
+        .join('');
+      row.innerHTML = `
+        <select class="form-select form-select-sm" data-filter-column>
+          ${columnOptions}
+        </select>
+        <select class="form-select form-select-sm" data-filter-value>
+          <option value="">Seçiniz</option>
+        </select>
+        <div class="filter-row-shell__actions">
+          <button class="btn btn-outline-primary btn-sm" data-filter-add type="button">
+            <i class="bi bi-plus-lg"></i>
+          </button>
+          <button class="btn btn-outline-danger btn-sm" data-filter-remove type="button">
+            <i class="bi bi-dash-lg"></i>
+          </button>
+        </div>
+      `;
+      return row;
+    }
+
+    async _populateRowValues(row, field, presetValue) {
+      if (!row) return;
+      const valueSelect = row.querySelector('[data-filter-value]');
+      if (!valueSelect) return;
+      valueSelect.innerHTML = '<option value="">Seçiniz</option>';
+      if (!field) return;
+      const column = this.columns.find((col) => col.field === field);
+      if (!column) return;
+      const urlTemplate = this.options.distinctUrl || '';
+      const endpoint = urlTemplate
+        ? urlTemplate.replace('__COL__', encodeURIComponent(field))
+        : `${API_DISTINCT_PREFIX}${encodeURIComponent(field)}`;
+      try {
+        const response = await fetch(endpoint);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const data = await response.json();
+        const values = Array.isArray(data) ? data : [];
+        values
+          .map((item) => (typeof item === 'object' ? item.value ?? item.text ?? '' : item))
+          .filter((item) => item !== null && item !== undefined && item !== '')
+          .forEach((value) => {
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = value;
+            valueSelect.appendChild(option);
+          });
+        if (presetValue) {
+          valueSelect.value = presetValue;
+        }
+      } catch (error) {
+        console.warn('AdvancedFilterModal: distinct fetch failed', { field, error });
+      }
+    }
+
+    _appendRow(field, presetValue) {
+      if (!this.rowsContainer) return;
+      const row = this._createRowElement();
+      this.rowsContainer.appendChild(row);
+      if (field) {
+        const columnSelect = row.querySelector('[data-filter-column]');
+        if (columnSelect) {
+          columnSelect.value = field;
+        }
+        this._populateRowValues(row, field, presetValue);
+      } else {
+        const columnSelect = row.querySelector('[data-filter-column]');
+        this._populateRowValues(row, columnSelect ? columnSelect.value : null);
+      }
+    }
+
+    _collectFilters() {
+      if (!this.rowsContainer) return [];
+      const filters = [];
+      Array.from(this.rowsContainer.querySelectorAll('.filter-row-shell')).forEach((row, index) => {
+        const columnSelect = row.querySelector('[data-filter-column]');
+        const valueSelect = row.querySelector('[data-filter-value]');
+        const field = columnSelect ? columnSelect.value : '';
+        const value = valueSelect ? valueSelect.value : '';
+        if (!field || !value) return;
+        const column = this.columns.find((col) => col.field === field);
+        const label = column ? column.name : field;
+        const displayValue = getOptionLabel(valueSelect, value) || value;
+        filters.push({
+          id: `${field}-${value}-${index}`,
+          field,
+          columnField: field,
+          label,
+          value,
+          displayValue,
+        });
+      });
+      return filters;
+    }
+  }
+
+  window.populateDistinctValues = populateDistinctValues;
+  window.UnifiedFilterSystem = UnifiedFilterSystem;
+  window.AdvancedFilterModal = AdvancedFilterModal;
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link href="{{ url_for('static', path='css/custom.css') }}" rel="stylesheet">
+  <link href="{{ url_for('static', path='css/unified-design.css') }}" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" rel="stylesheet">
   <title>{% block title %}{% endblock %}</title>
 </head>
@@ -138,6 +139,7 @@
     <script defer src="/static/js/selects.js"></script>
     <script src="{{ url_for('static', path='js/actions.js') }}"></script>
     <script src="{{ url_for('static', path='js/faults.js') }}"></script>
+    <script src="{{ url_for('static', path='js/unified-filters.js') }}"></script>
   {% block scripts %}
   <script>
 document.addEventListener("DOMContentLoaded", () => {

--- a/templates/bilgiler/index.html
+++ b/templates/bilgiler/index.html
@@ -1,58 +1,63 @@
 {% extends "base.html" %} {% block title %}Bilgi Merkezi{% endblock %} {% block
 content %}
-<div class="container-fluid px-0">
-  <div
-    class="d-flex flex-wrap gap-3 align-items-center justify-content-between mb-4"
-  >
-    <div>
-      <h1 class="h4 mb-1">Bilgi Merkezi</h1>
-      <p class="text-muted small mb-0">
-        Ekip içerisinde paylaşılan önemli notlar ve yönergeler.
-      </p>
-    </div>
-    <button
-      class="btn btn-primary"
-      type="button"
-      data-bs-toggle="modal"
-      data-bs-target="#bilgiModal"
-    >
-      <i class="bi bi-plus-circle me-1"></i>Yeni Bilgi Ekle
-    </button>
-  </div>
+<div class="container-fluid py-4">
+  <div class="page-shell">
+    <header class="page-header">
+      <div class="page-header__heading">
+        <span class="eyebrow text-primary">BİLGİ BANKASI</span>
+        <h1 class="page-header__title">Bilgiler</h1>
+        <p class="page-header__subtitle">
+          Bilgi ve dokümantasyonları yönetin.
+        </p>
+      </div>
+      <div class="page-header__actions page-actions">
+        <button
+          class="btn btn-success btn-sm"
+          type="button"
+          data-bs-toggle="modal"
+          data-bs-target="#bilgiModal"
+        >
+          <i class="bi bi-plus-lg"></i>
+          Yeni Bilgi
+        </button>
+      </div>
+    </header>
 
-  <div class="card shadow-sm border-0 mb-4">
-    <div class="card-body">
-      <div class="row g-3 align-items-end" id="bilgiFilters">
-        <div class="col-md-3">
-          <label for="kategoriFilter" class="form-label text-muted"
-            >Kategori</label
-          >
-          <select id="kategoriFilter" class="form-select form-select-sm">
-            <option value="">Tümü</option>
-            {% for kategori in categories %}
-            <option value="{{ kategori.id }}">{{ kategori.ad }}</option>
-            {% endfor %}
-          </select>
+    <div class="filter-search-bar mb-4">
+      <div class="filter-search-bar__row">
+        <div class="filter-search-bar__main">
+          <div class="search-wrapper">
+            <i class="bi bi-search"></i>
+            <input
+              id="bilgiSearch"
+              class="form-control form-control-sm"
+              type="search"
+              placeholder="Başlık veya içerik içinde ara..."
+              value="{{ search_query }}"
+            />
+          </div>
+          <div class="filter-group">
+            <label for="kategoriFilter">Kategori:</label>
+            <select id="kategoriFilter" class="form-select form-select-sm">
+              <option value="">Tümü</option>
+              {% for kategori in categories %}
+              <option value="{{ kategori.id }}">{{ kategori.ad }}</option>
+              {% endfor %}
+            </select>
+          </div>
         </div>
-        <div class="col-md-6">
-          <label for="bilgiSearch" class="form-label text-muted">Arama</label>
-          <input
-            id="bilgiSearch"
-            class="form-control form-control-sm"
-            type="search"
-            placeholder="Başlık veya içerik içinde ara..."
-            value="{{ search_query }}"
-          />
-        </div>
-        <div class="col-md-3 text-md-end">
-          <small class="text-muted d-block"
-            >Toplam {{ (pinned_items|length + other_items|length) }}
-            kayıt</small
+        <div class="filter-search-bar__actions">
+          <button
+            class="btn btn-primary btn-sm"
+            type="button"
+            onclick="applyBilgiFilters()"
           >
+            <i class="bi bi-funnel"></i>
+            Filtrele
+          </button>
         </div>
       </div>
     </div>
-  </div>
 
   {% if pinned_items %}
   <section class="mb-5" id="pinnedBilgiler">
@@ -88,6 +93,7 @@ content %}
       {% endif %}
     </div>
   </section>
+</div>
 </div>
 
 <div class="modal fade" id="bilgiModal" tabindex="-1" aria-hidden="true">
@@ -186,6 +192,36 @@ content %}
 <script src="{{ url_for('static', path='js/bilgiler.js') }}"></script>
 <script>
   window.addEventListener('DOMContentLoaded', () => {
+    const searchInput = document.getElementById('bilgiSearch');
+    const kategoriFilter = document.getElementById('kategoriFilter');
+    const bilgiCards = Array.from(document.querySelectorAll('.bilgi-card'));
+
+    function applyBilgiFilters() {
+      const searchValue = (searchInput?.value || '').toLowerCase();
+      const kategoriValue = kategoriFilter?.value || '';
+
+      bilgiCards.forEach((card) => {
+        const cardText = (card.dataset.search || card.textContent || '')
+          .toLowerCase();
+        const cardKategori = card.dataset.category || '';
+
+        const matchSearch = !searchValue || cardText.includes(searchValue);
+        const matchKategori = !kategoriValue || cardKategori === kategoriValue;
+
+        card.classList.toggle('d-none', !(matchSearch && matchKategori));
+      });
+    }
+
+    if (searchInput) {
+      searchInput.addEventListener('input', applyBilgiFilters);
+    }
+    if (kategoriFilter) {
+      kategoriFilter.addEventListener('change', applyBilgiFilters);
+    }
+
+    window.applyBilgiFilters = applyBilgiFilters;
+    applyBilgiFilters();
+
     initBilgiPage({
       kategori: "{{ selected_category }}",
       search: "{{ search_query }}",

--- a/templates/bilgiler/index.html
+++ b/templates/bilgiler/index.html
@@ -6,9 +6,7 @@ content %}
       <div class="page-header__heading">
         <span class="eyebrow text-primary">BİLGİ BANKASI</span>
         <h1 class="page-header__title">Bilgiler</h1>
-        <p class="page-header__subtitle">
-          Bilgi ve dokümantasyonları yönetin.
-        </p>
+        <p class="page-header__subtitle">Bilgi ve dokümantasyonları yönetin.</p>
       </div>
       <div class="page-header__actions page-actions">
         <button
@@ -59,41 +57,41 @@ content %}
       </div>
     </div>
 
-  {% if pinned_items %}
-  <section class="mb-5" id="pinnedBilgiler">
-    <div class="d-flex align-items-center gap-2 mb-2">
-      <span class="text-uppercase text-muted fw-semibold small"
-        >Sabitlenen Bilgiler</span
-      >
-      <span class="badge bg-warning text-dark"
-        >{{ pinned_items|length }}/3</span
-      >
-    </div>
-    <div class="row g-3">
-      {% for bilgi in pinned_items %} {% include "partials/bilgi_card.html" %}
-      {% endfor %}
-    </div>
-  </section>
-  {% endif %}
-
-  <section>
-    <div class="d-flex align-items-center gap-2 mb-2">
-      <span class="text-uppercase text-muted fw-semibold small"
-        >Tüm Bilgiler</span
-      >
-    </div>
-    <div class="row g-3" id="bilgiList">
-      {% if other_items %} {% for bilgi in other_items %} {% include
-      "partials/bilgi_card.html" %} {% endfor %} {% else %}
-      <div class="col-12">
-        <div class="alert alert-info mb-0">
-          Henüz paylaşılmış bilgi bulunmuyor. İlk bilgiyi siz ekleyin!
-        </div>
+    {% if pinned_items %}
+    <section class="mb-5" id="pinnedBilgiler">
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <span class="text-uppercase text-muted fw-semibold small"
+          >Sabitlenen Bilgiler</span
+        >
+        <span class="badge bg-warning text-dark"
+          >{{ pinned_items|length }}/3</span
+        >
       </div>
-      {% endif %}
-    </div>
-  </section>
-</div>
+      <div class="row g-3">
+        {% for bilgi in pinned_items %} {% include "partials/bilgi_card.html" %}
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
+
+    <section>
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <span class="text-uppercase text-muted fw-semibold small"
+          >Tüm Bilgiler</span
+        >
+      </div>
+      <div class="row g-3" id="bilgiList">
+        {% if other_items %} {% for bilgi in other_items %} {% include
+        "partials/bilgi_card.html" %} {% endfor %} {% else %}
+        <div class="col-12">
+          <div class="alert alert-info mb-0">
+            Henüz paylaşılmış bilgi bulunmuyor. İlk bilgiyi siz ekleyin!
+          </div>
+        </div>
+        {% endif %}
+      </div>
+    </section>
+  </div>
 </div>
 
 <div class="modal fade" id="bilgiModal" tabindex="-1" aria-hidden="true">

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -1,111 +1,159 @@
 {% extends "base.html" %} {% block title %}Envanter Listesi{% endblock %} {%
 block content %}
-<div id="inventory-list-root" class="container-fluid p-2">
-  <div class="d-flex align-items-center justify-content-between mb-3">
-    <h5 class="mb-0">Envanter</h5>
-    <div class="d-flex align-items-center gap-2 flex-wrap">
-      <a
-        href="#"
-        id="addBtn"
-        class="btn btn-success btn-sm d-flex align-items-center gap-1"
-        title="Yeni Ekle"
-      >
-        <i class="bi bi-plus-lg"></i>
-        <span>Ekle</span>
-      </a>
-      {% with fault_entity='inventory', fault_prefix='inventory',
-      fault_label='Envanter Arızalı Durum' %} {% include
-      'partials/_fault_controls.html' %} {% endwith %}
-      <div class="dropdown">
-        <button
-          class="btn btn-outline-primary btn-sm dropdown-toggle"
-          type="button"
-          data-bs-toggle="dropdown"
-          aria-expanded="false"
-        >
-          Excel
-        </button>
-        <ul class="dropdown-menu dropdown-menu-end">
-          <li>
-            <a class="dropdown-item" href="/inventory/export">Dışa Aktar</a>
-          </li>
-          <li>
-            <form
-              action="/inventory/import"
-              method="post"
-              enctype="multipart/form-data"
-            >
-              <input
-                type="file"
-                name="file"
-                id="invExcel"
-                class="d-none"
-                onchange="this.form.submit()"
-              />
-              <label for="invExcel" class="dropdown-item mb-0">İçe Aktar</label>
-            </form>
-          </li>
-        </ul>
+<div class="container-fluid py-4">
+  <div class="page-shell">
+    <header class="page-header">
+      <div class="page-header__heading">
+        <span class="eyebrow text-primary">ENVANTER YÖNETİMİ</span>
+        <h1 class="page-header__title">Envanter Listesi</h1>
+        <p class="page-header__subtitle">
+          Envanterinizdeki tüm cihazları görüntüleyin ve yönetin.
+        </p>
       </div>
-      <button class="btn btn-outline-secondary btn-sm" id="filterBtn">
-        Filtre
-      </button>
-      <button
-        class="btn btn-outline-secondary btn-sm d-none"
-        id="clearFilterBtn"
-      >
-        Temizle
-      </button>
-      <input
-        type="text"
-        id="searchInput"
-        class="form-control form-control-sm"
-        placeholder="Ara..."
-      />
+      <div class="page-header__actions page-actions">
+        <div class="page-actions__group">
+          <a
+            href="#"
+            id="addBtn"
+            class="btn btn-success btn-sm"
+            title="Yeni Ekle"
+          >
+            <i class="bi bi-plus-lg"></i>
+            <span>Ekle</span>
+          </a>
+          {% with fault_entity='inventory', fault_prefix='inventory',
+          fault_label='Envanter Arızalı Durum' %} {% include
+          'partials/_fault_controls.html' %} {% endwith %}
+          <div class="dropdown">
+            <button
+              class="btn btn-outline-primary btn-sm dropdown-toggle"
+              type="button"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+            >
+              Excel
+            </button>
+            <ul class="dropdown-menu dropdown-menu-end">
+              <li>
+                <a class="dropdown-item" href="/inventory/export">Dışa Aktar</a>
+              </li>
+              <li>
+                <form
+                  action="/inventory/import"
+                  method="post"
+                  enctype="multipart/form-data"
+                >
+                  <input
+                    type="file"
+                    name="file"
+                    id="invExcel"
+                    class="d-none"
+                    onchange="this.form.submit()"
+                  />
+                  <label for="invExcel" class="dropdown-item mb-0"
+                    >İçe Aktar</label
+                  >
+                </form>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div class="filter-search-bar">
+      <div class="filter-search-bar__row">
+        <div class="filter-search-bar__main">
+          <div class="search-wrapper">
+            <i class="bi bi-search"></i>
+            <input
+              type="text"
+              id="searchInput"
+              class="form-control form-control-sm"
+              placeholder="Envanter ara..."
+            />
+          </div>
+          <div class="filter-group">
+            <label for="fabrikaFilter">Fabrika:</label>
+            <select id="fabrikaFilter" class="form-select form-select-sm">
+              <option value="">Tümü</option>
+            </select>
+          </div>
+          <div class="filter-group">
+            <label for="departmanFilter">Departman:</label>
+            <select id="departmanFilter" class="form-select form-select-sm">
+              <option value="">Tümü</option>
+            </select>
+          </div>
+        </div>
+        <div class="filter-search-bar__actions">
+          <button class="btn btn-primary btn-sm" id="filterBtn">
+            <i class="bi bi-funnel"></i>
+            Filtrele
+          </button>
+          <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">
+            <i class="bi bi-x-circle"></i>
+            Temizle
+          </button>
+        </div>
+      </div>
+      <div class="active-filters-section d-none" id="activeFiltersSection">
+        <div class="active-filters">
+          <span class="active-filters__label">Aktif Filtreler:</span>
+          <div id="activeFilterBadges"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="page-card">
+      <div class="table-responsive">
+        <table
+          id="inventoryTable"
+          class="table table-sm table-hover table-rounded align-middle mb-0"
+        >
+          <thead>
+            <tr>
+              <th data-field="no">Envanter No</th>
+              <th data-field="fabrika">Fabrika</th>
+              <th data-field="departman">Departman</th>
+              <th data-field="sorumlu_personel">Sorumlu</th>
+              <th data-field="marka">Marka/Model</th>
+              <th style="width: 180px">İşlemler</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in items %}
+            <tr
+              data-id="{{ row.id }}"
+              data-fabrika="{{ row.fabrika or '' }}"
+              data-departman="{{ row.departman or '' }}"
+              data-sorumlu="{{ row.sorumlu_personel or '' }}"
+              data-bagli="{{ row.bagli_envanter_no or '' }}"
+              class="inv-row{% if row.durum == 'arızalı' %} table-warning{% endif %}"
+            >
+              <td>
+                {{ row.no }} {% if row.durum == 'arızalı' %}
+                <span class="badge text-bg-warning text-dark ms-1">Arızalı</span>
+                {% endif %}
+              </td>
+              <td>{{ row.fabrika }}</td>
+              <td>{{ row.departman }}</td>
+              <td>{{ row.sorumlu_personel }}</td>
+              <td>{{ row.marka }} {{ row.model }}</td>
+              <td class="text-nowrap">
+                {% set entity = 'inventory' %} {% set row_id = row.id %} {% set
+                fault_mode = True %} {% set fault_device = row.no %} {% set
+                fault_title = (row.marka ~ ' ' ~ row.model)|trim %} {% set
+                fault_entity_key = row.no %} {% set fault_status = row.durum %}
+                {% include 'partials/_actions_menu.html' %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
-
-  <table class="table table-sm table-striped align-middle table-rounded">
-    <thead>
-      <tr>
-        <th data-field="no">Envanter No</th>
-        <th data-field="fabrika">Fabrika</th>
-        <th data-field="departman">Departman</th>
-        <th data-field="sorumlu_personel">Sorumlu</th>
-        <th data-field="marka">Marka/Model</th>
-        <th style="width: 180px">İşlemler</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for row in items %}
-      <tr
-        data-id="{{ row.id }}"
-        data-fabrika="{{ row.fabrika or '' }}"
-        data-departman="{{ row.departman or '' }}"
-        data-sorumlu="{{ row.sorumlu_personel or '' }}"
-        data-bagli="{{ row.bagli_envanter_no or '' }}"
-        class="inv-row{% if row.durum == 'arızalı' %} table-warning{% endif %}"
-      >
-        <td>
-          {{ row.no }} {% if row.durum == 'arızalı' %}
-          <span class="badge text-bg-warning text-dark ms-1">Arızalı</span>
-          {% endif %}
-        </td>
-        <td>{{ row.fabrika }}</td>
-        <td>{{ row.departman }}</td>
-        <td>{{ row.sorumlu_personel }}</td>
-        <td>{{ row.marka }} {{ row.model }}</td>
-        <td class="text-nowrap">
-          {% set entity = 'inventory' %} {% set row_id = row.id %} {% set
-          fault_mode = True %} {% set fault_device = row.no %} {% set
-          fault_title = (row.marka ~ ' ' ~ row.model)|trim %} {% set
-          fault_entity_key = row.no %} {% set fault_status = row.durum %} {%
-          include 'partials/_actions_menu.html' %}
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
 </div>
 
 <style>
@@ -401,29 +449,23 @@ block content %}
 </script>
 
 <!-- Filtre Modal -->
-<div class="modal fade" id="filterModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form id="filterForm" class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Filtrele</h5>
-        <button
-          type="button"
-          class="btn-close"
-          data-bs-dismiss="modal"
-        ></button>
-      </div>
-      <div class="modal-body">
-        <div id="filterRows"></div>
-      </div>
-      <div class="modal-footer">
-        <button
-          type="button"
-          class="btn btn-secondary btn-sm"
-          data-bs-dismiss="modal"
-        >
-          Kapat
-        </button>
-        <button type="submit" class="btn btn-primary btn-sm">Uygula</button>
+<div class="modal fade" id="filterModal" tabindex="-1">
+  <div class="modal-dialog modal-dialog-centered">
+    <form id="filterForm" class="modal-content border-0 bg-transparent p-0">
+      <div class="modal-shell">
+        <div class="modal-shell__header">
+          <h5 class="modal-shell__title">Gelişmiş Filtre</h5>
+          <p class="modal-shell__subtitle">Birden fazla kritere göre filtreleyin</p>
+        </div>
+        <div class="modal-shell__body filter-modal-body">
+          <div id="filterRows" class="filter-rows-container"></div>
+        </div>
+        <div class="modal-shell__footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+            İptal
+          </button>
+          <button type="submit" class="btn btn-primary">Uygula</button>
+        </div>
       </div>
     </form>
   </div>
@@ -515,333 +557,286 @@ block content %}
 </div>
 
 <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    const assignModal = new bootstrap.Modal(
-      document.getElementById("assignModal"),
-    );
-    const scrapModal = new bootstrap.Modal(
-      document.getElementById("scrapModal"),
-    );
-    const addModal = new bootstrap.Modal(
-      document.getElementById("inventoryCreateModal"),
-    );
-    const filterModal = new bootstrap.Modal(
-      document.getElementById("filterModal"),
-    );
+  document.addEventListener('DOMContentLoaded', async () => {
+    const assignModalEl = document.getElementById('assignModal');
+    const scrapModalEl = document.getElementById('scrapModal');
+    const addModalEl = document.getElementById('inventoryCreateModal');
 
-    const searchInput = document.getElementById("searchInput");
-    const filterForm = document.getElementById("filterForm");
-    const clearBtn = document.getElementById("clearFilterBtn");
-    const filterRowsDiv = document.getElementById("filterRows");
-    const distinctUrl =
-      "{{ url_for('lookup.distinct', entity='inventory', column='__COL__') }}";
-    let activeFilters = [];
-    const columns = Array.from(document.querySelectorAll("table thead th"))
-      .map((th, idx) => ({
-        idx,
+    const assignModal = assignModalEl
+      ? bootstrap.Modal.getOrCreateInstance(assignModalEl)
+      : null;
+    const scrapModal = scrapModalEl
+      ? bootstrap.Modal.getOrCreateInstance(scrapModalEl)
+      : null;
+    const addModal = addModalEl
+      ? bootstrap.Modal.getOrCreateInstance(addModalEl)
+      : null;
+
+    const addBtn = document.getElementById('addBtn');
+    if (addBtn && addModal) {
+      addBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        addModal.show();
+      });
+    }
+
+    await loadInventoryFormOptions();
+
+    await populateDistinctValues('fabrikaFilter', 'inventory', 'fabrika');
+    await populateDistinctValues('departmanFilter', 'inventory', 'departman');
+
+    const filterSystem = new UnifiedFilterSystem({
+      tableSelector: '#inventoryTable',
+      searchInputId: 'searchInput',
+      filters: [
+        { id: 'fabrikaFilter', label: 'Fabrika', columnField: 'fabrika' },
+        { id: 'departmanFilter', label: 'Departman', columnField: 'departman' },
+      ],
+    });
+    window.filterSystem = filterSystem;
+
+    const tableColumns = Array.from(
+      document.querySelectorAll('#inventoryTable thead th'),
+    )
+      .map((th) => ({
         name: th.textContent.trim(),
         field: th.dataset.field,
       }))
-      .filter((c) => c.field);
+      .filter((column) => column.field);
 
-    // Envanter ekleme formundaki dropdown'ları doldur
-    (async function () {
-      async function loadOptions(sel, url) {
-        const res = await fetch(url);
-        const data = await res.json();
-        sel.innerHTML =
+    if (tableColumns.length) {
+      const advancedFilter = new AdvancedFilterModal({
+        modalId: 'filterModal',
+        formId: 'filterForm',
+        triggerId: 'filterBtn',
+        columns: tableColumns,
+        distinctUrl:
+          "{{ url_for('lookup.distinct', entity='inventory', column='__COL__') }}",
+      });
+      filterSystem.registerAdvancedFilter(advancedFilter);
+      window.advancedFilter = advancedFilter;
+    }
+
+    document.querySelectorAll('.action-select').forEach((sel) => {
+      sel.addEventListener('change', async (event) => {
+        const value = event.target.value;
+        if (!value) return;
+        const id = event.target.dataset.id;
+        if (!id) return;
+
+        if (value === 'assign') {
+          event.stopImmediatePropagation();
+          const row = event.target.closest('tr');
+          const assignInput = document.getElementById('assign_item_id');
+          if (assignInput) {
+            assignInput.value = id;
+          }
+          await preloadAssignDropdowns(id);
+          if (row) {
+            setSelectValue('selFabrika', row.dataset.fabrika);
+            setSelectValue('selDepartman', row.dataset.departman);
+            setSelectValue('selPersonel', row.dataset.sorumlu);
+            setSelectValue('selBagli', row.dataset.bagli);
+          }
+          if (assignModal) assignModal.show();
+          event.target.value = '';
+          return;
+        }
+
+        if (value === 'fault') {
+          if (window.Faults) {
+            event.stopImmediatePropagation();
+            window.Faults.openMarkModal('inventory', {
+              entityId: Number(id),
+              entityKey:
+                event.target.dataset.entityKey ||
+                event.target.dataset.device ||
+                id,
+              deviceNo: event.target.dataset.device || '',
+              title: event.target.dataset.title || '',
+            });
+          }
+          event.target.value = '';
+          return;
+        }
+
+        if (value === 'repair') {
+          if (window.Faults) {
+            event.stopImmediatePropagation();
+            window.Faults.openRepairModal('inventory', {
+              entityId: Number(id),
+              entityKey:
+                event.target.dataset.entityKey ||
+                event.target.dataset.device ||
+                id,
+              deviceNo: event.target.dataset.device || '',
+            });
+          }
+          event.target.value = '';
+          return;
+        }
+
+        if (value === 'scrap') {
+          event.stopImmediatePropagation();
+          const scrapInput = document.getElementById('scrap_item_id');
+          if (scrapInput) {
+            scrapInput.value = id;
+          }
+          if (scrapModal) scrapModal.show();
+          event.target.value = '';
+        }
+      });
+    });
+
+    const assignForm = document.getElementById('assignForm');
+    if (assignForm) {
+      assignForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const response = await fetch(`{{ url_for('inventory.assign') }}`, {
+          method: 'POST',
+          body: formData,
+        });
+        if (response.ok) {
+          window.location.reload();
+        } else {
+          alert('Atama kaydedilemedi');
+        }
+      });
+    }
+
+    const scrapForm = document.getElementById('scrapForm');
+    if (scrapForm) {
+      scrapForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const response = await fetch(`{{ url_for('inventory.scrap') }}`, {
+          method: 'POST',
+          body: formData,
+        });
+        if (response.ok) {
+          window.location.href = `{{ url_for('inventory.hurdalar') }}`;
+        } else {
+          alert('Hurdaya ayırma başarısız');
+        }
+      });
+    }
+
+    async function loadInventoryFormOptions() {
+      async function loadOptions(selectEl, url) {
+        if (!selectEl) return;
+        const response = await fetch(url);
+        const data = await response.json();
+        selectEl.innerHTML =
           '<option value="">Seçiniz...</option>' +
           data
             .map(
-              (o) =>
-                `<option value="${o.text}" data-id="${o.id}">${o.text}</option>`,
+              (item) =>
+                `<option value="${item.text}" data-id="${item.id}">${item.text}</option>`,
             )
-            .join("");
+            .join('');
       }
 
-      const fabrikaSel = document.getElementById("fabrika");
-      const departmanSel = document.getElementById("departman");
-      const donanimSel = document.getElementById("donanim_tipi");
-      const personelSel = document.getElementById("sorumlu_personel");
-      const markaSel = document.getElementById("marka");
-      const modelSel = document.getElementById("model");
+      const fabrikaSel = document.getElementById('fabrika');
+      const departmanSel = document.getElementById('departman');
+      const donanimSel = document.getElementById('donanim_tipi');
+      const personelSel = document.getElementById('sorumlu_personel');
+      const markaSel = document.getElementById('marka');
+      const modelSel = document.getElementById('model');
 
-      await loadOptions(fabrikaSel, "/api/picker/fabrika");
-      await loadOptions(departmanSel, "/api/picker/kullanim_alani");
-      await loadOptions(donanimSel, "/api/picker/donanim_tipi");
-      await _selects.fillChoices({
-        endpoint: "/api/picker/kullanici",
-        selectId: "sorumlu_personel",
-        mapFn: (r) => ({ value: r.text, label: r.text }),
-      });
-      _selects.enableRemoteSearch(
-        "sorumlu_personel",
-        "/api/picker/kullanici",
-        () => ({}),
-        (r) => ({ value: r.text, label: r.text }),
-      );
+      await loadOptions(fabrikaSel, '/api/picker/fabrika');
+      await loadOptions(departmanSel, '/api/picker/kullanim_alani');
+      await loadOptions(donanimSel, '/api/picker/donanim_tipi');
 
-      const brandRes = await fetch("/api/picker/marka");
-      const brands = await brandRes.json();
-      markaSel.innerHTML =
-        '<option value="">Seçiniz...</option>' +
-        brands
-          .map(
-            (b) =>
-              `<option value="${b.text}" data-id="${b.id}">${b.text}</option>`,
-          )
-          .join("");
-
-      markaSel.addEventListener("change", async () => {
-        const opt = markaSel.options[markaSel.selectedIndex];
-        const brandId = opt && opt.dataset.id;
-        modelSel.innerHTML = '<option value="">Seçiniz...</option>';
-        modelSel.disabled = !brandId;
-        if (!brandId) return;
-        const res = await fetch(`/api/picker/model?marka_id=${brandId}`);
-        const models = await res.json();
-        modelSel.innerHTML += models
-          .map((m) => `<option value="${m.text}">${m.text}</option>`)
-          .join("");
-      });
-    })();
-
-    document.getElementById("addBtn").addEventListener("click", () => {
-      addModal.show();
-    });
-
-    document.getElementById("filterBtn").addEventListener("click", () => {
-      filterForm.reset();
-      filterRowsDiv.innerHTML = "";
-      createFilterRow();
-      filterModal.show();
-    });
-
-    clearBtn.addEventListener("click", () => {
-      activeFilters = [];
-      filterRows();
-      clearBtn.classList.add("d-none");
-    });
-
-    searchInput.addEventListener("input", filterRows);
-
-    function createFilterRow() {
-      const row = document.createElement("div");
-      row.className = "row g-2 align-items-center mb-2 filter-row";
-      row.innerHTML = `
-      <div class="col-5">
-        <select class="form-select form-select-sm column-select">
-          ${columns.map((c) => `<option value="${c.idx}">${c.name}</option>`).join("")}
-        </select>
-      </div>
-      <div class="col-5">
-        <select class="form-select form-select-sm value-select"></select>
-      </div>
-      <div class="col-2 d-flex gap-1">
-        <button type="button" class="btn btn-success btn-sm add-row">+</button>
-        <button type="button" class="btn btn-danger btn-sm remove-row">-</button>
-      </div>`;
-      filterRowsDiv.appendChild(row);
-      const colSel = row.querySelector(".column-select");
-      const valSel = row.querySelector(".value-select");
-      loadValues(colSel, valSel);
-      colSel.addEventListener("change", () => loadValues(colSel, valSel));
-      updateRemoveButtons();
-    }
-
-    async function loadValues(colSelect, valSelect) {
-      const col = columns.find((c) => c.idx == colSelect.value);
-      const res = await fetch(distinctUrl.replace("__COL__", col.field));
-      const data = await res.json();
-      valSelect.innerHTML =
-        '<option value="">Seçiniz</option>' +
-        data.map((v) => `<option value="${v}">${v}</option>`).join("");
-    }
-
-    function updateRemoveButtons() {
-      const rows = filterRowsDiv.querySelectorAll(".filter-row");
-      rows.forEach((r) =>
-        r
-          .querySelector(".remove-row")
-          .classList.toggle("d-none", rows.length === 1),
-      );
-    }
-
-    filterForm.addEventListener("click", (e) => {
-      if (e.target.classList.contains("add-row")) {
-        createFilterRow();
-      } else if (e.target.classList.contains("remove-row")) {
-        e.target.closest(".filter-row").remove();
-        updateRemoveButtons();
-      }
-    });
-
-    filterForm.addEventListener("submit", (e) => {
-      e.preventDefault();
-      activeFilters = [];
-      filterRowsDiv.querySelectorAll(".filter-row").forEach((row) => {
-        const col = parseInt(row.querySelector(".column-select").value, 10);
-        const val = row
-          .querySelector(".value-select")
-          .value.trim()
-          .toLowerCase();
-        if (val) activeFilters.push({ col, val });
-      });
-      filterModal.hide();
-      clearBtn.classList.toggle("d-none", activeFilters.length === 0);
-      filterRows();
-    });
-
-    function filterRows() {
-      const q = searchInput.value.toLowerCase();
-      document.querySelectorAll("tbody tr").forEach((tr) => {
-        const cells = tr.querySelectorAll("td");
-        const texts = Array.from(cells).map((td) =>
-          td.textContent.toLowerCase(),
+      if (personelSel && window._selects) {
+        await _selects.fillChoices({
+          endpoint: '/api/picker/kullanici',
+          selectId: 'sorumlu_personel',
+          mapFn: (row) => ({ value: row.text, label: row.text }),
+        });
+        _selects.enableRemoteSearch(
+          'sorumlu_personel',
+          '/api/picker/kullanici',
+          () => ({}),
+          (row) => ({ value: row.text, label: row.text }),
         );
-        let match = texts.some((t) => t.includes(q));
-        if (activeFilters.length) {
-          match =
-            match &&
-            activeFilters.every(
-              (f) => texts[f.col] && texts[f.col].includes(f.val),
-            );
-        }
-        tr.classList.toggle("d-none", !match);
-      });
+      }
+
+      if (markaSel) {
+        const response = await fetch('/api/picker/marka');
+        const brands = await response.json();
+        markaSel.innerHTML =
+          '<option value="">Seçiniz...</option>' +
+          brands
+            .map(
+              (brand) =>
+                `<option value="${brand.text}" data-id="${brand.id}">${brand.text}</option>`,
+            )
+            .join('');
+        markaSel.addEventListener('change', async () => {
+          const option = markaSel.options[markaSel.selectedIndex];
+          const brandId = option && option.dataset.id;
+          if (!modelSel) return;
+          modelSel.innerHTML = '<option value="">Seçiniz...</option>';
+          modelSel.disabled = !brandId;
+          if (!brandId) return;
+          const modelResponse = await fetch(`/api/picker/model?marka_id=${brandId}`);
+          const models = await modelResponse.json();
+          modelSel.innerHTML += models
+            .map((model) => `<option value="${model.text}">${model.text}</option>`)
+            .join('');
+        });
+      }
     }
-
-    // İşlem seçimi
-    document.querySelectorAll(".action-select").forEach((sel) => {
-      sel.addEventListener("change", async (e) => {
-        const val = e.target.value;
-        if (!val) return;
-        const id = e.target.dataset.id;
-        if (!id) return;
-
-        if (val === "assign") {
-          e.stopImmediatePropagation();
-          const tr = e.target.closest("tr");
-          document.getElementById("assign_item_id").value = id;
-          await preloadAssignDropdowns(id);
-          if (tr) {
-            setSelectValue("selFabrika", tr.dataset.fabrika);
-            setSelectValue("selDepartman", tr.dataset.departman);
-            setSelectValue("selPersonel", tr.dataset.sorumlu);
-            setSelectValue("selBagli", tr.dataset.bagli);
-          }
-          assignModal.show();
-          e.target.value = "";
-          return;
-        }
-
-        if (val === "fault") {
-          if (window.Faults) {
-            e.stopImmediatePropagation();
-            window.Faults.openMarkModal("inventory", {
-              entityId: Number(id),
-              entityKey:
-                e.target.dataset.entityKey || e.target.dataset.device || id,
-              deviceNo: e.target.dataset.device || "",
-              title: e.target.dataset.title || "",
-            });
-          }
-          e.target.value = "";
-          return;
-        }
-
-        if (val === "repair") {
-          if (window.Faults) {
-            e.stopImmediatePropagation();
-            window.Faults.openRepairModal("inventory", {
-              entityId: Number(id),
-              entityKey:
-                e.target.dataset.entityKey || e.target.dataset.device || id,
-              deviceNo: e.target.dataset.device || "",
-            });
-          }
-          e.target.value = "";
-          return;
-        }
-
-        if (val === "scrap") {
-          e.stopImmediatePropagation();
-          document.getElementById("scrap_item_id").value = id;
-          scrapModal.show();
-          e.target.value = "";
-        }
-      });
-    });
 
     async function preloadAssignDropdowns(itemId) {
-      const [fabr, dept, users, invs] = await Promise.all([
-        fetch(`{{ url_for('inventory.assign_sources') }}?type=fabrika`).then(
-          (r) => r.json(),
+      const [factories, departments, users, inventories] = await Promise.all([
+        fetch(`{{ url_for('inventory.assign_sources') }}?type=fabrika`).then((r) =>
+          r.json(),
         ),
-        fetch(`{{ url_for('inventory.assign_sources') }}?type=departman`).then(
-          (r) => r.json(),
+        fetch(`{{ url_for('inventory.assign_sources') }}?type=departman`).then((r) =>
+          r.json(),
         ),
-        fetch(`{{ url_for('inventory.assign_sources') }}?type=users`).then(
-          (r) => r.json(),
+        fetch(`{{ url_for('inventory.assign_sources') }}?type=users`).then((r) =>
+          r.json(),
         ),
         fetch(
           `{{ url_for('inventory.assign_sources') }}?type=envanter&exclude_id=` +
             itemId,
         ).then((r) => r.json()),
       ]);
-      fillSelect("selFabrika", fabr);
-      fillSelect("selDepartman", dept);
-      fillSelect("selPersonel", users);
-      fillSelect("selBagli", invs);
+
+      fillSelect('selFabrika', factories);
+      fillSelect('selDepartman', departments);
+      fillSelect('selPersonel', users);
+      fillSelect('selBagli', inventories);
     }
-    function fillSelect(id, arr) {
-      const el = document.getElementById(id);
-      el.innerHTML =
+
+    function fillSelect(selectId, items) {
+      const selectEl = document.getElementById(selectId);
+      if (!selectEl) return;
+      selectEl.innerHTML =
         '<option value="">Seçiniz</option>' +
-        arr.map((x) => `<option value="${x.id}">${x.text}</option>`).join("");
+        items
+          .map((item) => `<option value="${item.id}">${item.text}</option>`)
+          .join('');
     }
 
     function setSelectValue(selectId, value) {
-      const el = document.getElementById(selectId);
-      if (!el) return;
-      const val = value || "";
-      if (val && !Array.from(el.options).some((opt) => opt.value === val)) {
-        const opt = document.createElement("option");
-        opt.value = val;
-        opt.textContent = val;
-        el.appendChild(opt);
+      const selectEl = document.getElementById(selectId);
+      if (!selectEl) return;
+      const normalized = value || '';
+      if (
+        normalized &&
+        !Array.from(selectEl.options).some((option) => option.value === normalized)
+      ) {
+        const option = document.createElement('option');
+        option.value = normalized;
+        option.textContent = normalized;
+        selectEl.appendChild(option);
       }
-      el.value = val;
+      selectEl.value = normalized;
     }
-
-    // Atama submit
-    document
-      .getElementById("assignForm")
-      .addEventListener("submit", async (e) => {
-        e.preventDefault();
-        const fd = new FormData(e.target);
-        const res = await fetch(`{{ url_for('inventory.assign') }}`, {
-          method: "POST",
-          body: fd,
-        });
-        if (res.ok) location.reload();
-        else alert("Atama kaydedilemedi");
-      });
-
-    // Hurda submit
-    document
-      .getElementById("scrapForm")
-      .addEventListener("submit", async (e) => {
-        e.preventDefault();
-        const fd = new FormData(e.target);
-        const res = await fetch(`{{ url_for('inventory.scrap') }}`, {
-          method: "POST",
-          body: fd,
-        });
-        if (res.ok)
-          window.location.href = `{{ url_for('inventory.hurdalar') }}`;
-        else alert("Hurdaya ayırma başarısız");
-      });
   });
 </script>
 {% endblock %}

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -91,7 +91,10 @@ block content %}
             <i class="bi bi-funnel"></i>
             Filtrele
           </button>
-          <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">
+          <button
+            class="btn btn-outline-secondary btn-sm d-none"
+            id="clearFilterBtn"
+          >
             <i class="bi bi-x-circle"></i>
             Temizle
           </button>
@@ -133,7 +136,9 @@ block content %}
             >
               <td>
                 {{ row.no }} {% if row.durum == 'arızalı' %}
-                <span class="badge text-bg-warning text-dark ms-1">Arızalı</span>
+                <span class="badge text-bg-warning text-dark ms-1"
+                  >Arızalı</span
+                >
                 {% endif %}
               </td>
               <td>{{ row.fabrika }}</td>
@@ -455,13 +460,19 @@ block content %}
       <div class="modal-shell">
         <div class="modal-shell__header">
           <h5 class="modal-shell__title">Gelişmiş Filtre</h5>
-          <p class="modal-shell__subtitle">Birden fazla kritere göre filtreleyin</p>
+          <p class="modal-shell__subtitle">
+            Birden fazla kritere göre filtreleyin
+          </p>
         </div>
         <div class="modal-shell__body filter-modal-body">
           <div id="filterRows" class="filter-rows-container"></div>
         </div>
         <div class="modal-shell__footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            data-bs-dismiss="modal"
+          >
             İptal
           </button>
           <button type="submit" class="btn btn-primary">Uygula</button>
@@ -557,10 +568,10 @@ block content %}
 </div>
 
 <script>
-  document.addEventListener('DOMContentLoaded', async () => {
-    const assignModalEl = document.getElementById('assignModal');
-    const scrapModalEl = document.getElementById('scrapModal');
-    const addModalEl = document.getElementById('inventoryCreateModal');
+  document.addEventListener("DOMContentLoaded", async () => {
+    const assignModalEl = document.getElementById("assignModal");
+    const scrapModalEl = document.getElementById("scrapModal");
+    const addModalEl = document.getElementById("inventoryCreateModal");
 
     const assignModal = assignModalEl
       ? bootstrap.Modal.getOrCreateInstance(assignModalEl)
@@ -572,9 +583,9 @@ block content %}
       ? bootstrap.Modal.getOrCreateInstance(addModalEl)
       : null;
 
-    const addBtn = document.getElementById('addBtn');
+    const addBtn = document.getElementById("addBtn");
     if (addBtn && addModal) {
-      addBtn.addEventListener('click', (event) => {
+      addBtn.addEventListener("click", (event) => {
         event.preventDefault();
         addModal.show();
       });
@@ -582,21 +593,21 @@ block content %}
 
     await loadInventoryFormOptions();
 
-    await populateDistinctValues('fabrikaFilter', 'inventory', 'fabrika');
-    await populateDistinctValues('departmanFilter', 'inventory', 'departman');
+    await populateDistinctValues("fabrikaFilter", "inventory", "fabrika");
+    await populateDistinctValues("departmanFilter", "inventory", "departman");
 
     const filterSystem = new UnifiedFilterSystem({
-      tableSelector: '#inventoryTable',
-      searchInputId: 'searchInput',
+      tableSelector: "#inventoryTable",
+      searchInputId: "searchInput",
       filters: [
-        { id: 'fabrikaFilter', label: 'Fabrika', columnField: 'fabrika' },
-        { id: 'departmanFilter', label: 'Departman', columnField: 'departman' },
+        { id: "fabrikaFilter", label: "Fabrika", columnField: "fabrika" },
+        { id: "departmanFilter", label: "Departman", columnField: "departman" },
       ],
     });
     window.filterSystem = filterSystem;
 
     const tableColumns = Array.from(
-      document.querySelectorAll('#inventoryTable thead th'),
+      document.querySelectorAll("#inventoryTable thead th"),
     )
       .map((th) => ({
         name: th.textContent.trim(),
@@ -606,9 +617,9 @@ block content %}
 
     if (tableColumns.length) {
       const advancedFilter = new AdvancedFilterModal({
-        modalId: 'filterModal',
-        formId: 'filterForm',
-        triggerId: 'filterBtn',
+        modalId: "filterModal",
+        formId: "filterForm",
+        triggerId: "filterBtn",
         columns: tableColumns,
         distinctUrl:
           "{{ url_for('lookup.distinct', entity='inventory', column='__COL__') }}",
@@ -617,107 +628,107 @@ block content %}
       window.advancedFilter = advancedFilter;
     }
 
-    document.querySelectorAll('.action-select').forEach((sel) => {
-      sel.addEventListener('change', async (event) => {
+    document.querySelectorAll(".action-select").forEach((sel) => {
+      sel.addEventListener("change", async (event) => {
         const value = event.target.value;
         if (!value) return;
         const id = event.target.dataset.id;
         if (!id) return;
 
-        if (value === 'assign') {
+        if (value === "assign") {
           event.stopImmediatePropagation();
-          const row = event.target.closest('tr');
-          const assignInput = document.getElementById('assign_item_id');
+          const row = event.target.closest("tr");
+          const assignInput = document.getElementById("assign_item_id");
           if (assignInput) {
             assignInput.value = id;
           }
           await preloadAssignDropdowns(id);
           if (row) {
-            setSelectValue('selFabrika', row.dataset.fabrika);
-            setSelectValue('selDepartman', row.dataset.departman);
-            setSelectValue('selPersonel', row.dataset.sorumlu);
-            setSelectValue('selBagli', row.dataset.bagli);
+            setSelectValue("selFabrika", row.dataset.fabrika);
+            setSelectValue("selDepartman", row.dataset.departman);
+            setSelectValue("selPersonel", row.dataset.sorumlu);
+            setSelectValue("selBagli", row.dataset.bagli);
           }
           if (assignModal) assignModal.show();
-          event.target.value = '';
+          event.target.value = "";
           return;
         }
 
-        if (value === 'fault') {
+        if (value === "fault") {
           if (window.Faults) {
             event.stopImmediatePropagation();
-            window.Faults.openMarkModal('inventory', {
+            window.Faults.openMarkModal("inventory", {
               entityId: Number(id),
               entityKey:
                 event.target.dataset.entityKey ||
                 event.target.dataset.device ||
                 id,
-              deviceNo: event.target.dataset.device || '',
-              title: event.target.dataset.title || '',
+              deviceNo: event.target.dataset.device || "",
+              title: event.target.dataset.title || "",
             });
           }
-          event.target.value = '';
+          event.target.value = "";
           return;
         }
 
-        if (value === 'repair') {
+        if (value === "repair") {
           if (window.Faults) {
             event.stopImmediatePropagation();
-            window.Faults.openRepairModal('inventory', {
+            window.Faults.openRepairModal("inventory", {
               entityId: Number(id),
               entityKey:
                 event.target.dataset.entityKey ||
                 event.target.dataset.device ||
                 id,
-              deviceNo: event.target.dataset.device || '',
+              deviceNo: event.target.dataset.device || "",
             });
           }
-          event.target.value = '';
+          event.target.value = "";
           return;
         }
 
-        if (value === 'scrap') {
+        if (value === "scrap") {
           event.stopImmediatePropagation();
-          const scrapInput = document.getElementById('scrap_item_id');
+          const scrapInput = document.getElementById("scrap_item_id");
           if (scrapInput) {
             scrapInput.value = id;
           }
           if (scrapModal) scrapModal.show();
-          event.target.value = '';
+          event.target.value = "";
         }
       });
     });
 
-    const assignForm = document.getElementById('assignForm');
+    const assignForm = document.getElementById("assignForm");
     if (assignForm) {
-      assignForm.addEventListener('submit', async (event) => {
+      assignForm.addEventListener("submit", async (event) => {
         event.preventDefault();
         const formData = new FormData(event.target);
         const response = await fetch(`{{ url_for('inventory.assign') }}`, {
-          method: 'POST',
+          method: "POST",
           body: formData,
         });
         if (response.ok) {
           window.location.reload();
         } else {
-          alert('Atama kaydedilemedi');
+          alert("Atama kaydedilemedi");
         }
       });
     }
 
-    const scrapForm = document.getElementById('scrapForm');
+    const scrapForm = document.getElementById("scrapForm");
     if (scrapForm) {
-      scrapForm.addEventListener('submit', async (event) => {
+      scrapForm.addEventListener("submit", async (event) => {
         event.preventDefault();
         const formData = new FormData(event.target);
         const response = await fetch(`{{ url_for('inventory.scrap') }}`, {
-          method: 'POST',
+          method: "POST",
           body: formData,
         });
         if (response.ok) {
           window.location.href = `{{ url_for('inventory.hurdalar') }}`;
         } else {
-          alert('Hurdaya ayırma başarısız');
+          alert("Hurdaya ayırma başarısız");
         }
       });
     }
@@ -734,36 +745,36 @@ block content %}
               (item) =>
                 `<option value="${item.text}" data-id="${item.id}">${item.text}</option>`,
             )
-            .join('');
+            .join("");
       }
 
-      const fabrikaSel = document.getElementById('fabrika');
-      const departmanSel = document.getElementById('departman');
-      const donanimSel = document.getElementById('donanim_tipi');
-      const personelSel = document.getElementById('sorumlu_personel');
-      const markaSel = document.getElementById('marka');
-      const modelSel = document.getElementById('model');
+      const fabrikaSel = document.getElementById("fabrika");
+      const departmanSel = document.getElementById("departman");
+      const donanimSel = document.getElementById("donanim_tipi");
+      const personelSel = document.getElementById("sorumlu_personel");
+      const markaSel = document.getElementById("marka");
+      const modelSel = document.getElementById("model");
 
-      await loadOptions(fabrikaSel, '/api/picker/fabrika');
-      await loadOptions(departmanSel, '/api/picker/kullanim_alani');
-      await loadOptions(donanimSel, '/api/picker/donanim_tipi');
+      await loadOptions(fabrikaSel, "/api/picker/fabrika");
+      await loadOptions(departmanSel, "/api/picker/kullanim_alani");
+      await loadOptions(donanimSel, "/api/picker/donanim_tipi");
 
       if (personelSel && window._selects) {
         await _selects.fillChoices({
-          endpoint: '/api/picker/kullanici',
-          selectId: 'sorumlu_personel',
+          endpoint: "/api/picker/kullanici",
+          selectId: "sorumlu_personel",
           mapFn: (row) => ({ value: row.text, label: row.text }),
         });
         _selects.enableRemoteSearch(
-          'sorumlu_personel',
-          '/api/picker/kullanici',
+          "sorumlu_personel",
+          "/api/picker/kullanici",
           () => ({}),
           (row) => ({ value: row.text, label: row.text }),
         );
       }
 
       if (markaSel) {
-        const response = await fetch('/api/picker/marka');
+        const response = await fetch("/api/picker/marka");
         const brands = await response.json();
         markaSel.innerHTML =
           '<option value="">Seçiniz...</option>' +
@@ -772,33 +783,37 @@ block content %}
               (brand) =>
                 `<option value="${brand.text}" data-id="${brand.id}">${brand.text}</option>`,
             )
-            .join('');
-        markaSel.addEventListener('change', async () => {
+            .join("");
+        markaSel.addEventListener("change", async () => {
           const option = markaSel.options[markaSel.selectedIndex];
           const brandId = option && option.dataset.id;
           if (!modelSel) return;
           modelSel.innerHTML = '<option value="">Seçiniz...</option>';
           modelSel.disabled = !brandId;
           if (!brandId) return;
-          const modelResponse = await fetch(`/api/picker/model?marka_id=${brandId}`);
+          const modelResponse = await fetch(
+            `/api/picker/model?marka_id=${brandId}`,
+          );
           const models = await modelResponse.json();
           modelSel.innerHTML += models
-            .map((model) => `<option value="${model.text}">${model.text}</option>`)
-            .join('');
+            .map(
+              (model) => `<option value="${model.text}">${model.text}</option>`,
+            )
+            .join("");
         });
       }
     }
 
     async function preloadAssignDropdowns(itemId) {
       const [factories, departments, users, inventories] = await Promise.all([
-        fetch(`{{ url_for('inventory.assign_sources') }}?type=fabrika`).then((r) =>
-          r.json(),
+        fetch(`{{ url_for('inventory.assign_sources') }}?type=fabrika`).then(
+          (r) => r.json(),
         ),
-        fetch(`{{ url_for('inventory.assign_sources') }}?type=departman`).then((r) =>
-          r.json(),
+        fetch(`{{ url_for('inventory.assign_sources') }}?type=departman`).then(
+          (r) => r.json(),
         ),
-        fetch(`{{ url_for('inventory.assign_sources') }}?type=users`).then((r) =>
-          r.json(),
+        fetch(`{{ url_for('inventory.assign_sources') }}?type=users`).then(
+          (r) => r.json(),
         ),
         fetch(
           `{{ url_for('inventory.assign_sources') }}?type=envanter&exclude_id=` +
@@ -806,10 +821,10 @@ block content %}
         ).then((r) => r.json()),
       ]);
 
-      fillSelect('selFabrika', factories);
-      fillSelect('selDepartman', departments);
-      fillSelect('selPersonel', users);
-      fillSelect('selBagli', inventories);
+      fillSelect("selFabrika", factories);
+      fillSelect("selDepartman", departments);
+      fillSelect("selPersonel", users);
+      fillSelect("selBagli", inventories);
     }
 
     function fillSelect(selectId, items) {
@@ -819,18 +834,20 @@ block content %}
         '<option value="">Seçiniz</option>' +
         items
           .map((item) => `<option value="${item.id}">${item.text}</option>`)
-          .join('');
+          .join("");
     }
 
     function setSelectValue(selectId, value) {
       const selectEl = document.getElementById(selectId);
       if (!selectEl) return;
-      const normalized = value || '';
+      const normalized = value || "";
       if (
         normalized &&
-        !Array.from(selectEl.options).some((option) => option.value === normalized)
+        !Array.from(selectEl.options).some(
+          (option) => option.value === normalized,
+        )
       ) {
-        const option = document.createElement('option');
+        const option = document.createElement("option");
         option.value = normalized;
         option.textContent = normalized;
         selectEl.appendChild(option);

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -4,18 +4,17 @@ content %}
   <div class="page-shell">
     <header class="page-header">
       <div class="page-header__heading">
-        <span class="eyebrow text-primary">Lisans Takip</span>
+        <span class="eyebrow text-primary">LİSANS TAKİP</span>
         <h1 class="page-header__title">Lisanslar</h1>
         <p class="page-header__subtitle">
-          Envanterinizdeki yazılım lisanslarını görüntüleyin, aktarın ve
-          yönetin.
+          Yazılım lisanslarını görüntüleyin ve yönetin.
         </p>
       </div>
       <div class="page-header__actions page-actions">
         <div class="page-actions__group">
           <a
             href="#"
-            class="btn btn-success btn-sm d-flex align-items-center gap-1"
+            class="btn btn-success btn-sm"
             title="Yeni Ekle"
             data-bs-toggle="modal"
             data-bs-target="#addModal"
@@ -56,33 +55,55 @@ content %}
               </li>
             </ul>
           </div>
-          <button class="btn btn-outline-secondary btn-sm" id="filterBtn">
-            Filtre
-          </button>
-          <button
-            class="btn btn-outline-secondary btn-sm d-none"
-            id="clearFilterBtn"
-          >
-            Temizle
-          </button>
-        </div>
-        <div class="page-actions__group page-actions__group--grow">
-          <label for="searchInput" class="visually-hidden">Ara</label>
-          <input
-            type="text"
-            id="searchInput"
-            class="form-control form-control-sm"
-            placeholder="Ara..."
-          />
         </div>
       </div>
     </header>
 
-    <div class="page-card soft-card">
+    <div class="filter-search-bar">
+      <div class="filter-search-bar__row">
+        <div class="filter-search-bar__main">
+          <div class="search-wrapper">
+            <i class="bi bi-search"></i>
+            <input
+              type="text"
+              id="searchInput"
+              class="form-control form-control-sm"
+              placeholder="Lisans ara..."
+            />
+          </div>
+          <div class="filter-group">
+            <label for="durumFilter">Durum:</label>
+            <select id="durumFilter" class="form-select form-select-sm">
+              <option value="">Tümü</option>
+              <option value="aktif">Aktif</option>
+              <option value="bos">Boş</option>
+            </select>
+          </div>
+        </div>
+        <div class="filter-search-bar__actions">
+          <button class="btn btn-primary btn-sm" id="filterBtn">
+            <i class="bi bi-funnel"></i>
+            Filtrele
+          </button>
+          <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">
+            <i class="bi bi-x-circle"></i>
+            Temizle
+          </button>
+        </div>
+      </div>
+      <div class="active-filters-section d-none" id="activeFiltersSection">
+        <div class="active-filters">
+          <span class="active-filters__label">Aktif Filtreler:</span>
+          <div id="activeFilterBadges"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="page-card">
       <div class="table-responsive">
         <table
           id="licensesTable"
-          class="table table-hover align-middle table-rounded"
+          class="table table-sm table-hover table-rounded align-middle mb-0"
         >
           <thead>
             <tr>
@@ -276,49 +297,6 @@ content %}
   </div>
 </div>
 
-<!-- Filtre Modal -->
-<div class="modal fade" id="filterModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
-    <form id="filterForm" class="modal-content border-0 bg-transparent p-0">
-      <div class="modal-shell">
-        <div class="modal-shell__header">
-          <div class="modal-shell__heading">
-            <h5 class="modal-shell__title">Lisansları Filtrele</h5>
-            <p class="modal-shell__subtitle">
-              Birden fazla kriter belirleyerek tabloyu daraltabilirsiniz.
-            </p>
-          </div>
-          <div class="modal-shell__header-actions">
-            <button
-              type="button"
-              class="btn-close"
-              data-bs-dismiss="modal"
-              aria-label="Kapat"
-            ></button>
-          </div>
-        </div>
-
-        <div class="modal-shell__body">
-          <div id="filterRows" class="stack-sm"></div>
-        </div>
-
-        <div class="modal-shell__footer">
-          <div class="modal-shell__actions">
-            <button
-              type="button"
-              class="btn btn-outline-secondary btn-sm"
-              data-bs-dismiss="modal"
-            >
-              Vazgeç
-            </button>
-            <button type="submit" class="btn btn-primary btn-sm">Uygula</button>
-          </div>
-        </div>
-      </div>
-    </form>
-  </div>
-</div>
-
 <!-- ATAMA MODALI -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
@@ -471,124 +449,13 @@ content %}
 
 <script>
   document.addEventListener("DOMContentLoaded", () => {
-    const filterModal = new bootstrap.Modal(
-      document.getElementById("filterModal"),
-    );
-    const searchInput = document.getElementById("searchInput");
-    const filterForm = document.getElementById("filterForm");
-    const clearBtn = document.getElementById("clearFilterBtn");
-    const filterRowsDiv = document.getElementById("filterRows");
-    const distinctUrl =
-      "{{ url_for('lookup.distinct', entity='license', column='__COL__') }}";
-    let activeFilters = [];
-    const columns = Array.from(document.querySelectorAll("table thead th"))
-      .map((th, idx) => ({
-        idx,
-        name: th.textContent.trim(),
-        field: th.dataset.field,
-      }))
-      .filter((c) => c.field);
-
-    document.getElementById("filterBtn").addEventListener("click", () => {
-      filterForm.reset();
-      filterRowsDiv.innerHTML = "";
-      createFilterRow();
-      filterModal.show();
+    window.filterSystem = new UnifiedFilterSystem({
+      tableSelector: '#licensesTable',
+      searchInputId: 'searchInput',
+      filters: [
+        { id: 'durumFilter', label: 'Durum', columnField: 'durum' },
+      ],
     });
-
-    clearBtn.addEventListener("click", () => {
-      activeFilters = [];
-      filterRows();
-      clearBtn.classList.add("d-none");
-    });
-
-    searchInput.addEventListener("input", filterRows);
-
-    function createFilterRow() {
-      const row = document.createElement("div");
-      row.className = "row g-2 align-items-center mb-2 filter-row";
-      row.innerHTML = `
-        <div class="col-5">
-          <select class="form-select form-select-sm column-select">
-            ${columns.map((c) => `<option value="${c.idx}">${c.name}</option>`).join("")}
-          </select>
-        </div>
-        <div class="col-5">
-          <select class="form-select form-select-sm value-select"></select>
-        </div>
-        <div class="col-2 d-flex gap-1">
-          <button type="button" class="btn btn-success btn-sm add-row">+</button>
-          <button type="button" class="btn btn-danger btn-sm remove-row">-</button>
-        </div>`;
-      filterRowsDiv.appendChild(row);
-      const colSel = row.querySelector(".column-select");
-      const valSel = row.querySelector(".value-select");
-      loadValues(colSel, valSel);
-      colSel.addEventListener("change", () => loadValues(colSel, valSel));
-      updateRemoveButtons();
-    }
-
-    async function loadValues(colSelect, valSelect) {
-      const col = columns.find((c) => c.idx == colSelect.value);
-      const res = await fetch(distinctUrl.replace("__COL__", col.field));
-      const data = await res.json();
-      valSelect.innerHTML =
-        '<option value="">Seçiniz</option>' +
-        data.map((v) => `<option value="${v}">${v}</option>`).join("");
-    }
-
-    function updateRemoveButtons() {
-      const rows = filterRowsDiv.querySelectorAll(".filter-row");
-      rows.forEach((r) =>
-        r
-          .querySelector(".remove-row")
-          .classList.toggle("d-none", rows.length === 1),
-      );
-    }
-
-    filterForm.addEventListener("click", (e) => {
-      if (e.target.classList.contains("add-row")) {
-        createFilterRow();
-      } else if (e.target.classList.contains("remove-row")) {
-        e.target.closest(".filter-row").remove();
-        updateRemoveButtons();
-      }
-    });
-
-    filterForm.addEventListener("submit", (e) => {
-      e.preventDefault();
-      activeFilters = [];
-      filterRowsDiv.querySelectorAll(".filter-row").forEach((row) => {
-        const col = parseInt(row.querySelector(".column-select").value, 10);
-        const val = row
-          .querySelector(".value-select")
-          .value.trim()
-          .toLowerCase();
-        if (val) activeFilters.push({ col, val });
-      });
-      filterModal.hide();
-      clearBtn.classList.toggle("d-none", activeFilters.length === 0);
-      filterRows();
-    });
-
-    function filterRows() {
-      const q = searchInput.value.toLowerCase();
-      document.querySelectorAll("tbody tr").forEach((tr) => {
-        const cells = tr.querySelectorAll("td");
-        const texts = Array.from(cells).map((td) =>
-          td.textContent.toLowerCase(),
-        );
-        let match = texts.some((t) => t.includes(q));
-        if (activeFilters.length) {
-          match =
-            match &&
-            activeFilters.every(
-              (f) => texts[f.col] && texts[f.col].includes(f.val),
-            );
-        }
-        tr.classList.toggle("d-none", !match);
-      });
-    }
 
     // Mevcut atama/hurda işlemleri
     const assignModal = new bootstrap.Modal(

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -85,7 +85,10 @@ content %}
             <i class="bi bi-funnel"></i>
             Filtrele
           </button>
-          <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">
+          <button
+            class="btn btn-outline-secondary btn-sm d-none"
+            id="clearFilterBtn"
+          >
             <i class="bi bi-x-circle"></i>
             Temizle
           </button>
@@ -450,11 +453,9 @@ content %}
 <script>
   document.addEventListener("DOMContentLoaded", () => {
     window.filterSystem = new UnifiedFilterSystem({
-      tableSelector: '#licensesTable',
-      searchInputId: 'searchInput',
-      filters: [
-        { id: 'durumFilter', label: 'Durum', columnField: 'durum' },
-      ],
+      tableSelector: "#licensesTable",
+      searchInputId: "searchInput",
+      filters: [{ id: "durumFilter", label: "Durum", columnField: "durum" }],
     });
 
     // Mevcut atama/hurda işlemleri

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -92,7 +92,10 @@ content %}
             <i class="bi bi-funnel"></i>
             Filtrele
           </button>
-          <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">
+          <button
+            class="btn btn-outline-secondary btn-sm d-none"
+            id="clearFilterBtn"
+          >
             <i class="bi bi-x-circle"></i>
             Temizle
           </button>
@@ -135,7 +138,14 @@ content %}
               data-kullanim="{{ p.kullanim_alani or '' }}"
               data-personel="{{ p.sorumlu_personel or '' }}"
               data-bagli="{{ p.bagli_envanter_no or '' }}"
-              {% if p.durum == 'arızalı' %}class="table-warning"{% endif %}
+              {%
+              if
+              p.durum=""
+              ="arızalı"
+              %}class="table-warning"
+              {%
+              endif
+              %}
             >
               <td>#{{ p.id }}</td>
               <td>{{ p.marka or '-' }}</td>

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -4,18 +4,17 @@ content %}
   <div class="page-shell">
     <header class="page-header">
       <div class="page-header__heading">
-        <span class="eyebrow text-primary">Yazıcı Takip</span>
+        <span class="eyebrow text-primary">YAZICI TAKİP</span>
         <h1 class="page-header__title">Yazıcılar</h1>
         <p class="page-header__subtitle">
-          Tüm yazıcı envanterini görüntüleyin, durumlarını yönetin ve hızlıca
-          aksiyon alın.
+          Yazıcı envanterini görüntüleyin ve yönetin.
         </p>
       </div>
       <div class="page-header__actions page-actions">
         <div class="page-actions__group">
           <a
             href="#"
-            class="btn btn-success btn-sm d-flex align-items-center gap-1"
+            class="btn btn-success btn-sm"
             title="Yeni Ekle"
             data-bs-toggle="modal"
             data-bs-target="#addModal"
@@ -59,32 +58,61 @@ content %}
               </li>
             </ul>
           </div>
-          <button class="btn btn-outline-secondary btn-sm" id="filterBtn">
-            Filtre
-          </button>
-          <button
-            class="btn btn-outline-secondary btn-sm d-none"
-            id="clearFilterBtn"
-          >
-            Temizle
-          </button>
-        </div>
-        <div class="page-actions__group page-actions__group--grow">
-          <label for="searchInput" class="visually-hidden">Ara</label>
-          <input
-            type="text"
-            id="searchInput"
-            class="form-control form-control-sm"
-            placeholder="Ara..."
-          />
         </div>
       </div>
     </header>
 
-    <div class="page-card soft-card">
+    <div class="filter-search-bar">
+      <div class="filter-search-bar__row">
+        <div class="filter-search-bar__main">
+          <div class="search-wrapper">
+            <i class="bi bi-search"></i>
+            <input
+              type="text"
+              id="searchInput"
+              class="form-control form-control-sm"
+              placeholder="Yazıcı ara..."
+            />
+          </div>
+          <div class="filter-group">
+            <label for="markaFilter">Marka:</label>
+            <select id="markaFilter" class="form-select form-select-sm">
+              <option value="">Tümü</option>
+            </select>
+          </div>
+          <div class="filter-group">
+            <label for="fabrikaFilter">Fabrika:</label>
+            <select id="fabrikaFilter" class="form-select form-select-sm">
+              <option value="">Tümü</option>
+            </select>
+          </div>
+        </div>
+        <div class="filter-search-bar__actions">
+          <button class="btn btn-primary btn-sm" id="filterBtn">
+            <i class="bi bi-funnel"></i>
+            Filtrele
+          </button>
+          <button class="btn btn-outline-secondary btn-sm d-none" id="clearFilterBtn">
+            <i class="bi bi-x-circle"></i>
+            Temizle
+          </button>
+        </div>
+      </div>
+      <div class="active-filters-section d-none" id="activeFiltersSection">
+        <div class="active-filters">
+          <span class="active-filters__label">Aktif Filtreler:</span>
+          <div id="activeFilterBadges"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="page-card">
       <div class="table-responsive">
-        <table class="table table-sm align-middle table-rounded">
-          <thead class="table-light">
+        <table
+          id="printersTable"
+          class="table table-sm table-hover table-rounded align-middle mb-0"
+        >
+          <thead>
             <tr>
               <th data-field="id">ID</th>
               <th data-field="marka">Marka</th>
@@ -311,49 +339,6 @@ content %}
   window.SKIP_SELECT_ENHANCE = true;
 </script>
 
-<!-- Filtre Modal -->
-<div class="modal fade" id="filterModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
-    <form id="filterForm" class="modal-content border-0 bg-transparent p-0">
-      <div class="modal-shell">
-        <div class="modal-shell__header">
-          <div class="modal-shell__heading">
-            <h5 class="modal-shell__title">Yazıcıları Filtrele</h5>
-            <p class="modal-shell__subtitle">
-              Marka, model veya sorumlu gibi kriterlerle listeyi daraltın.
-            </p>
-          </div>
-          <div class="modal-shell__header-actions">
-            <button
-              type="button"
-              class="btn-close"
-              data-bs-dismiss="modal"
-              aria-label="Kapat"
-            ></button>
-          </div>
-        </div>
-
-        <div class="modal-shell__body">
-          <div id="filterRows" class="stack-sm"></div>
-        </div>
-
-        <div class="modal-shell__footer">
-          <div class="modal-shell__actions">
-            <button
-              type="button"
-              class="btn btn-outline-secondary btn-sm"
-              data-bs-dismiss="modal"
-            >
-              Vazgeç
-            </button>
-            <button type="submit" class="btn btn-primary btn-sm">Uygula</button>
-          </div>
-        </div>
-      </div>
-    </form>
-  </div>
-</div>
-
 <!-- ATAMA MODAL -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
@@ -524,24 +509,19 @@ content %}
 />
 <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
 <script>
-  document.addEventListener("DOMContentLoaded", () => {
-    const filterModal = new bootstrap.Modal(
-      document.getElementById("filterModal"),
-    );
-    const searchInput = document.getElementById("searchInput");
-    const filterForm = document.getElementById("filterForm");
-    const clearBtn = document.getElementById("clearFilterBtn");
-    const filterRowsDiv = document.getElementById("filterRows");
-    const distinctUrl =
-      "{{ url_for('lookup.distinct', entity='printer', column='__COL__') }}";
-    let activeFilters = [];
-    const columns = Array.from(document.querySelectorAll("table thead th"))
-      .map((th, idx) => ({
-        idx,
-        name: th.textContent.trim(),
-        field: th.dataset.field,
-      }))
-      .filter((c) => c.field);
+  document.addEventListener("DOMContentLoaded", async () => {
+    await populateDistinctValues("markaFilter", "printer", "marka");
+    await populateDistinctValues("fabrikaFilter", "printer", "fabrika");
+
+    const filterSystem = new UnifiedFilterSystem({
+      tableSelector: "#printersTable",
+      searchInputId: "searchInput",
+      filters: [
+        { id: "markaFilter", label: "Marka", columnField: "marka" },
+        { id: "fabrikaFilter", label: "Fabrika", columnField: "fabrika" },
+      ],
+    });
+    window.filterSystem = filterSystem;
 
     const markaSel = document.getElementById("selYaziciMarka");
     const modelSel = document.getElementById("selYaziciModel");
@@ -576,115 +556,16 @@ content %}
       loadModels();
     }
 
-    // Modal tetikleyici attribute ile handle ediliyor; ek JS gerekmez.
-
-    document.getElementById("filterBtn").addEventListener("click", () => {
-      filterForm.reset();
-      filterRowsDiv.innerHTML = "";
-      createFilterRow();
-      filterModal.show();
-    });
-
-    clearBtn.addEventListener("click", () => {
-      activeFilters = [];
-      filterRows();
-      clearBtn.classList.add("d-none");
-    });
-
-    searchInput.addEventListener("input", filterRows);
-
-    function createFilterRow() {
-      const row = document.createElement("div");
-      row.className = "row g-2 align-items-center mb-2 filter-row";
-      row.innerHTML = `
-      <div class="col-5">
-        <select class="form-select form-select-sm column-select">
-          ${columns.map((c) => `<option value="${c.idx}">${c.name}</option>`).join("")}
-        </select>
-      </div>
-      <div class="col-5">
-        <select class="form-select form-select-sm value-select"></select>
-      </div>
-      <div class="col-2 d-flex gap-1">
-        <button type="button" class="btn btn-success btn-sm add-row">+</button>
-        <button type="button" class="btn btn-danger btn-sm remove-row">-</button>
-      </div>`;
-      filterRowsDiv.appendChild(row);
-      const colSel = row.querySelector(".column-select");
-      const valSel = row.querySelector(".value-select");
-      loadValues(colSel, valSel);
-      colSel.addEventListener("change", () => loadValues(colSel, valSel));
-      updateRemoveButtons();
-    }
-
-    async function loadValues(colSelect, valSelect) {
-      const col = columns.find((c) => c.idx == colSelect.value);
-      const res = await fetch(distinctUrl.replace("__COL__", col.field));
-      const data = await res.json();
-      valSelect.innerHTML =
-        '<option value="">Seçiniz</option>' +
-        data.map((v) => `<option value="${v}">${v}</option>`).join("");
-    }
-
-    function updateRemoveButtons() {
-      const rows = filterRowsDiv.querySelectorAll(".filter-row");
-      rows.forEach((r) =>
-        r
-          .querySelector(".remove-row")
-          .classList.toggle("d-none", rows.length === 1),
-      );
-    }
-
-    filterForm.addEventListener("click", (e) => {
-      if (e.target.classList.contains("add-row")) {
-        createFilterRow();
-      } else if (e.target.classList.contains("remove-row")) {
-        e.target.closest(".filter-row").remove();
-        updateRemoveButtons();
-      }
-    });
-
-    filterForm.addEventListener("submit", (e) => {
-      e.preventDefault();
-      activeFilters = [];
-      filterRowsDiv.querySelectorAll(".filter-row").forEach((row) => {
-        const col = parseInt(row.querySelector(".column-select").value, 10);
-        const val = row
-          .querySelector(".value-select")
-          .value.trim()
-          .toLowerCase();
-        if (val) activeFilters.push({ col, val });
-      });
-      filterModal.hide();
-      clearBtn.classList.toggle("d-none", activeFilters.length === 0);
-      filterRows();
-    });
-
-    function filterRows() {
-      const q = searchInput.value.toLowerCase();
-      document.querySelectorAll("tbody tr").forEach((tr) => {
-        const cells = tr.querySelectorAll("td");
-        const texts = Array.from(cells).map((td) =>
-          td.textContent.toLowerCase(),
-        );
-        let match = texts.some((t) => t.includes(q));
-        if (activeFilters.length) {
-          match =
-            match &&
-            activeFilters.every(
-              (f) => texts[f.col] && texts[f.col].includes(f.val),
-            );
-        }
-        tr.classList.toggle("d-none", !match);
-      });
-    }
-
     // Atama/Hurda işlemleri
     const assignModalEl = document.getElementById("assignModal");
-    const assignModal = new bootstrap.Modal(assignModalEl);
+    const assignModal = assignModalEl
+      ? bootstrap.Modal.getOrCreateInstance(assignModalEl)
+      : null;
     const assignForm = document.getElementById("assignForm");
     const scrapModalEl = document.getElementById("scrapModal");
-    const scrapModal = new bootstrap.Modal(scrapModalEl);
+    const scrapModal = scrapModalEl
+      ? bootstrap.Modal.getOrCreateInstance(scrapModalEl)
+      : null;
     const scrapForm = document.getElementById("scrapForm");
 
     document.querySelectorAll(".action-select").forEach((sel) => {


### PR DESCRIPTION
## Summary
- add the unified design stylesheet and shared filter script to the base layout
- restyle the inventory, license, and printer list templates with the new header, filter bar, and table metadata
- align the knowledge base page with the design system and hook it into the shared filtering helpers

## Testing
- `pytest` *(fails: tests/test_stock_assign_concurrent.py::test_concurrent_assignments raises TypeError in _setup_engine due to poolclass argument conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68d673c7417c832b999bbce6d20fd8ad