### PR TITLE
Adjust inventory modal header styling

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1686,7 +1686,27 @@ tr[data-fault-status="arizali"] .action-select.js-actions {
 }
 
 #inventoryCreateModal .modal-header {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%) !important;
+  background: #ffffff !important;
+  color: var(--color-heading, #111827) !important;
+  border-bottom: 1px solid var(--color-border, #e5e7eb) !important;
+}
+
+#inventoryCreateModal .modal-header .modal-title {
+  color: inherit !important;
+}
+
+#inventoryCreateModal .modal-header .text-muted {
+  background: rgba(15, 23, 42, 0.05) !important;
+  color: #6b7280 !important;
+}
+
+#inventoryCreateModal .modal-header .btn-close {
+  background-color: #ef4444 !important;
+  filter: invert(1) !important;
+}
+
+#inventoryCreateModal .modal-header .btn-close:hover {
+  background-color: #dc2626 !important;
 }
 
 /* Required yıldız işareti */


### PR DESCRIPTION
## Summary
- set the inventory creation modal header background to white so it matches the rest of the modal
- update the modal title, badge, and close button styling to keep contrast on the lighter header and highlight the close action in red

## Testing
- not run (network access to install dependencies is blocked)


------
https://chatgpt.com/codex/tasks/task_e_68d792d29700832b9daa195447396cc9