### PR TITLE
Align edit and assign forms with new layout

### DIFF
--- a/templates/_printer_form_fields.html
+++ b/templates/_printer_form_fields.html
@@ -1,52 +1,47 @@
-<div class="row g-3">
-  <div class="col-md-6">
-    <label class="form-label">Yazıcı Markası</label>
-    <select id="selYaziciMarka" name="marka_id" class="form-select"></select>
+<div class="env-grid">
+  <div class="field">
+    <label>Yazıcı Markası</label>
+    <select id="selYaziciMarka" name="marka_id" class="ctrl"></select>
   </div>
-  <div class="col-md-6">
-    <label class="form-label">Yazıcı Modeli</label>
-    <select
-      id="selYaziciModel"
-      name="model_id"
-      class="form-select"
-      disabled
-    ></select>
-    <small class="text-muted"
+  <div class="field">
+    <label>Yazıcı Modeli</label>
+    <select id="selYaziciModel" name="model_id" class="ctrl" disabled></select>
+    <small class="text-muted small"
       >Not: Model listesi seçilen Markaya göre filtrelenir.</small
     >
   </div>
 
-  <div class="col-md-6">
-    <label class="form-label">Kullanım Alanı</label>
+  <div class="field">
+    <label>Kullanım Alanı</label>
     <select
       id="selYaziciKullanim"
       name="kullanim_alani_id"
-      class="form-select"
+      class="ctrl"
     ></select>
   </div>
 
-  <div class="col-md-6">
-    <label class="form-label">Envanter No</label>
-    <input name="envanter_no" class="form-control" required />
+  <div class="field">
+    <label>Envanter No</label>
+    <input name="envanter_no" class="ctrl" required />
   </div>
 
-  <div class="col-md-4">
-    <label class="form-label">IP Adresi</label>
-    <input name="ip_adresi" class="form-control" />
+  <div class="field">
+    <label>IP Adresi</label>
+    <input name="ip_adresi" class="ctrl" />
   </div>
 
-  <div class="col-md-4">
-    <label class="form-label">MAC</label>
-    <input name="mac" class="form-control" />
+  <div class="field">
+    <label>MAC</label>
+    <input name="mac" class="ctrl" />
   </div>
 
-  <div class="col-md-4">
-    <label class="form-label">Hostname</label>
-    <input name="hostname" class="form-control" />
+  <div class="field">
+    <label>Hostname</label>
+    <input name="hostname" class="ctrl" />
   </div>
 
-  <div class="col-md-4">
-    <label class="form-label">IFS No</label>
-    <input name="ifs_no" class="form-control" />
+  <div class="field">
+    <label>IFS No</label>
+    <input name="ifs_no" class="ctrl" />
   </div>
 </div>

--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -83,37 +83,6 @@ block content %}
   </form>
 </div>
 
-<style>
-  #inventory-edit-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 12px 16px;
-  }
-  @media (min-width: 768px) {
-    #inventory-edit-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-    #inventory-edit-grid .span-2 {
-      grid-column: 1 / -1;
-    }
-  }
-  #inventory-edit-grid .field label {
-    display: block;
-    margin-bottom: 6px;
-    font-weight: 600;
-  }
-  #inventory-edit-grid .ctrl {
-    width: 100%;
-    padding: 10px 12px;
-    border: 1px solid #ced4da;
-    border-radius: 0.5rem;
-    background: var(--bs-body-bg, #fff);
-  }
-  #inventory-edit-grid .ctrl:disabled {
-    background: var(--bs-tertiary-bg, #f1f3f5);
-  }
-</style>
-
 <script>
   window.SKIP_SELECT_ENHANCE = true;
 </script>

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -507,11 +507,19 @@ block content %}
           </div>
           <div class="field">
             <label>Sorumlu Personel</label>
-            <select name="sorumlu_personel" id="selPersonel" class="ctrl"></select>
+            <select
+              name="sorumlu_personel"
+              id="selPersonel"
+              class="ctrl"
+            ></select>
           </div>
           <div class="field">
             <label>Bağlı Olduğu Envanter</label>
-            <select name="bagli_envanter_no" id="selBagli" class="ctrl"></select>
+            <select
+              name="bagli_envanter_no"
+              id="selBagli"
+              class="ctrl"
+            ></select>
           </div>
         </div>
       </div>

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -494,35 +494,25 @@ block content %}
           data-bs-dismiss="modal"
         ></button>
       </div>
-      <div class="modal-body row g-3">
+      <div class="modal-body">
         <input type="hidden" name="item_id" id="assign_item_id" />
-        <div class="col-md-3">
-          <label class="form-label">Fabrika</label>
-          <select name="fabrika" id="selFabrika" class="form-select"></select>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Departman</label>
-          <select
-            name="departman"
-            id="selDepartman"
-            class="form-select"
-          ></select>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Sorumlu Personel</label>
-          <select
-            name="sorumlu_personel"
-            id="selPersonel"
-            class="form-select"
-          ></select>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Bağlı Olduğu Envanter</label>
-          <select
-            name="bagli_envanter_no"
-            id="selBagli"
-            class="form-select"
-          ></select>
+        <div class="env-grid">
+          <div class="field">
+            <label>Fabrika</label>
+            <select name="fabrika" id="selFabrika" class="ctrl"></select>
+          </div>
+          <div class="field">
+            <label>Departman</label>
+            <select name="departman" id="selDepartman" class="ctrl"></select>
+          </div>
+          <div class="field">
+            <label>Sorumlu Personel</label>
+            <select name="sorumlu_personel" id="selPersonel" class="ctrl"></select>
+          </div>
+          <div class="field">
+            <label>Bağlı Olduğu Envanter</label>
+            <select name="bagli_envanter_no" id="selBagli" class="ctrl"></select>
+          </div>
         </div>
       </div>
       <div class="modal-footer">

--- a/templates/license_assign.html
+++ b/templates/license_assign.html
@@ -15,33 +15,35 @@ content %}
           name="islem_yapan"
           value="{{ current_user.full_name if current_user else 'system' }}"
         />
-        <div class="mb-3">
-          <label class="form-label">Sorumlu Personel</label>
-          <select name="sorumlu_personel" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for u in users %}
-            <option
-              value="{{ u }}"
-              {% if license.sorumlu_personel == u %}selected{% endif %}
-            >
-              {{ u }}
-            </option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Bağlı Olduğu Envanter No</label>
-          <select name="bagli_envanter_no" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for inv in envanterler %}
-            <option
-              value="{{ inv.no }}"
-              {% if license.bagli_envanter_no == inv.no %}selected{% endif %}
-            >
-              {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
-            </option>
-            {% endfor %}
-          </select>
+        <div class="env-grid">
+          <div class="field">
+            <label>Sorumlu Personel</label>
+            <select name="sorumlu_personel" class="ctrl">
+              <option value="">Seçiniz</option>
+              {% for u in users %}
+              <option
+                value="{{ u }}"
+                {% if license.sorumlu_personel == u %}selected{% endif %}
+              >
+                {{ u }}
+              </option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="field">
+            <label>Bağlı Olduğu Envanter No</label>
+            <select name="bagli_envanter_no" class="ctrl">
+              <option value="">Seçiniz</option>
+              {% for inv in envanterler %}
+              <option
+                value="{{ inv.no }}"
+                {% if license.bagli_envanter_no == inv.no %}selected{% endif %}
+              >
+                {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
+              </option>
+              {% endfor %}
+            </select>
+          </div>
         </div>
         <div class="d-flex gap-2 mt-4">
           <button class="btn btn-primary" type="submit">Kaydet</button>

--- a/templates/license_assign.html
+++ b/templates/license_assign.html
@@ -23,7 +23,13 @@ content %}
               {% for u in users %}
               <option
                 value="{{ u }}"
-                {% if license.sorumlu_personel == u %}selected{% endif %}
+                {%
+                if
+                license.sorumlu_personel=""
+                ="u"
+                %}selected{%
+                endif
+                %}
               >
                 {{ u }}
               </option>
@@ -37,7 +43,13 @@ content %}
               {% for inv in envanterler %}
               <option
                 value="{{ inv.no }}"
-                {% if license.bagli_envanter_no == inv.no %}selected{% endif %}
+                {%
+                if
+                license.bagli_envanter_no=""
+                ="inv.no"
+                %}selected{%
+                endif
+                %}
               >
                 {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
               </option>

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -24,7 +24,15 @@
               {% for ln in license_names %}
               <option
                 value="{{ ln.name }}"
-                {% if license and license.lisans_adi == ln.name %}selected{% endif %}
+                {%
+                if
+                license
+                and
+                license.lisans_adi=""
+                ="ln.name"
+                %}selected{%
+                endif
+                %}
               >
                 {{ ln.name }}
               </option>
@@ -48,7 +56,15 @@
               {% for u in users %}
               <option
                 value="{{ u }}"
-                {% if license and license.sorumlu_personel == u %}selected{% endif %}
+                {%
+                if
+                license
+                and
+                license.sorumlu_personel=""
+                ="u"
+                %}selected{%
+                endif
+                %}
               >
                 {{ u }}
               </option>
@@ -63,7 +79,15 @@
               {% for inv in envanterler %}
               <option
                 value="{{ inv.id }}"
-                {% if license and license.inventory_id == inv.id %}selected{% endif %}
+                {%
+                if
+                license
+                and
+                license.inventory_id=""
+                ="inv.id"
+                %}selected{%
+                endif
+                %}
               >
                 {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
               </option>

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -16,10 +16,10 @@
         method="post"
         action="{{ form_action }}{{ '?modal=1' if modal else '' }}"
       >
-        <div class="row g-3">
-          <div class="col-md-6">
-            <label class="form-label">Lisans Adı</label>
-            <select name="adi" class="form-select" required>
+        <div class="env-grid">
+          <div class="field">
+            <label>Lisans Adı</label>
+            <select name="adi" class="ctrl" required>
               <option value="">Seçiniz...</option>
               {% for ln in license_names %}
               <option
@@ -32,18 +32,18 @@
             </select>
           </div>
 
-          <div class="col-md-6">
-            <label class="form-label">Lisans Anahtarı</label>
+          <div class="field">
+            <label>Lisans Anahtarı</label>
             <input
               name="anahtar"
-              class="form-control"
+              class="ctrl"
               value="{{ license.anahtar if license else '' }}"
             />
           </div>
 
-          <div class="col-md-6">
-            <label class="form-label">Sorumlu Personel</label>
-            <select name="sorumlu_personel" class="form-select">
+          <div class="field">
+            <label>Sorumlu Personel</label>
+            <select name="sorumlu_personel" class="ctrl">
               <option value="">(Seçiniz)</option>
               {% for u in users %}
               <option
@@ -56,13 +56,9 @@
             </select>
           </div>
 
-          <div class="col-md-6">
-            <label class="form-label">Bağlı Olduğu Envanter No</label>
-            <select
-              id="selBagliEnvanter"
-              name="inventory_id"
-              class="form-select"
-            >
+          <div class="field">
+            <label>Bağlı Olduğu Envanter No</label>
+            <select id="selBagliEnvanter" name="inventory_id" class="ctrl">
               <option value="">(Seçimsiz)</option>
               {% for inv in envanterler %}
               <option
@@ -75,21 +71,21 @@
             </select>
           </div>
 
-          <div class="col-md-4">
-            <label class="form-label">IFS No</label>
+          <div class="field">
+            <label>IFS No</label>
             <input
               name="ifs_no"
-              class="form-control"
+              class="ctrl"
               value="{{ license.ifs_no if license else '' }}"
             />
           </div>
 
-          <div class="col-md-6">
-            <label class="form-label">Mail Adresi</label>
+          <div class="field">
+            <label>Mail Adresi</label>
             <input
               type="email"
               name="mail_adresi"
-              class="form-control"
+              class="ctrl"
               value="{{ license.mail_adresi if license else '' }}"
             />
           </div>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -193,13 +193,13 @@ content %}
         </div>
 
         <div class="modal-shell__body">
-          <div class="modal-form-grid">
-            <div class="form-group">
-              <label class="form-label" for="selLisansAdi">Lisans Adı</label>
+          <div class="modal-form-grid env-grid">
+            <div class="form-group field">
+              <label for="selLisansAdi">Lisans Adı</label>
               <select
                 id="selLisansAdi"
                 name="lisans_adi"
-                class="form-select"
+                class="ctrl"
                 required
               >
                 <option value="">Seçiniz</option>
@@ -208,29 +208,21 @@ content %}
                 {% endfor %}
               </select>
             </div>
-            <div class="form-group">
-              <label class="form-label" for="lisansAnahtari"
-                >Lisans Anahtarı</label
-              >
+            <div class="form-group field">
+              <label for="lisansAnahtari">Lisans Anahtarı</label>
               <input
                 id="lisansAnahtari"
                 name="lisans_anahtari"
                 type="text"
-                class="form-control"
+                class="ctrl"
                 required
                 placeholder="XXXX-XXXX-XXXX-XXXX"
               />
             </div>
 
-            <div class="form-group">
-              <label class="form-label" for="selPersonelAdd"
-                >Sorumlu Personel</label
-              >
-              <select
-                id="selPersonelAdd"
-                name="sorumlu_personel"
-                class="form-select"
-              >
+            <div class="form-group field">
+              <label for="selPersonelAdd">Sorumlu Personel</label>
+              <select id="selPersonelAdd" name="sorumlu_personel" class="ctrl">
                 <option value="">Seçiniz</option>
                 {% for u in users %}
                 <option value="{{ u }}">{{ u }}</option>
@@ -238,14 +230,12 @@ content %}
               </select>
             </div>
 
-            <div class="form-group">
-              <label class="form-label" for="bagliEnvanter"
-                >Bağlı Olduğu Envanter No</label
-              >
+            <div class="form-group field">
+              <label for="bagliEnvanter">Bağlı Olduğu Envanter No</label>
               <select
                 id="bagliEnvanter"
                 name="bagli_envanter_no"
-                class="form-select"
+                class="ctrl"
                 required
               >
                 <option value="">Seçiniz...</option>
@@ -255,28 +245,26 @@ content %}
               </select>
             </div>
 
-            <div class="form-group">
-              <label class="form-label" for="ifsNo">
-                IFS No <small class="text-muted">(opsiyonel)</small>
+            <div class="form-group field">
+              <label for="ifsNo">
+                IFS No <span class="muted">(opsiyonel)</span>
               </label>
               <input
                 id="ifsNo"
                 name="ifs_no"
                 type="text"
-                class="form-control"
+                class="ctrl"
                 placeholder="IFS numarası"
               />
             </div>
 
-            <div class="form-group">
-              <label class="form-label" for="lisansEmail"
-                >E-posta (opsiyonel)</label
-              >
+            <div class="form-group field">
+              <label for="lisansEmail">E-posta <span class="muted">(opsiyonel)</span></label>
               <input
                 id="lisansEmail"
                 name="mail_adresi"
                 type="email"
-                class="form-control"
+                class="ctrl"
                 placeholder="ornek@firma.com"
               />
             </div>
@@ -332,31 +320,19 @@ content %}
             name="islem_yapan"
             value="{{ current_user.full_name if current_user else 'system' }}"
           />
-          <div class="modal-form-grid">
-            <div class="form-group">
-              <label class="form-label" for="selPersonel"
-                >Sorumlu Personel</label
-              >
-              <select
-                name="sorumlu_personel"
-                class="form-select"
-                id="selPersonel"
-              >
+          <div class="modal-form-grid env-grid">
+            <div class="form-group field">
+              <label for="selPersonel">Sorumlu Personel</label>
+              <select name="sorumlu_personel" class="ctrl" id="selPersonel">
                 <option value="">Seçiniz</option>
                 {% for u in users %}
                 <option value="{{ u }}">{{ u }}</option>
                 {% endfor %}
               </select>
             </div>
-            <div class="form-group">
-              <label class="form-label" for="selBagli"
-                >Bağlı Olduğu Envanter No</label
-              >
-              <select
-                name="bagli_envanter_no"
-                class="form-select"
-                id="selBagli"
-              >
+            <div class="form-group field">
+              <label for="selBagli">Bağlı Olduğu Envanter No</label>
+              <select name="bagli_envanter_no" class="ctrl" id="selBagli">
                 <option value="">Seçiniz</option>
                 {% for inv in envanterler %}
                 <option value="{{ inv.no }}">
@@ -412,15 +388,13 @@ content %}
 
         <div class="modal-shell__body">
           <p class="mb-2">Bu lisans hurdaya ayrılacak. Onaylıyor musunuz?</p>
-          <div class="modal-form-grid">
-            <div class="form-group modal-form-grid--full">
-              <label class="form-label" for="scrapNote"
-                >Açıklama (opsiyonel)</label
-              >
+          <div class="modal-form-grid env-grid">
+            <div class="form-group field modal-form-grid--full span-2">
+              <label for="scrapNote">Açıklama <span class="muted">(opsiyonel)</span></label>
               <textarea
                 id="scrapNote"
                 name="aciklama"
-                class="form-control"
+                class="ctrl"
                 rows="3"
                 placeholder="Hurda sebebi / not"
               ></textarea>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -196,12 +196,7 @@ content %}
           <div class="modal-form-grid env-grid">
             <div class="form-group field">
               <label for="selLisansAdi">Lisans Adı</label>
-              <select
-                id="selLisansAdi"
-                name="lisans_adi"
-                class="ctrl"
-                required
-              >
+              <select id="selLisansAdi" name="lisans_adi" class="ctrl" required>
                 <option value="">Seçiniz</option>
                 {% for ln in license_names %}
                 <option value="{{ ln.name }}">{{ ln.name }}</option>
@@ -259,7 +254,9 @@ content %}
             </div>
 
             <div class="form-group field">
-              <label for="lisansEmail">E-posta <span class="muted">(opsiyonel)</span></label>
+              <label for="lisansEmail"
+                >E-posta <span class="muted">(opsiyonel)</span></label
+              >
               <input
                 id="lisansEmail"
                 name="mail_adresi"
@@ -390,7 +387,9 @@ content %}
           <p class="mb-2">Bu lisans hurdaya ayrılacak. Onaylıyor musunuz?</p>
           <div class="modal-form-grid env-grid">
             <div class="form-group field modal-form-grid--full span-2">
-              <label for="scrapNote">Açıklama <span class="muted">(opsiyonel)</span></label>
+              <label for="scrapNote"
+                >Açıklama <span class="muted">(opsiyonel)</span></label
+              >
               <textarea
                 id="scrapNote"
                 name="aciklama"

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -1,4 +1,5 @@
-{% extends "base.html" %} {% block title %}Yazıcı Düzenle{% endblock %} {% block content %}
+{% extends "base.html" %} {% block title %}Yazıcı Düzenle{% endblock %} {% block
+content %}
 <div class="container-fluid py-4">
   <div class="modal-shell">
     <div class="modal-shell__header">
@@ -6,7 +7,8 @@
         <div class="eyebrow text-primary mb-1">Yazıcı #{{ p.id }}</div>
         <h5 class="modal-shell__title">Yazıcı Bilgilerini Düzenle</h5>
         <p class="modal-shell__subtitle">
-          {{ ((p.marka or '-') ~ ' ' ~ (p.model or '')) | trim }}{% if p.seri_no %} • Seri No: {{ p.seri_no }}{% endif %}
+          {{ ((p.marka or '-') ~ ' ' ~ (p.model or '')) | trim }}{% if p.seri_no
+          %} • Seri No: {{ p.seri_no }}{% endif %}
         </p>
       </div>
       <div class="modal-shell__header-actions">
@@ -14,8 +16,7 @@
         <span class="badge rounded-pill bg-light text-muted modal-shell__badge">
           {{ p.envanter_no }}
         </span>
-        {% endif %}
-        {% if not modal %}
+        {% endif %} {% if not modal %}
         <a
           href="/printers/{{ p.id }}"
           class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-1"
@@ -76,7 +77,9 @@
             class="ctrl"
             rows="4"
             placeholder="Bakım, toner değişimi veya diğer notlar..."
-          >{{ p.notlar or '' }}</textarea>
+          >
+{{ p.notlar or '' }}</textarea
+          >
         </div>
       </div>
 

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -1,5 +1,4 @@
-{% extends "base.html" %} {% block title %}Yazıcı Düzenle{% endblock %} {% block
-content %}
+{% extends "base.html" %} {% block title %}Yazıcı Düzenle{% endblock %} {% block content %}
 <div class="container-fluid py-4">
   <div class="modal-shell">
     <div class="modal-shell__header">
@@ -7,8 +6,7 @@ content %}
         <div class="eyebrow text-primary mb-1">Yazıcı #{{ p.id }}</div>
         <h5 class="modal-shell__title">Yazıcı Bilgilerini Düzenle</h5>
         <p class="modal-shell__subtitle">
-          {{ ((p.marka or '-') ~ ' ' ~ (p.model or '')) | trim }}{% if p.seri_no
-          %} • Seri No: {{ p.seri_no }}{% endif %}
+          {{ ((p.marka or '-') ~ ' ' ~ (p.model or '')) | trim }}{% if p.seri_no %} • Seri No: {{ p.seri_no }}{% endif %}
         </p>
       </div>
       <div class="modal-shell__header-actions">
@@ -16,7 +14,8 @@ content %}
         <span class="badge rounded-pill bg-light text-muted modal-shell__badge">
           {{ p.envanter_no }}
         </span>
-        {% endif %} {% if not modal %}
+        {% endif %}
+        {% if not modal %}
         <a
           href="/printers/{{ p.id }}"
           class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-1"
@@ -34,52 +33,50 @@ content %}
       class="modal-shell__body"
       autocomplete="off"
     >
-      <div class="modal-form-grid">
-        <div class="form-group">
-          <label class="form-label" for="printerMarka">Marka</label>
+      <div class="modal-form-grid env-grid">
+        <div class="form-group field">
+          <label for="printerMarka">Marka</label>
           <input
             type="text"
             name="marka"
             id="printerMarka"
             value="{{ p.marka or '' }}"
-            class="form-control"
+            class="ctrl"
             placeholder="Örn. HP"
             autofocus
           />
         </div>
-        <div class="form-group">
-          <label class="form-label" for="printerModel">Model</label>
+        <div class="form-group field">
+          <label for="printerModel">Model</label>
           <input
             type="text"
             name="model"
             id="printerModel"
             value="{{ p.model or '' }}"
-            class="form-control"
+            class="ctrl"
             placeholder="Örn. LaserJet Pro 400"
           />
         </div>
-        <div class="form-group">
-          <label class="form-label" for="printerSerial">Seri No</label>
+        <div class="form-group field">
+          <label for="printerSerial">Seri No</label>
           <input
             type="text"
             name="seri_no"
             id="printerSerial"
             value="{{ p.seri_no or '' }}"
-            class="form-control"
+            class="ctrl"
             placeholder="Seri numarası"
           />
         </div>
-        <div class="form-group modal-form-grid--full">
-          <label class="form-label" for="printerNotes">Notlar</label>
+        <div class="form-group field modal-form-grid--full span-2">
+          <label for="printerNotes">Notlar</label>
           <textarea
             name="notlar"
             id="printerNotes"
-            class="form-control"
+            class="ctrl"
             rows="4"
             placeholder="Bakım, toner değişimi veya diğer notlar..."
-          >
-{{ p.notlar or '' }}</textarea
-          >
+          >{{ p.notlar or '' }}</textarea>
         </div>
       </div>
 

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -377,10 +377,10 @@ content %}
         <div class="modal-shell__body">
           <input type="hidden" id="assignPrinterId" name="printer_id" />
 
-          <div class="modal-form-grid">
-            <div class="form-group">
-              <label class="form-label" for="selFabrika">Fabrika</label>
-              <select id="selFabrika" name="fabrika" class="form-select">
+          <div class="modal-form-grid env-grid">
+            <div class="form-group field">
+              <label for="selFabrika">Fabrika</label>
+              <select id="selFabrika" name="fabrika" class="ctrl">
                 <option value="">Seçiniz</option>
                 {% for f in factories %}
                 <option value="{{ f }}">{{ f }}</option>
@@ -388,13 +388,9 @@ content %}
               </select>
             </div>
 
-            <div class="form-group">
-              <label class="form-label" for="selKullanim">Kullanım Alanı</label>
-              <select
-                id="selKullanim"
-                name="kullanim_alani"
-                class="form-select"
-              >
+            <div class="form-group field">
+              <label for="selKullanim">Kullanım Alanı</label>
+              <select id="selKullanim" name="kullanim_alani" class="ctrl">
                 <option value="">Seçiniz</option>
                 {% for a in areas %}
                 <option value="{{ a }}">{{ a }}</option>
@@ -402,15 +398,9 @@ content %}
               </select>
             </div>
 
-            <div class="form-group">
-              <label class="form-label" for="selPersonel"
-                >Sorumlu Personel</label
-              >
-              <select
-                id="selPersonel"
-                name="sorumlu_personel"
-                class="form-select"
-              >
+            <div class="form-group field">
+              <label for="selPersonel">Sorumlu Personel</label>
+              <select id="selPersonel" name="sorumlu_personel" class="ctrl">
                 <option value="">Seçiniz</option>
                 {% for u in users %}
                 <option value="{{ u }}">{{ u }}</option>
@@ -418,15 +408,9 @@ content %}
               </select>
             </div>
 
-            <div class="form-group">
-              <label class="form-label" for="selBagliEnv"
-                >Bağlı Olduğu Envanter</label
-              >
-              <select
-                id="selBagliEnv"
-                name="bagli_envanter_no"
-                class="form-select"
-              >
+            <div class="form-group field">
+              <label for="selBagliEnv">Bağlı Olduğu Envanter</label>
+              <select id="selBagliEnv" name="bagli_envanter_no" class="ctrl">
                 <option value="">Seçiniz</option>
                 {% for inv in inventory_nos %}
                 <option value="{{ inv }}">{{ inv }}</option>

--- a/templates/stock_assign.html
+++ b/templates/stock_assign.html
@@ -1,40 +1,40 @@
-<div class="row g-2">
-  <div class="col-md-6">
-    <label class="form-label">Donanım Tipi</label>
-    <select id="saDonanim" class="form-select" required></select>
+<div class="env-grid">
+  <div class="field">
+    <label>Donanım Tipi</label>
+    <select id="saDonanim" class="ctrl" required></select>
   </div>
-  <div class="col-md-6">
-    <label class="form-label">IFS No</label>
-    <select id="saIfs" class="form-select">
+  <div class="field">
+    <label>IFS No</label>
+    <select id="saIfs" class="ctrl">
       <option value="">(Otomatik/tekse seçilmez)</option>
     </select>
   </div>
-  <div class="col-md-6">
-    <label class="form-label">Miktar</label>
-    <input id="saMiktar" type="number" min="1" class="form-control" required />
-    <div class="form-text" id="saMaxInfo"></div>
+  <div class="field">
+    <label>Miktar</label>
+    <input id="saMiktar" type="number" min="1" class="ctrl" required />
+    <div class="text-muted small" id="saMaxInfo"></div>
   </div>
-  <div class="col-md-6">
-    <label class="form-label">Hedef Tür</label>
-    <select id="saHedefTur" class="form-select" required>
+  <div class="field">
+    <label>Hedef Tür</label>
+    <select id="saHedefTur" class="ctrl" required>
       <option value="envanter">Envanter</option>
       <option value="lisans">Lisans</option>
       <option value="yazici">Yazıcı</option>
     </select>
   </div>
-  <div class="col-md-6">
-    <label class="form-label">Hedef Envanter No (ops)</label>
-    <input id="saHedefEnv" type="text" class="form-control" />
+  <div class="field">
+    <label>Hedef Envanter No (ops)</label>
+    <input id="saHedefEnv" type="text" class="ctrl" />
   </div>
-  <div class="col-md-6">
-    <label class="form-label">Sorumlu Personel</label>
-    <select id="saPersonel" class="form-select">
+  <div class="field">
+    <label>Sorumlu Personel</label>
+    <select id="saPersonel" class="ctrl">
       <option value="">Seçiniz</option>
     </select>
   </div>
-  <div class="col-md-6">
-    <label class="form-label">Kullanım Alanı</label>
-    <select id="saKullanim" class="form-select">
+  <div class="field">
+    <label>Kullanım Alanı</label>
+    <select id="saKullanim" class="ctrl">
       <option value="">Seçiniz</option>
     </select>
   </div>


### PR DESCRIPTION
## Summary
- refresh printer form partial and edit view to use the shared env-grid/ctrl styling
- restyle inventory, license, and printer assignment modals to the new two-column layout
- remove inline inventory form CSS so all edit pages pick up the centralized theme

## Testing
- pytest *(fails: sqlalchemy.engine.create.create_engine() got multiple values for keyword argument 'poolclass')*

------
https://chatgpt.com/codex/tasks/task_e_68d69a43dc30832b9a1502a7cb208a92