### PR TITLE
Make assign modal close icon red

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1536,44 +1536,63 @@ body .container-fluid {
 
 /* ========== 2. ATAMA MODAL - MODERN TASARIM ========== */
 
-/* Atama modalı özel stil */
 #assignModal .modal-dialog {
-  max-width: 800px !important;
+  max-width: 900px !important;
+}
+
+#assignModal .modal-content {
+  border-radius: 1.25rem !important;
+  border: none !important;
+  background: var(--color-surface, #ffffff) !important;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.16) !important;
+  overflow: hidden;
 }
 
 #assignModal .modal-header {
-  background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%) !important;
+  padding: 1.75rem 2rem !important;
+  background: var(--color-surface, #ffffff) !important;
+  border-bottom: 1px solid var(--color-border, #e5e7eb) !important;
+  align-items: flex-start !important;
+  gap: 1.25rem;
+}
+
+#assignModal .modal-title {
+  font-size: 1.25rem !important;
+  font-weight: 700 !important;
+  color: var(--color-heading, #111827) !important;
+}
+
+#assignModal .modal-subtitle {
+  font-size: 0.875rem !important;
+  color: var(--color-muted, #6b7280) !important;
+  margin-top: 0.35rem !important;
+}
+
+#assignModal .modal-header .btn-close {
+  background-color: #ef4444 !important;
+  filter: invert(1) !important;
+  opacity: 1 !important;
+}
+
+#assignModal .modal-header .btn-close:hover {
+  background-color: #dc2626 !important;
 }
 
 #assignModal .modal-body {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.25rem !important;
   padding: 2rem !important;
+  background: var(--color-surface, #ffffff) !important;
 }
 
-@media (min-width: 576px) {
-  #assignModal .modal-body {
-    grid-template-columns: repeat(2, 1fr);
-  }
+#assignModal .modal-body .env-grid {
+  gap: 1.5rem !important;
 }
 
-@media (min-width: 768px) {
-  #assignModal .modal-body {
-    grid-template-columns: repeat(4, 1fr);
-  }
+#assignModal .modal-body .field {
+  margin: 0 !important;
 }
 
-#assignModal .col-md-3 {
-  margin-bottom: 0 !important;
-  padding: 0 !important;
-}
-
-#assignModal .form-label {
-  font-weight: 600 !important;
-  color: var(--color-heading) !important;
-  font-size: 0.875rem !important;
-  margin-bottom: 0.5rem !important;
+#assignModal .ctrl {
+  border-radius: var(--radius-sm) !important;
 }
 
 /* ========== 3. KULLANICI YÖNETİMİ TAB TASARIMI ========== */

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -421,24 +421,57 @@ block content %}
     padding: 0.5rem 0.75rem;
   }
 
-  #assignModal .form-select:focus {
-    border-color: #1a73e8;
-    box-shadow: 0 0 0 0.25rem rgba(26, 115, 232, 0.25);
-    background-color: #ffffff;
+  #assignModal .modal-dialog {
+    max-width: 900px;
   }
 
-  #assignModal .btn-primary {
-    background-color: #1a73e8;
-    border-color: #1a73e8;
-    border-radius: 999px;
-    padding: 0.55rem 1.75rem;
-    font-weight: 600;
+  #assignModal .modal-content {
+    border: none;
+    border-radius: 1.25rem;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+    overflow: hidden;
   }
 
-  #assignModal .btn-primary:hover,
-  #assignModal .btn-primary:focus {
-    background-color: #1558b0;
-    border-color: #1558b0;
+  #assignModal .modal-header {
+    padding: 1.75rem 2rem;
+    background: #ffffff;
+    border-bottom: 1px solid var(--color-border, #e5e7eb);
+  }
+
+  #assignModal .modal-title {
+    font-weight: 700;
+    color: var(--color-heading, #111827);
+  }
+
+  #assignModal .modal-header .modal-subtitle {
+    font-size: 0.875rem;
+    color: var(--color-muted, #6b7280);
+    margin-top: 0.25rem;
+  }
+
+  #assignModal .modal-header .btn-close {
+    --bs-btn-close-opacity: 1;
+    --bs-btn-close-color: #ef4444;
+    --bs-btn-close-hover-opacity: 1;
+    opacity: 1;
+    filter: none;
+  }
+
+  #assignModal .modal-header .btn-close:hover {
+    --bs-btn-close-color: #dc2626;
+  }
+
+  #assignModal .modal-body {
+    padding: 2rem;
+    background: #ffffff;
+  }
+
+  #assignModal .env-grid {
+    margin-bottom: 0;
+  }
+
+  #assignModal .ctrl {
+    border-radius: var(--radius-sm, 0.75rem);
   }
   .is-invalid {
     border-color: #dc3545 !important;
@@ -484,10 +517,17 @@ block content %}
 
 <!-- Atama Modal -->
 <div class="modal fade" id="assignModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
+  <div
+    class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable"
+  >
     <form id="assignForm" class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Envanter Atama</h5>
+        <div>
+          <h5 class="modal-title">Envanter Atama</h5>
+          <p class="modal-subtitle mb-0">
+            Envanteri ilgili personel ve departmanla eşleştirin.
+          </p>
+        </div>
         <button
           type="button"
           class="btn-close"
@@ -496,30 +536,24 @@ block content %}
       </div>
       <div class="modal-body">
         <input type="hidden" name="item_id" id="assign_item_id" />
-        <div class="row g-3">
-          <div class="col-md-6">
-            <label for="selFabrika" class="form-label">Fabrika</label>
-            <select name="fabrika" id="selFabrika" class="form-select"></select>
+        <div class="env-grid" id="envanter-atama">
+          <div class="field">
+            <label for="selFabrika">Fabrika</label>
+            <select name="fabrika" id="selFabrika" class="ctrl"></select>
           </div>
-          <div class="col-md-6">
-            <label for="selDepartman" class="form-label">Departman</label>
-            <select name="departman" id="selDepartman" class="form-select"></select>
+          <div class="field">
+            <label for="selDepartman">Departman</label>
+            <select name="departman" id="selDepartman" class="ctrl"></select>
           </div>
-          <div class="col-md-6">
-            <label for="selPersonel" class="form-label">Sorumlu Personel</label>
-            <select
-              name="sorumlu_personel"
-              id="selPersonel"
-              class="form-select"
-            ></select>
+          <div class="field">
+            <label for="selPersonel">Sorumlu Personel</label>
+            <select name="sorumlu_personel" id="selPersonel" class="ctrl"></select>
           </div>
-          <div class="col-md-6">
-            <label for="selBagli" class="form-label">Bağlı Olduğu Envanter</label>
-            <select
-              name="bagli_envanter_no"
-              id="selBagli"
-              class="form-select"
-            ></select>
+          <div class="field">
+            <label for="selBagli">
+              Bağlı Olduğu Envanter <span class="muted">(Opsiyonel)</span>
+            </label>
+            <select name="bagli_envanter_no" id="selBagli" class="ctrl"></select>
           </div>
         </div>
       </div>

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -547,13 +547,21 @@ block content %}
           </div>
           <div class="field">
             <label for="selPersonel">Sorumlu Personel</label>
-            <select name="sorumlu_personel" id="selPersonel" class="ctrl"></select>
+            <select
+              name="sorumlu_personel"
+              id="selPersonel"
+              class="ctrl"
+            ></select>
           </div>
           <div class="field">
             <label for="selBagli">
               Bağlı Olduğu Envanter <span class="muted">(Opsiyonel)</span>
             </label>
-            <select name="bagli_envanter_no" id="selBagli" class="ctrl"></select>
+            <select
+              name="bagli_envanter_no"
+              id="selBagli"
+              class="ctrl"
+            ></select>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- restyle the inventory assignment modal to mirror the Envanter Ekle experience with env-grid fields and contextual subtitle
- refresh the assign modal styles for a white header, rounded content, and consistent control styling across the app
- update the assign modal close control so the dismiss icon renders as a red “X”

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d79a081e78832bbbf7a1827fb6a835