### PR TITLE
Remove border from inventory edit modal card

### DIFF
--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -227,7 +227,7 @@ block content %}
   .inventory-edit__card {
     background: transparent;
     border-radius: 1.5rem;
-    border: 1px solid rgba(15, 23, 42, 0.12);
+    border: none;
     box-shadow: none;
     padding: clamp(1.75rem, 1.55rem + 0.5vw, 2.25rem);
     display: flex;
@@ -256,7 +256,7 @@ block content %}
 
   body.theme-dark .inventory-edit__card {
     background: transparent;
-    border: 1px solid rgba(148, 163, 184, 0.25);
+    border: none;
     box-shadow: none;
   }
 


### PR DESCRIPTION
## Summary
- remove the border from the inventory edit modal card in light mode to eliminate the white frame
- remove the border from the inventory edit modal card in dark mode so the gradient backdrop blends smoothly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8141e1a54832bbb9a0fb93af41951