### PR TITLE
Refine Bootstrap styling for assignment and edit screens

### DIFF
--- a/templates/_printer_form_fields.html
+++ b/templates/_printer_form_fields.html
@@ -1,47 +1,45 @@
-<div class="env-grid">
-  <div class="field">
-    <label>Yazıcı Markası</label>
-    <select id="selYaziciMarka" name="marka_id" class="ctrl"></select>
+<div class="row g-3">
+  <div class="col-md-6">
+    <label for="selYaziciMarka" class="form-label">Yazıcı Markası</label>
+    <select id="selYaziciMarka" name="marka_id" class="form-select"></select>
   </div>
-  <div class="field">
-    <label>Yazıcı Modeli</label>
-    <select id="selYaziciModel" name="model_id" class="ctrl" disabled></select>
-    <small class="text-muted small"
-      >Not: Model listesi seçilen Markaya göre filtrelenir.</small
-    >
+  <div class="col-md-6">
+    <label for="selYaziciModel" class="form-label">Yazıcı Modeli</label>
+    <select id="selYaziciModel" name="model_id" class="form-select" disabled></select>
+    <div class="form-text">Not: Model listesi seçilen Markaya göre filtrelenir.</div>
   </div>
 
-  <div class="field">
-    <label>Kullanım Alanı</label>
+  <div class="col-md-6">
+    <label for="selYaziciKullanim" class="form-label">Kullanım Alanı</label>
     <select
       id="selYaziciKullanim"
       name="kullanim_alani_id"
-      class="ctrl"
+      class="form-select"
     ></select>
   </div>
 
-  <div class="field">
-    <label>Envanter No</label>
-    <input name="envanter_no" class="ctrl" required />
+  <div class="col-md-6">
+    <label for="printerEnvanterNo" class="form-label">Envanter No</label>
+    <input id="printerEnvanterNo" name="envanter_no" class="form-control" required />
   </div>
 
-  <div class="field">
-    <label>IP Adresi</label>
-    <input name="ip_adresi" class="ctrl" />
+  <div class="col-md-6">
+    <label for="printerIp" class="form-label">IP Adresi</label>
+    <input id="printerIp" name="ip_adresi" class="form-control" />
   </div>
 
-  <div class="field">
-    <label>MAC</label>
-    <input name="mac" class="ctrl" />
+  <div class="col-md-6">
+    <label for="printerMac" class="form-label">MAC</label>
+    <input id="printerMac" name="mac" class="form-control" />
   </div>
 
-  <div class="field">
-    <label>Hostname</label>
-    <input name="hostname" class="ctrl" />
+  <div class="col-md-6">
+    <label for="printerHostname" class="form-label">Hostname</label>
+    <input id="printerHostname" name="hostname" class="form-control" />
   </div>
 
-  <div class="field">
-    <label>IFS No</label>
-    <input name="ifs_no" class="ctrl" />
+  <div class="col-md-6">
+    <label for="printerIfs" class="form-label">IFS No</label>
+    <input id="printerIfs" name="ifs_no" class="form-control" />
   </div>
 </div>

--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -14,60 +14,60 @@ block content %}
     class="needs-validation"
     novalidate
   >
-    <div class="env-grid" id="inventory-edit-grid">
-      <div class="field">
-        <label>Envanter No</label>
-        <input type="text" class="ctrl" value="{{ item.no }}" readonly />
+    <div class="row g-3" id="inventory-edit-grid">
+      <div class="col-md-6">
+        <label class="form-label" for="inventoryNo">Envanter No</label>
+        <input id="inventoryNo" type="text" class="form-control" value="{{ item.no }}" readonly />
       </div>
-      <div class="field">
-        <label>Bilgisayar Adı</label>
-        <input name="bilgisayar_adi" type="text" class="ctrl" />
+      <div class="col-md-6">
+        <label class="form-label" for="inventoryName">Bilgisayar Adı</label>
+        <input id="inventoryName" name="bilgisayar_adi" type="text" class="form-control" />
       </div>
-      <div class="field">
-        <label>Fabrika</label>
-        <select id="edit_fabrika" name="fabrika" class="ctrl"></select>
+      <div class="col-md-6">
+        <label class="form-label" for="edit_fabrika">Fabrika</label>
+        <select id="edit_fabrika" name="fabrika" class="form-select"></select>
       </div>
-      <div class="field">
-        <label>Departman</label>
-        <select id="edit_departman" name="departman" class="ctrl"></select>
+      <div class="col-md-6">
+        <label class="form-label" for="edit_departman">Departman</label>
+        <select id="edit_departman" name="departman" class="form-select"></select>
       </div>
-      <div class="field">
-        <label>Donanım Tipi</label>
-        <select id="edit_donanim" name="donanim_tipi" class="ctrl"></select>
+      <div class="col-md-6">
+        <label class="form-label" for="edit_donanim">Donanım Tipi</label>
+        <select id="edit_donanim" name="donanim_tipi" class="form-select"></select>
       </div>
-      <div class="field">
-        <label>Sorumlu Personel</label>
-        <select id="edit_sorumlu" name="sorumlu_personel" class="ctrl"></select>
+      <div class="col-md-6">
+        <label class="form-label" for="edit_sorumlu">Sorumlu Personel</label>
+        <select id="edit_sorumlu" name="sorumlu_personel" class="form-select"></select>
       </div>
-      <div class="field">
-        <label>Marka</label>
-        <select id="edit_marka" name="marka" class="ctrl"></select>
+      <div class="col-md-6">
+        <label class="form-label" for="edit_marka">Marka</label>
+        <select id="edit_marka" name="marka" class="form-select"></select>
       </div>
-      <div class="field">
-        <label>Model</label>
-        <select id="edit_model" name="model" class="ctrl" disabled>
+      <div class="col-md-6">
+        <label class="form-label" for="edit_model">Model</label>
+        <select id="edit_model" name="model" class="form-select" disabled>
           <option value="">Önce marka seçiniz...</option>
         </select>
       </div>
-      <div class="field">
-        <label>Seri No</label>
-        <input name="seri_no" type="text" class="ctrl" />
+      <div class="col-md-6">
+        <label class="form-label" for="inventorySerial">Seri No</label>
+        <input id="inventorySerial" name="seri_no" type="text" class="form-control" />
       </div>
-      <div class="field">
-        <label>Kullanım Alanı</label>
-        <select id="edit_kullanim" name="kullanim_alani" class="ctrl"></select>
+      <div class="col-md-6">
+        <label class="form-label" for="edit_kullanim">Kullanım Alanı</label>
+        <select id="edit_kullanim" name="kullanim_alani" class="form-select"></select>
       </div>
-      <div class="field">
-        <label>IFS No</label>
-        <input name="ifs_no" type="text" class="ctrl" />
+      <div class="col-md-6">
+        <label class="form-label" for="inventoryIfs">IFS No</label>
+        <input id="inventoryIfs" name="ifs_no" type="text" class="form-control" />
       </div>
-      <div class="field">
-        <label>Bağlı Envanter No</label>
-        <input name="bagli_envanter_no" type="text" class="ctrl" />
+      <div class="col-md-6">
+        <label class="form-label" for="inventoryLinked">Bağlı Envanter No</label>
+        <input id="inventoryLinked" name="bagli_envanter_no" type="text" class="form-control" />
       </div>
-      <div class="field span-2">
-        <label>Not</label>
-        <textarea name="not" class="ctrl" rows="2"></textarea>
+      <div class="col-12">
+        <label class="form-label" for="inventoryNote">Not</label>
+        <textarea id="inventoryNote" name="not" class="form-control" rows="2"></textarea>
       </div>
     </div>
     <div class="mt-3 d-flex gap-2">

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -496,29 +496,29 @@ block content %}
       </div>
       <div class="modal-body">
         <input type="hidden" name="item_id" id="assign_item_id" />
-        <div class="env-grid">
-          <div class="field">
-            <label>Fabrika</label>
-            <select name="fabrika" id="selFabrika" class="ctrl"></select>
+        <div class="row g-3">
+          <div class="col-md-6">
+            <label for="selFabrika" class="form-label">Fabrika</label>
+            <select name="fabrika" id="selFabrika" class="form-select"></select>
           </div>
-          <div class="field">
-            <label>Departman</label>
-            <select name="departman" id="selDepartman" class="ctrl"></select>
+          <div class="col-md-6">
+            <label for="selDepartman" class="form-label">Departman</label>
+            <select name="departman" id="selDepartman" class="form-select"></select>
           </div>
-          <div class="field">
-            <label>Sorumlu Personel</label>
+          <div class="col-md-6">
+            <label for="selPersonel" class="form-label">Sorumlu Personel</label>
             <select
               name="sorumlu_personel"
               id="selPersonel"
-              class="ctrl"
+              class="form-select"
             ></select>
           </div>
-          <div class="field">
-            <label>Bağlı Olduğu Envanter</label>
+          <div class="col-md-6">
+            <label for="selBagli" class="form-label">Bağlı Olduğu Envanter</label>
             <select
               name="bagli_envanter_no"
               id="selBagli"
-              class="ctrl"
+              class="form-select"
             ></select>
           </div>
         </div>

--- a/templates/license_assign.html
+++ b/templates/license_assign.html
@@ -3,65 +3,41 @@ content %}
 <div class="container-fluid p-3 content">
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h4 class="mb-0">Lisans Atama</h4>
-    <a class="btn btn-light" href="{{ url_for('license_list') }}"
-      >← Listeye Dön</a
-    >
+    <a class="btn btn-light" href="{{ url_for('license_list') }}">← Listeye Dön</a>
   </div>
   <div class="card shadow-sm">
     <div class="card-body">
-      <form method="post" action="/lisans/{{ license.id }}/assign">
+      <form method="post" action="/lisans/{{ license.id }}/assign" class="row g-3">
         <input
           type="hidden"
           name="islem_yapan"
           value="{{ current_user.full_name if current_user else 'system' }}"
         />
-        <div class="env-grid">
-          <div class="field">
-            <label>Sorumlu Personel</label>
-            <select name="sorumlu_personel" class="ctrl">
-              <option value="">Seçiniz</option>
-              {% for u in users %}
-              <option
-                value="{{ u }}"
-                {%
-                if
-                license.sorumlu_personel=""
-                ="u"
-                %}selected{%
-                endif
-                %}
-              >
-                {{ u }}
-              </option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="field">
-            <label>Bağlı Olduğu Envanter No</label>
-            <select name="bagli_envanter_no" class="ctrl">
-              <option value="">Seçiniz</option>
-              {% for inv in envanterler %}
-              <option
-                value="{{ inv.no }}"
-                {%
-                if
-                license.bagli_envanter_no=""
-                ="inv.no"
-                %}selected{%
-                endif
-                %}
-              >
-                {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
-              </option>
-              {% endfor %}
-            </select>
-          </div>
+        <div class="col-md-6">
+          <label for="assignSorumlu" class="form-label">Sorumlu Personel</label>
+          <select id="assignSorumlu" name="sorumlu_personel" class="form-select">
+            <option value="">Seçiniz</option>
+            {% for u in users %}
+            <option value="{{ u }}" {% if license and license.sorumlu_personel==u %}selected{% endif %}>
+              {{ u }}
+            </option>
+            {% endfor %}
+          </select>
         </div>
-        <div class="d-flex gap-2 mt-4">
+        <div class="col-md-6">
+          <label for="assignInventory" class="form-label">Bağlı Olduğu Envanter No</label>
+          <select id="assignInventory" name="bagli_envanter_no" class="form-select">
+            <option value="">Seçiniz</option>
+            {% for inv in envanterler %}
+            <option value="{{ inv.no }}" {% if license and license.bagli_envanter_no==inv.no %}selected{% endif %}>
+              {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="col-12 d-flex gap-2 mt-3">
           <button class="btn btn-primary" type="submit">Kaydet</button>
-          <a class="btn btn-secondary" href="{{ url_for('license_list') }}"
-            >İptal</a
-          >
+          <a class="btn btn-secondary" href="{{ url_for('license_list') }}">İptal</a>
         </div>
       </form>
     </div>

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -15,112 +15,79 @@
       <form
         method="post"
         action="{{ form_action }}{{ '?modal=1' if modal else '' }}"
+        class="row g-3"
       >
-        <div class="env-grid">
-          <div class="field">
-            <label>Lisans Adı</label>
-            <select name="adi" class="ctrl" required>
-              <option value="">Seçiniz...</option>
-              {% for ln in license_names %}
-              <option
-                value="{{ ln.name }}"
-                {%
-                if
-                license
-                and
-                license.lisans_adi=""
-                ="ln.name"
-                %}selected{%
-                endif
-                %}
-              >
-                {{ ln.name }}
-              </option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div class="field">
-            <label>Lisans Anahtarı</label>
-            <input
-              name="anahtar"
-              class="ctrl"
-              value="{{ license.anahtar if license else '' }}"
-            />
-          </div>
-
-          <div class="field">
-            <label>Sorumlu Personel</label>
-            <select name="sorumlu_personel" class="ctrl">
-              <option value="">(Seçiniz)</option>
-              {% for u in users %}
-              <option
-                value="{{ u }}"
-                {%
-                if
-                license
-                and
-                license.sorumlu_personel=""
-                ="u"
-                %}selected{%
-                endif
-                %}
-              >
-                {{ u }}
-              </option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div class="field">
-            <label>Bağlı Olduğu Envanter No</label>
-            <select id="selBagliEnvanter" name="inventory_id" class="ctrl">
-              <option value="">(Seçimsiz)</option>
-              {% for inv in envanterler %}
-              <option
-                value="{{ inv.id }}"
-                {%
-                if
-                license
-                and
-                license.inventory_id=""
-                ="inv.id"
-                %}selected{%
-                endif
-                %}
-              >
-                {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
-              </option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div class="field">
-            <label>IFS No</label>
-            <input
-              name="ifs_no"
-              class="ctrl"
-              value="{{ license.ifs_no if license else '' }}"
-            />
-          </div>
-
-          <div class="field">
-            <label>Mail Adresi</label>
-            <input
-              type="email"
-              name="mail_adresi"
-              class="ctrl"
-              value="{{ license.mail_adresi if license else '' }}"
-            />
-          </div>
+        <div class="col-md-6">
+          <label for="licenseAdi" class="form-label">Lisans Adı</label>
+          <select id="licenseAdi" name="adi" class="form-select" required>
+            <option value="">Seçiniz...</option>
+            {% for ln in license_names %}
+            <option value="{{ ln.name }}" {% if license and license.lisans_adi==ln.name %}selected{% endif %}>
+              {{ ln.name }}
+            </option>
+            {% endfor %}
+          </select>
         </div>
 
-        <div class="d-flex gap-2 mt-4">
+        <div class="col-md-6">
+          <label for="licenseKey" class="form-label">Lisans Anahtarı</label>
+          <input
+            id="licenseKey"
+            name="anahtar"
+            class="form-control"
+            value="{{ license.anahtar if license else '' }}"
+          />
+        </div>
+
+        <div class="col-md-6">
+          <label for="licenseSorumlu" class="form-label">Sorumlu Personel</label>
+          <select id="licenseSorumlu" name="sorumlu_personel" class="form-select">
+            <option value="">(Seçiniz)</option>
+            {% for u in users %}
+            <option value="{{ u }}" {% if license and license.sorumlu_personel==u %}selected{% endif %}>
+              {{ u }}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
+
+        <div class="col-md-6">
+          <label for="selBagliEnvanter" class="form-label">Bağlı Olduğu Envanter No</label>
+          <select id="selBagliEnvanter" name="inventory_id" class="form-select">
+            <option value="">(Seçimsiz)</option>
+            {% for inv in envanterler %}
+            <option value="{{ inv.id }}" {% if license and license.inventory_id==inv.id %}selected{% endif %}>
+              {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
+
+        <div class="col-md-6">
+          <label for="licenseIfs" class="form-label">IFS No</label>
+          <input
+            id="licenseIfs"
+            name="ifs_no"
+            class="form-control"
+            value="{{ license.ifs_no if license else '' }}"
+          />
+        </div>
+
+        <div class="col-md-6">
+          <label for="licenseMail" class="form-label">Mail Adresi</label>
+          <input
+            id="licenseMail"
+            type="email"
+            name="mail_adresi"
+            class="form-control"
+            value="{{ license.mail_adresi if license else '' }}"
+          />
+        </div>
+
+        <div class="col-12 d-flex gap-2 mt-3">
           <button class="btn btn-primary" type="submit">Kaydet</button>
           {% if not modal %}
-          <a class="btn btn-secondary" href="{{ url_for('license_list') }}"
-            >İptal</a
-          >
+          <a class="btn btn-secondary" href="{{ url_for('license_list') }}">İptal</a>
           {% endif %}
         </div>
       </form>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -193,31 +193,31 @@ content %}
         </div>
 
         <div class="modal-shell__body">
-          <div class="modal-form-grid env-grid">
-            <div class="form-group field">
-              <label for="selLisansAdi">Lisans Adı</label>
-              <select id="selLisansAdi" name="lisans_adi" class="ctrl" required>
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label for="selLisansAdi" class="form-label">Lisans Adı</label>
+              <select id="selLisansAdi" name="lisans_adi" class="form-select" required>
                 <option value="">Seçiniz</option>
                 {% for ln in license_names %}
                 <option value="{{ ln.name }}">{{ ln.name }}</option>
                 {% endfor %}
               </select>
             </div>
-            <div class="form-group field">
-              <label for="lisansAnahtari">Lisans Anahtarı</label>
+            <div class="col-md-6">
+              <label for="lisansAnahtari" class="form-label">Lisans Anahtarı</label>
               <input
                 id="lisansAnahtari"
                 name="lisans_anahtari"
                 type="text"
-                class="ctrl"
+                class="form-control"
                 required
                 placeholder="XXXX-XXXX-XXXX-XXXX"
               />
             </div>
 
-            <div class="form-group field">
-              <label for="selPersonelAdd">Sorumlu Personel</label>
-              <select id="selPersonelAdd" name="sorumlu_personel" class="ctrl">
+            <div class="col-md-6">
+              <label for="selPersonelAdd" class="form-label">Sorumlu Personel</label>
+              <select id="selPersonelAdd" name="sorumlu_personel" class="form-select">
                 <option value="">Seçiniz</option>
                 {% for u in users %}
                 <option value="{{ u }}">{{ u }}</option>
@@ -225,12 +225,12 @@ content %}
               </select>
             </div>
 
-            <div class="form-group field">
-              <label for="bagliEnvanter">Bağlı Olduğu Envanter No</label>
+            <div class="col-md-6">
+              <label for="bagliEnvanter" class="form-label">Bağlı Olduğu Envanter No</label>
               <select
                 id="bagliEnvanter"
                 name="bagli_envanter_no"
-                class="ctrl"
+                class="form-select"
                 required
               >
                 <option value="">Seçiniz...</option>
@@ -240,28 +240,28 @@ content %}
               </select>
             </div>
 
-            <div class="form-group field">
-              <label for="ifsNo">
+            <div class="col-md-6">
+              <label for="ifsNo" class="form-label">
                 IFS No <span class="muted">(opsiyonel)</span>
               </label>
               <input
                 id="ifsNo"
                 name="ifs_no"
                 type="text"
-                class="ctrl"
+                class="form-control"
                 placeholder="IFS numarası"
               />
             </div>
 
-            <div class="form-group field">
-              <label for="lisansEmail"
+            <div class="col-md-6">
+              <label for="lisansEmail" class="form-label"
                 >E-posta <span class="muted">(opsiyonel)</span></label
               >
               <input
                 id="lisansEmail"
                 name="mail_adresi"
                 type="email"
-                class="ctrl"
+                class="form-control"
                 placeholder="ornek@firma.com"
               />
             </div>
@@ -317,19 +317,19 @@ content %}
             name="islem_yapan"
             value="{{ current_user.full_name if current_user else 'system' }}"
           />
-          <div class="modal-form-grid env-grid">
-            <div class="form-group field">
-              <label for="selPersonel">Sorumlu Personel</label>
-              <select name="sorumlu_personel" class="ctrl" id="selPersonel">
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label for="selPersonel" class="form-label">Sorumlu Personel</label>
+              <select name="sorumlu_personel" class="form-select" id="selPersonel">
                 <option value="">Seçiniz</option>
                 {% for u in users %}
                 <option value="{{ u }}">{{ u }}</option>
                 {% endfor %}
               </select>
             </div>
-            <div class="form-group field">
-              <label for="selBagli">Bağlı Olduğu Envanter No</label>
-              <select name="bagli_envanter_no" class="ctrl" id="selBagli">
+            <div class="col-md-6">
+              <label for="selBagli" class="form-label">Bağlı Olduğu Envanter No</label>
+              <select name="bagli_envanter_no" class="form-select" id="selBagli">
                 <option value="">Seçiniz</option>
                 {% for inv in envanterler %}
                 <option value="{{ inv.no }}">
@@ -385,15 +385,15 @@ content %}
 
         <div class="modal-shell__body">
           <p class="mb-2">Bu lisans hurdaya ayrılacak. Onaylıyor musunuz?</p>
-          <div class="modal-form-grid env-grid">
-            <div class="form-group field modal-form-grid--full span-2">
-              <label for="scrapNote"
+          <div class="row g-3">
+            <div class="col-12">
+              <label for="scrapNote" class="form-label"
                 >Açıklama <span class="muted">(opsiyonel)</span></label
               >
               <textarea
                 id="scrapNote"
                 name="aciklama"
-                class="ctrl"
+                class="form-control"
                 rows="3"
                 placeholder="Hurda sebebi / not"
               ></textarea>

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -34,52 +34,50 @@ content %}
       class="modal-shell__body"
       autocomplete="off"
     >
-      <div class="modal-form-grid env-grid">
-        <div class="form-group field">
-          <label for="printerMarka">Marka</label>
+      <div class="row g-3">
+        <div class="col-md-6">
+          <label for="printerMarka" class="form-label">Marka</label>
           <input
             type="text"
             name="marka"
             id="printerMarka"
             value="{{ p.marka or '' }}"
-            class="ctrl"
+            class="form-control"
             placeholder="Örn. HP"
             autofocus
           />
         </div>
-        <div class="form-group field">
-          <label for="printerModel">Model</label>
+        <div class="col-md-6">
+          <label for="printerModel" class="form-label">Model</label>
           <input
             type="text"
             name="model"
             id="printerModel"
             value="{{ p.model or '' }}"
-            class="ctrl"
+            class="form-control"
             placeholder="Örn. LaserJet Pro 400"
           />
         </div>
-        <div class="form-group field">
-          <label for="printerSerial">Seri No</label>
+        <div class="col-md-6">
+          <label for="printerSerial" class="form-label">Seri No</label>
           <input
             type="text"
             name="seri_no"
             id="printerSerial"
             value="{{ p.seri_no or '' }}"
-            class="ctrl"
+            class="form-control"
             placeholder="Seri numarası"
           />
         </div>
-        <div class="form-group field modal-form-grid--full span-2">
-          <label for="printerNotes">Notlar</label>
+        <div class="col-12">
+          <label for="printerNotes" class="form-label">Notlar</label>
           <textarea
             name="notlar"
             id="printerNotes"
-            class="ctrl"
+            class="form-control"
             rows="4"
             placeholder="Bakım, toner değişimi veya diğer notlar..."
-          >
-{{ p.notlar or '' }}</textarea
-          >
+          >{{ p.notlar or '' }}</textarea>
         </div>
       </div>
 

--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -370,10 +370,10 @@ content %}
         <div class="modal-shell__body">
           <input type="hidden" id="assignPrinterId" name="printer_id" />
 
-          <div class="modal-form-grid env-grid">
-            <div class="form-group field">
-              <label for="selFabrika">Fabrika</label>
-              <select id="selFabrika" name="fabrika" class="ctrl">
+          <div class="row g-3">
+            <div class="col-md-6">
+              <label for="selFabrika" class="form-label">Fabrika</label>
+              <select id="selFabrika" name="fabrika" class="form-select">
                 <option value="">Seçiniz</option>
                 {% for f in factories %}
                 <option value="{{ f }}">{{ f }}</option>
@@ -381,9 +381,9 @@ content %}
               </select>
             </div>
 
-            <div class="form-group field">
-              <label for="selKullanim">Kullanım Alanı</label>
-              <select id="selKullanim" name="kullanim_alani" class="ctrl">
+            <div class="col-md-6">
+              <label for="selKullanim" class="form-label">Kullanım Alanı</label>
+              <select id="selKullanim" name="kullanim_alani" class="form-select">
                 <option value="">Seçiniz</option>
                 {% for a in areas %}
                 <option value="{{ a }}">{{ a }}</option>
@@ -391,9 +391,9 @@ content %}
               </select>
             </div>
 
-            <div class="form-group field">
-              <label for="selPersonel">Sorumlu Personel</label>
-              <select id="selPersonel" name="sorumlu_personel" class="ctrl">
+            <div class="col-md-6">
+              <label for="selPersonel" class="form-label">Sorumlu Personel</label>
+              <select id="selPersonel" name="sorumlu_personel" class="form-select">
                 <option value="">Seçiniz</option>
                 {% for u in users %}
                 <option value="{{ u }}">{{ u }}</option>
@@ -401,9 +401,9 @@ content %}
               </select>
             </div>
 
-            <div class="form-group field">
-              <label for="selBagliEnv">Bağlı Olduğu Envanter</label>
-              <select id="selBagliEnv" name="bagli_envanter_no" class="ctrl">
+            <div class="col-md-6">
+              <label for="selBagliEnv" class="form-label">Bağlı Olduğu Envanter</label>
+              <select id="selBagliEnv" name="bagli_envanter_no" class="form-select">
                 <option value="">Seçiniz</option>
                 {% for inv in inventory_nos %}
                 <option value="{{ inv }}">{{ inv }}</option>

--- a/templates/stock_assign.html
+++ b/templates/stock_assign.html
@@ -1,40 +1,40 @@
-<div class="env-grid">
-  <div class="field">
-    <label>Donanım Tipi</label>
-    <select id="saDonanim" class="ctrl" required></select>
+<div class="row g-3">
+  <div class="col-md-6">
+    <label for="saDonanim" class="form-label">Donanım Tipi</label>
+    <select id="saDonanim" class="form-select" required></select>
   </div>
-  <div class="field">
-    <label>IFS No</label>
-    <select id="saIfs" class="ctrl">
+  <div class="col-md-6">
+    <label for="saIfs" class="form-label">IFS No</label>
+    <select id="saIfs" class="form-select">
       <option value="">(Otomatik/tekse seçilmez)</option>
     </select>
   </div>
-  <div class="field">
-    <label>Miktar</label>
-    <input id="saMiktar" type="number" min="1" class="ctrl" required />
-    <div class="text-muted small" id="saMaxInfo"></div>
+  <div class="col-md-6">
+    <label for="saMiktar" class="form-label">Miktar</label>
+    <input id="saMiktar" type="number" min="1" class="form-control" required />
+    <div class="form-text" id="saMaxInfo"></div>
   </div>
-  <div class="field">
-    <label>Hedef Tür</label>
-    <select id="saHedefTur" class="ctrl" required>
+  <div class="col-md-6">
+    <label for="saHedefTur" class="form-label">Hedef Tür</label>
+    <select id="saHedefTur" class="form-select" required>
       <option value="envanter">Envanter</option>
       <option value="lisans">Lisans</option>
       <option value="yazici">Yazıcı</option>
     </select>
   </div>
-  <div class="field">
-    <label>Hedef Envanter No (ops)</label>
-    <input id="saHedefEnv" type="text" class="ctrl" />
+  <div class="col-md-6">
+    <label for="saHedefEnv" class="form-label">Hedef Envanter No (ops)</label>
+    <input id="saHedefEnv" type="text" class="form-control" />
   </div>
-  <div class="field">
-    <label>Sorumlu Personel</label>
-    <select id="saPersonel" class="ctrl">
+  <div class="col-md-6">
+    <label for="saPersonel" class="form-label">Sorumlu Personel</label>
+    <select id="saPersonel" class="form-select">
       <option value="">Seçiniz</option>
     </select>
   </div>
-  <div class="field">
-    <label>Kullanım Alanı</label>
-    <select id="saKullanim" class="ctrl">
+  <div class="col-md-6">
+    <label for="saKullanim" class="form-label">Kullanım Alanı</label>
+    <select id="saKullanim" class="form-select">
       <option value="">Seçiniz</option>
     </select>
   </div>


### PR DESCRIPTION
## Summary
- restyle license assignment, creation, and modal forms around Bootstrap cards and grid utilities for a cohesive appearance
- align inventory editing and assignment workflows with Bootstrap form controls and spacing
- refresh printer edit and assignment layouts plus the stock assignment widget to use Bootstrap rows, columns, and helper text

## Testing
- pytest *(fails: `TypeError: sqlalchemy.engine.create.create_engine() got multiple values for keyword argument 'poolclass'` in tests/test_stock_assign_concurrent.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d69f457dd4832bbd4b74e454a5f19c