### PR TITLE
Revamp inventory edit screen layout

### DIFF
--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -1,87 +1,344 @@
-{% extends "base.html" %}{% block title %}Envanter Düzenle{% endblock %} {%
-block content %}
-<div class="container-fluid p-3">
-  <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
-    <h5 class="mb-2 mb-md-0">Envanter Düzenle</h5>
-    <div class="text-muted small">
-      <strong>Envanter No:</strong> {{ item.no }}
+{% extends "base.html" %}{% block title %}Envanter Düzenle{% endblock %} {% block content %}
+<div class="container-fluid py-4">
+  <div class="modal-shell inventory-edit-shell">
+    <div class="modal-shell__header inventory-edit__header">
+      <div class="modal-shell__heading inventory-edit__heading">
+        <div class="eyebrow text-primary mb-2">Envanter #{{ item.no }}</div>
+        <h5 class="modal-shell__title">Envanter Bilgilerini Düzenle</h5>
+        <p class="modal-shell__subtitle">
+          Envanterin kimlik, konum ve sorumlu bilgilerini güncelleyerek kayıtlarınızı güncel tutun.
+        </p>
+      </div>
+      <div class="modal-shell__header-actions inventory-edit__actions">
+        <button
+          type="button"
+          class="inventory-edit__close"
+          data-edit-close
+          {% if not modal %}data-target-url="{{ url_for('inventory.list') }}"{% endif %}
+          aria-label="Kapat"
+        >
+          <i class="bi bi-x-lg"></i>
+        </button>
+      </div>
     </div>
+
+    <form
+      method="post"
+      action="{{ '?modal=1' if modal else '' }}"
+      id="inventory-edit-form"
+      class="modal-shell__body stack-lg needs-validation"
+      autocomplete="off"
+      novalidate
+    >
+      <div class="row g-3" id="inventory-edit-grid">
+        <div class="col-md-6">
+          <label class="form-label" for="inventoryNo">Envanter No</label>
+          <input
+            id="inventoryNo"
+            type="text"
+            class="form-control"
+            value="{{ item.no }}"
+            readonly
+          />
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="inventoryName">Bilgisayar Adı</label>
+          <input
+            id="inventoryName"
+            name="bilgisayar_adi"
+            type="text"
+            class="form-control"
+            value="{{ item.bilgisayar_adi or '' }}"
+            placeholder="Örn. BT-WS-01"
+          />
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="edit_fabrika">Fabrika</label>
+          <select id="edit_fabrika" name="fabrika" class="form-select"></select>
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="edit_departman">Departman</label>
+          <select id="edit_departman" name="departman" class="form-select"></select>
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="edit_donanim">Donanım Tipi</label>
+          <select id="edit_donanim" name="donanim_tipi" class="form-select"></select>
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="edit_sorumlu">Sorumlu Personel</label>
+          <select id="edit_sorumlu" name="sorumlu_personel" class="form-select"></select>
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="edit_marka">Marka</label>
+          <select id="edit_marka" name="marka" class="form-select"></select>
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="edit_model">Model</label>
+          <select id="edit_model" name="model" class="form-select" disabled>
+            <option value="">Önce marka seçiniz...</option>
+          </select>
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="inventorySerial">Seri No</label>
+          <input
+            id="inventorySerial"
+            name="seri_no"
+            type="text"
+            class="form-control"
+            value="{{ item.seri_no or '' }}"
+            placeholder="Seri numarası"
+          />
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="edit_kullanim">Kullanım Alanı</label>
+          <select id="edit_kullanim" name="kullanim_alani" class="form-select"></select>
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="inventoryIfs">IFS No</label>
+          <input
+            id="inventoryIfs"
+            name="ifs_no"
+            type="text"
+            class="form-control"
+            value="{{ item.ifs_no or '' }}"
+            placeholder="IFS referansı"
+          />
+        </div>
+        <div class="col-md-6">
+          <label class="form-label" for="inventoryLinked">Bağlı Envanter No</label>
+          <input
+            id="inventoryLinked"
+            name="bagli_envanter_no"
+            type="text"
+            class="form-control"
+            value="{{ item.bagli_envanter_no or '' }}"
+            placeholder="Varsa bağlı envanter"
+          />
+        </div>
+        <div class="col-12">
+          <label class="form-label" for="inventoryNote">Not</label>
+          <textarea
+            id="inventoryNote"
+            name="not"
+            class="form-control"
+            rows="3"
+            placeholder="Envanterle ilgili önemli notları girin"
+          >{{ item.not_ or '' }}</textarea>
+        </div>
+      </div>
+
+      <div class="modal-shell__footer inventory-edit__footer">
+        <div class="modal-shell__note inventory-edit__note">
+          <i class="bi bi-info-circle-fill"></i>
+          <span>Kaydettiğiniz bilgiler envanter geçmişine işlenecektir.</span>
+        </div>
+        <div class="modal-shell__actions">
+          {% if not modal %}
+          <a href="{{ url_for('inventory.list') }}" class="btn btn-outline-secondary">
+            İptal
+          </a>
+          {% endif %}
+          <button type="submit" class="btn btn-primary">
+            <i class="bi bi-save me-1"></i>
+            Kaydet
+          </button>
+        </div>
+      </div>
+    </form>
   </div>
-  <form
-    method="post"
-    action="{{ '?modal=1' if modal else '' }}"
-    id="inventory-edit-form"
-    class="needs-validation"
-    novalidate
-  >
-    <div class="row g-3" id="inventory-edit-grid">
-      <div class="col-md-6">
-        <label class="form-label" for="inventoryNo">Envanter No</label>
-        <input id="inventoryNo" type="text" class="form-control" value="{{ item.no }}" readonly />
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="inventoryName">Bilgisayar Adı</label>
-        <input id="inventoryName" name="bilgisayar_adi" type="text" class="form-control" />
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="edit_fabrika">Fabrika</label>
-        <select id="edit_fabrika" name="fabrika" class="form-select"></select>
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="edit_departman">Departman</label>
-        <select id="edit_departman" name="departman" class="form-select"></select>
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="edit_donanim">Donanım Tipi</label>
-        <select id="edit_donanim" name="donanim_tipi" class="form-select"></select>
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="edit_sorumlu">Sorumlu Personel</label>
-        <select id="edit_sorumlu" name="sorumlu_personel" class="form-select"></select>
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="edit_marka">Marka</label>
-        <select id="edit_marka" name="marka" class="form-select"></select>
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="edit_model">Model</label>
-        <select id="edit_model" name="model" class="form-select" disabled>
-          <option value="">Önce marka seçiniz...</option>
-        </select>
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="inventorySerial">Seri No</label>
-        <input id="inventorySerial" name="seri_no" type="text" class="form-control" />
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="edit_kullanim">Kullanım Alanı</label>
-        <select id="edit_kullanim" name="kullanim_alani" class="form-select"></select>
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="inventoryIfs">IFS No</label>
-        <input id="inventoryIfs" name="ifs_no" type="text" class="form-control" />
-      </div>
-      <div class="col-md-6">
-        <label class="form-label" for="inventoryLinked">Bağlı Envanter No</label>
-        <input id="inventoryLinked" name="bagli_envanter_no" type="text" class="form-control" />
-      </div>
-      <div class="col-12">
-        <label class="form-label" for="inventoryNote">Not</label>
-        <textarea id="inventoryNote" name="not" class="form-control" rows="2"></textarea>
-      </div>
-    </div>
-    <div class="mt-3 d-flex gap-2">
-      <button type="submit" class="btn btn-primary btn-sm">Kaydet</button>
-      {% if not modal %}
-      <a
-        href="{{ url_for('inventory.list') }}"
-        class="btn btn-outline-secondary btn-sm"
-        >İptal</a
-      >
-      {% endif %}
-    </div>
-  </form>
 </div>
+
+<style>
+  .inventory-edit-shell {
+    max-width: 1000px;
+    margin: 0 auto;
+    border-radius: 1.5rem;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    box-shadow: var(--shadow-lg);
+    overflow: hidden;
+  }
+
+  .inventory-edit__header {
+    background: linear-gradient(
+      135deg,
+      rgba(37, 99, 235, 0.08) 0%,
+      rgba(56, 189, 248, 0.14) 100%
+    );
+    padding: clamp(1.75rem, 1.25rem + 1.5vw, 2.5rem);
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--space-md);
+  }
+
+  body.theme-dark .inventory-edit__header {
+    background: linear-gradient(
+      135deg,
+      rgba(59, 130, 246, 0.26) 0%,
+      rgba(124, 58, 237, 0.24) 100%
+    );
+  }
+
+  .inventory-edit__heading .modal-shell__title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-heading);
+  }
+
+  .inventory-edit__heading .modal-shell__subtitle {
+    color: var(--color-muted);
+    max-width: 38rem;
+    margin-bottom: 0;
+  }
+
+  .inventory-edit-shell form.modal-shell__body {
+    padding: clamp(1.75rem, 1.35rem + 1vw, 2.5rem);
+    background: var(--color-surface);
+  }
+
+  .inventory-edit__footer {
+    padding: clamp(1.5rem, 1.15rem + 1vw, 2rem) clamp(1.75rem, 1.35rem + 1vw, 2.5rem);
+    background: linear-gradient(
+      135deg,
+      rgba(37, 99, 235, 0.06) 0%,
+      rgba(16, 185, 129, 0.08) 100%
+    );
+    border-top: 1px solid rgba(148, 163, 184, 0.25);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  body.theme-dark .inventory-edit__footer {
+    background: linear-gradient(
+      135deg,
+      rgba(59, 130, 246, 0.18) 0%,
+      rgba(16, 185, 129, 0.22) 100%
+    );
+    border-top: 1px solid rgba(148, 163, 184, 0.35);
+  }
+
+  .inventory-edit__note {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    color: var(--color-primary-strong);
+    font-weight: 600;
+  }
+
+  .inventory-edit__note .bi {
+    font-size: 1.1rem;
+  }
+
+  .inventory-edit-shell .form-label {
+    font-weight: 600;
+    color: var(--color-heading);
+  }
+
+  .inventory-edit-shell .form-control,
+  .inventory-edit-shell .form-select {
+    border-radius: 0.9rem;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    background: #f8fafc;
+    padding: 0.65rem 0.95rem;
+    transition: box-shadow var(--transition-fast), border-color var(--transition-fast);
+  }
+
+  body.theme-dark .inventory-edit-shell .form-control,
+  body.theme-dark .inventory-edit-shell .form-select {
+    background: rgba(15, 23, 42, 0.65);
+    border-color: rgba(148, 163, 184, 0.4);
+    color: var(--color-body);
+  }
+
+  .inventory-edit-shell .form-control:focus,
+  .inventory-edit-shell .form-select:focus {
+    border-color: rgba(37, 99, 235, 0.75);
+    box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.15);
+    background: #ffffff;
+  }
+
+  body.theme-dark .inventory-edit-shell .form-control:focus,
+  body.theme-dark .inventory-edit-shell .form-select:focus {
+    background: rgba(15, 23, 42, 0.8);
+    box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.25);
+  }
+
+  .inventory-edit__close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    border: none;
+    background: linear-gradient(135deg, #ef4444 0%, #b91c1c 100%);
+    color: #fff;
+    font-size: 1.2rem;
+    box-shadow: 0 18px 40px rgba(239, 68, 68, 0.28);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .inventory-edit__close:hover {
+    transform: translateY(-2px) scale(1.03);
+    box-shadow: 0 24px 48px rgba(220, 38, 38, 0.32);
+  }
+
+  .inventory-edit__close:active {
+    transform: translateY(0);
+  }
+
+  body.theme-dark .inventory-edit__close {
+    box-shadow: 0 20px 42px rgba(239, 68, 68, 0.35);
+  }
+
+  .inventory-edit-shell .modal-shell__actions {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  @media (max-width: 991.98px) {
+    .inventory-edit-shell {
+      border-radius: 1.25rem;
+    }
+
+    .inventory-edit__close {
+      width: 44px;
+      height: 44px;
+      border-radius: 14px;
+    }
+  }
+
+  @media (max-width: 575.98px) {
+    .inventory-edit__header {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .inventory-edit__actions {
+      align-self: flex-end;
+    }
+
+    .inventory-edit__footer {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .inventory-edit-shell .modal-shell__actions {
+      width: 100%;
+      flex-direction: column-reverse;
+    }
+
+    .inventory-edit-shell .modal-shell__actions .btn {
+      width: 100%;
+    }
+  }
+</style>
 
 <script>
   window.SKIP_SELECT_ENHANCE = true;
@@ -89,6 +346,21 @@ block content %}
 
 <script>
   document.addEventListener("DOMContentLoaded", async () => {
+    const closeBtn = document.querySelector("[data-edit-close]");
+    if (closeBtn) {
+      closeBtn.addEventListener("click", (event) => {
+        event.preventDefault();
+        if (window.self !== window.top) {
+          window.parent.postMessage("modal-close", "*");
+        } else {
+          const target = closeBtn.dataset.targetUrl;
+          if (target) {
+            window.location.href = target;
+          }
+        }
+      });
+    }
+
     const current = {{ {
       "bilgisayar_adi": item.bilgisayar_adi or "",
       "fabrika": item.fabrika or "",

--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -1,4 +1,5 @@
-{% extends "base.html" %}{% block title %}Envanter Düzenle{% endblock %} {% block content %}
+{% extends "base.html" %}{% block title %}Envanter Düzenle{% endblock %} {%
+block content %}
 <div class="container-fluid py-4">
   <div class="modal-shell inventory-edit-shell">
     <div class="modal-shell__header inventory-edit__header">
@@ -6,7 +7,8 @@
         <div class="eyebrow text-primary mb-2">Envanter #{{ item.no }}</div>
         <h5 class="modal-shell__title">Envanter Bilgilerini Düzenle</h5>
         <p class="modal-shell__subtitle">
-          Envanterin kimlik, konum ve sorumlu bilgilerini güncelleyerek kayıtlarınızı güncel tutun.
+          Envanterin kimlik, konum ve sorumlu bilgilerini güncelleyerek
+          kayıtlarınızı güncel tutun.
         </p>
       </div>
       <div class="modal-shell__header-actions inventory-edit__actions">
@@ -14,7 +16,14 @@
           type="button"
           class="inventory-edit__close"
           data-edit-close
-          {% if not modal %}data-target-url="{{ url_for('inventory.list') }}"{% endif %}
+          {%
+          if
+          not
+          modal
+          %}data-target-url="{{ url_for('inventory.list') }}"
+          {%
+          endif
+          %}
           aria-label="Kapat"
         >
           <i class="bi bi-x-lg"></i>
@@ -58,15 +67,27 @@
         </div>
         <div class="col-md-6">
           <label class="form-label" for="edit_departman">Departman</label>
-          <select id="edit_departman" name="departman" class="form-select"></select>
+          <select
+            id="edit_departman"
+            name="departman"
+            class="form-select"
+          ></select>
         </div>
         <div class="col-md-6">
           <label class="form-label" for="edit_donanim">Donanım Tipi</label>
-          <select id="edit_donanim" name="donanim_tipi" class="form-select"></select>
+          <select
+            id="edit_donanim"
+            name="donanim_tipi"
+            class="form-select"
+          ></select>
         </div>
         <div class="col-md-6">
           <label class="form-label" for="edit_sorumlu">Sorumlu Personel</label>
-          <select id="edit_sorumlu" name="sorumlu_personel" class="form-select"></select>
+          <select
+            id="edit_sorumlu"
+            name="sorumlu_personel"
+            class="form-select"
+          ></select>
         </div>
         <div class="col-md-6">
           <label class="form-label" for="edit_marka">Marka</label>
@@ -91,7 +112,11 @@
         </div>
         <div class="col-md-6">
           <label class="form-label" for="edit_kullanim">Kullanım Alanı</label>
-          <select id="edit_kullanim" name="kullanim_alani" class="form-select"></select>
+          <select
+            id="edit_kullanim"
+            name="kullanim_alani"
+            class="form-select"
+          ></select>
         </div>
         <div class="col-md-6">
           <label class="form-label" for="inventoryIfs">IFS No</label>
@@ -105,7 +130,9 @@
           />
         </div>
         <div class="col-md-6">
-          <label class="form-label" for="inventoryLinked">Bağlı Envanter No</label>
+          <label class="form-label" for="inventoryLinked"
+            >Bağlı Envanter No</label
+          >
           <input
             id="inventoryLinked"
             name="bagli_envanter_no"
@@ -123,7 +150,9 @@
             class="form-control"
             rows="3"
             placeholder="Envanterle ilgili önemli notları girin"
-          >{{ item.not_ or '' }}</textarea>
+          >
+{{ item.not_ or '' }}</textarea
+          >
         </div>
       </div>
 
@@ -134,7 +163,10 @@
         </div>
         <div class="modal-shell__actions">
           {% if not modal %}
-          <a href="{{ url_for('inventory.list') }}" class="btn btn-outline-secondary">
+          <a
+            href="{{ url_for('inventory.list') }}"
+            class="btn btn-outline-secondary"
+          >
             İptal
           </a>
           {% endif %}
@@ -198,7 +230,8 @@
   }
 
   .inventory-edit__footer {
-    padding: clamp(1.5rem, 1.15rem + 1vw, 2rem) clamp(1.75rem, 1.35rem + 1vw, 2.5rem);
+    padding: clamp(1.5rem, 1.15rem + 1vw, 2rem)
+      clamp(1.75rem, 1.35rem + 1vw, 2.5rem);
     background: linear-gradient(
       135deg,
       rgba(37, 99, 235, 0.06) 0%,
@@ -244,7 +277,9 @@
     border: 1px solid rgba(148, 163, 184, 0.45);
     background: #f8fafc;
     padding: 0.65rem 0.95rem;
-    transition: box-shadow var(--transition-fast), border-color var(--transition-fast);
+    transition:
+      box-shadow var(--transition-fast),
+      border-color var(--transition-fast);
   }
 
   body.theme-dark .inventory-edit-shell .form-control,
@@ -280,7 +315,9 @@
     font-size: 1.2rem;
     box-shadow: 0 18px 40px rgba(239, 68, 68, 0.28);
     cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
   }
 
   .inventory-edit__close:hover {


### PR DESCRIPTION
## Summary
- restyle the inventory edit template with a modal-shell layout that mirrors the assignment view and adds a red close control
- enhance the form styling, responsive behavior, and footer messaging to deliver a polished experience
- hook a close button handler that either dismisses the iframe modal or returns to the inventory list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d79ccfce18832bacca9c4e726259ef