### PR TITLE
Neutralize inventory edit background

### DIFF
--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -3,7 +3,6 @@ block content %}
 <div class="inventory-edit-shell">
     <div class="modal-shell__header inventory-edit__header">
       <div class="modal-shell__heading inventory-edit__heading">
-        <div class="eyebrow text-primary mb-2">Envanter #{{ item.no }}</div>
         <h5 class="modal-shell__title">Envanter Bilgilerini Düzenle</h5>
         <p class="modal-shell__subtitle">
           Envanterin kimlik, konum ve sorumlu bilgilerini güncelleyerek
@@ -180,6 +179,26 @@ block content %}
 </div>
 
 <style>
+  body.theme-default.inventory-edit-page,
+  body.theme-green.inventory-edit-page,
+  body.theme-red.inventory-edit-page,
+  body.theme-purple.inventory-edit-page {
+    background: var(--color-surface);
+  }
+
+  body.theme-dark.inventory-edit-page {
+    background: rgba(15, 23, 42, 0.96);
+  }
+
+  body.inventory-edit-page.anim-gradient {
+    animation: none;
+    background-size: auto;
+  }
+
+  body.inventory-edit-page #bg {
+    display: none !important;
+  }
+
   .inventory-edit-shell {
     max-width: 1000px;
     margin: clamp(2rem, 1.5rem + 2vw, 3rem) auto;
@@ -191,11 +210,8 @@ block content %}
   }
 
   .inventory-edit__header {
-    background: linear-gradient(
-      135deg,
-      rgba(37, 99, 235, 0.08) 0%,
-      rgba(56, 189, 248, 0.14) 100%
-    );
+    background: var(--color-surface);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.35);
     padding: clamp(1.75rem, 1.25rem + 1.5vw, 2.5rem);
     display: flex;
     justify-content: space-between;
@@ -204,11 +220,8 @@ block content %}
   }
 
   body.theme-dark .inventory-edit__header {
-    background: linear-gradient(
-      135deg,
-      rgba(59, 130, 246, 0.26) 0%,
-      rgba(124, 58, 237, 0.24) 100%
-    );
+    background: rgba(15, 23, 42, 0.85);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.45);
   }
 
   .inventory-edit__heading .modal-shell__title {
@@ -382,6 +395,11 @@ block content %}
 
 <script>
   document.addEventListener("DOMContentLoaded", async () => {
+    document.body.classList.add("inventory-edit-page");
+    window.addEventListener("beforeunload", () => {
+      document.body.classList.remove("inventory-edit-page");
+    });
+
     const closeBtn = document.querySelector("[data-edit-close]");
     if (closeBtn) {
       closeBtn.addEventListener("click", (event) => {


### PR DESCRIPTION
## Summary
- override themed body gradients with a neutral surface background while the inventory edit view is open
- toggle a page-specific class on load/unload so the neutral background styling only applies to the edit screen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7aad5736c832ba6dfacda4813a0d4