### PR TITLE
Fix inventory modal white frame styling

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1657,6 +1657,10 @@ body .container-fluid {
   backdrop-filter: blur(4px);
 }
 
+.modal-backdrop.show {
+  opacity: 0.7 !important;
+}
+
 /* Modal açılma animasyonu */
 .modal.fade .modal-dialog {
   transition:
@@ -1677,10 +1681,32 @@ body .container-fluid {
   max-width: 900px !important;
 }
 
+/* ========== ENVANTER MODAL BEYAZ ÇERÇEVE DÜZELTMESİ ========== */
+
+#inventoryCreateModal .modal-content {
+  padding: 0 !important;
+  border: none !important;
+  border-radius: var(--radius-md) !important;
+  overflow: hidden !important;
+}
+
+#inventoryCreateModal .modal-content > * {
+  border-radius: 0 !important;
+}
+
 #inventoryCreateModal .modal-header {
   background: #ffffff !important;
   color: var(--color-heading, #111827) !important;
   border-bottom: 1px solid var(--color-border, #e5e7eb) !important;
+  border-radius: var(--radius-md) var(--radius-md) 0 0 !important;
+}
+
+#inventoryCreateModal .modal-body {
+  margin: 0 !important;
+}
+
+#inventoryCreateModal .modal-footer {
+  border-radius: 0 0 var(--radius-md) var(--radius-md) !important;
 }
 
 #inventoryCreateModal .modal-header .modal-title {


### PR DESCRIPTION
## Summary
- remove the default padding and border from the inventory creation modal so the blue panel reaches the edges
- ensure the modal header/footer radii stay rounded and slightly increase the backdrop opacity for a darker overlay

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8154937d8832bac9bb712f3152850