### PR TITLE
Adjust inventory edit modal wrapper styling

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1366,6 +1366,12 @@ body .container-fluid {
   background: var(--color-surface) !important;
 }
 
+body .modal.inventory-edit-modal .modal-content {
+  background: transparent !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
+}
+
 /* Modal header sade görünüm */
 
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1374,7 +1374,6 @@ body .modal.inventory-edit-modal .modal-content {
 
 /* Modal header sade görünüm */
 
-
 /* Envanter No bilgisi */
 .modal-header .text-muted {
   background: transparent !important;


### PR DESCRIPTION
## Summary
- remove the extra frame on the inventory edit modal by resetting the modal-content wrapper

## Testing
- Verified the static preview `static/previews/inventory-edit.html`


------
https://chatgpt.com/codex/tasks/task_e_68d940513744832b85d0003287792041