### PR TITLE
Remove inventory edit modal eyebrow label

### DIFF
--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -3,7 +3,6 @@ block content %}
 <div class="inventory-edit-shell">
     <div class="modal-shell__header inventory-edit__header">
       <div class="modal-shell__heading inventory-edit__heading">
-        <div class="eyebrow text-primary mb-2">Envanter #{{ item.no }}</div>
         <h5 class="modal-shell__title">Envanter Bilgilerini Düzenle</h5>
         <p class="modal-shell__subtitle">
           Envanterin kimlik, konum ve sorumlu bilgilerini güncelleyerek


### PR DESCRIPTION
## Summary
- remove the purple eyebrow label from the inventory edit modal header to match the desired layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7aad5736c832ba6dfacda4813a0d4