### PR TITLE
Remove border from inventory edit modal card

### DIFF
--- a/static/previews/inventory-edit.html
+++ b/static/previews/inventory-edit.html
@@ -339,7 +339,7 @@
       .inventory-edit__card {
         background: rgba(255, 255, 255, 0.98);
         border-radius: 1.5rem;
-        border: 1px solid rgba(15, 23, 42, 0.08);
+        border: none;
         box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
         padding: clamp(1.75rem, 1.55rem + 0.5vw, 2.25rem);
         display: flex;

--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -218,7 +218,7 @@
     .inventory-edit__card {
       background: var(--color-surface, #ffffff);
       border-radius: 1.5rem;
-      border: 1px solid rgba(15, 23, 42, 0.08);
+      border: none;
       box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
       padding: clamp(1.75rem, 1.55rem + 0.5vw, 2.25rem);
       display: flex;
@@ -247,7 +247,7 @@
 
     body.theme-dark .inventory-edit__card {
       background: rgba(15, 23, 42, 0.92);
-      border-color: rgba(148, 163, 184, 0.25);
+      border: none;
       box-shadow: 0 28px 56px rgba(2, 6, 23, 0.55);
     }
 


### PR DESCRIPTION
## Summary
- remove the border around the inventory edit modal card so the outer frame disappears
- mirror the styling change in the static preview to keep design examples aligned

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d80982c520832b882998df5b7e0201