### PR TITLE
Enable frameless inventory edit modal

### DIFF
--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -57,7 +57,8 @@
         const selectedOption = sel.options[sel.selectedIndex];
         const title = (sel.dataset.editModalTitle || selectedOption?.text || "").trim();
         const size = sel.dataset.editModalSize || "lg";
-        openModal(`${url}?modal=1`, title, { size });
+        const chrome = sel.dataset.editModalChrome || "default";
+        openModal(`${url}?modal=1`, title, { size, chrome });
       } else {
         go(url);
       }

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -55,7 +55,11 @@
       const url = `/${entity}/${id}/${map[val]}`;
       if (val === "edit" && window.openModal) {
         const selectedOption = sel.options[sel.selectedIndex];
-        const title = (sel.dataset.editModalTitle || selectedOption?.text || "").trim();
+        const title = (
+          sel.dataset.editModalTitle ||
+          selectedOption?.text ||
+          ""
+        ).trim();
         const size = sel.dataset.editModalSize || "lg";
         const chrome = sel.dataset.editModalChrome || "default";
         openModal(`${url}?modal=1`, title, { size, chrome });

--- a/templates/base.html
+++ b/templates/base.html
@@ -195,9 +195,19 @@ document.addEventListener("DOMContentLoaded", () => {
 function stopRowClick(e) { e.stopPropagation(); }
 
 function openModal(url, title="", options={}) {
+  const modalEl = document.getElementById("iframeModal");
   const frame = document.getElementById("iframeModalFrame");
-  frame.src = url;
-  document.getElementById("iframeModalTitle").textContent = title;
+  const chrome = (options && options.chrome) || "default";
+  if (modalEl) {
+    modalEl.classList.toggle("iframe-modal--frameless", chrome === "frameless");
+  }
+  if (frame) {
+    frame.src = url;
+  }
+  const titleEl = document.getElementById("iframeModalTitle");
+  if (titleEl) {
+    titleEl.textContent = chrome === "frameless" ? "" : title;
+  }
   const dialog = document.querySelector("#iframeModal .modal-dialog");
   if (dialog) {
     const sizeClasses = [
@@ -231,7 +241,7 @@ function openModal(url, title="", options={}) {
       dialog.classList.add("modal-lg");
     }
   }
-  const modal = new bootstrap.Modal(document.getElementById("iframeModal"));
+  const modal = new bootstrap.Modal(modalEl);
   modal.show();
 }
 window.openModal = openModal;
@@ -242,7 +252,8 @@ document.addEventListener("click", (e) => {
   e.preventDefault();
   const title = link.dataset.modalTitle || link.textContent?.trim() || "";
   const size = link.dataset.modalSize || undefined;
-  openModal(link.dataset.modalUrl, title, { size });
+  const chrome = link.dataset.modalChrome || "default";
+  openModal(link.dataset.modalUrl, title, { size, chrome });
 });
 
 window.addEventListener("message", (e) => {
@@ -260,6 +271,18 @@ window.addEventListener("message", (e) => {
     tr[data-href]:hover { background-color: #f8f9fa; }
     @media (hover:hover) {
       tr[data-href]:hover > td { transition: background-color .12s ease-in-out; }
+    }
+    #iframeModal.iframe-modal--frameless .modal-content {
+      background: transparent;
+      border: 0;
+      box-shadow: none;
+    }
+    #iframeModal.iframe-modal--frameless .modal-body {
+      padding: 0;
+      background: transparent;
+    }
+    #iframeModal.iframe-modal--frameless .modal-header {
+      display: none;
     }
     </style>
     {% endblock %}

--- a/templates/inventory/detail.html
+++ b/templates/inventory/detail.html
@@ -6,6 +6,7 @@ block content %}
   <a
     href="#"
     data-modal-url="/inventory/{{ item_id }}/edit?modal=1"
+    data-modal-chrome="frameless"
     class="btn btn-primary btn-sm"
     >Düzenle</a
   >

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -150,7 +150,8 @@ block content %}
                 fault_mode = True %} {% set fault_device = row.no %} {% set
                 fault_title = (row.marka ~ ' ' ~ row.model)|trim %} {% set
                 fault_entity_key = row.no %} {% set fault_status = row.durum %}
-                {% include 'partials/_actions_menu.html' %}
+                {% set edit_modal_chrome = 'frameless' %} {% include
+                'partials/_actions_menu.html' %}
               </td>
             </tr>
             {% endfor %}

--- a/templates/partials/_actions_menu.html
+++ b/templates/partials/_actions_menu.html
@@ -10,10 +10,10 @@ fault_status_value == 'arızalı' or fault_status_value == 'arizali' %} {% set
 filtered_actions = namespace(values=[]) %} {% for value, label in actions %} {%
 if value not in ['assign', 'edit', 'stock', 'fault'] %} {% set
 filtered_actions.values = filtered_actions.values + [(value, label)] %} {% endif
-%} {% endfor %} {% set actions = filtered_actions.values %} {% endif %}
-{% set edit_modal_size = edit_modal_size|default('lg') %}
-{% set edit_modal_title = edit_modal_title|default('') %}
-{% set edit_modal_chrome = edit_modal_chrome|default('default') %}
+%} {% endfor %} {% set actions = filtered_actions.values %} {% endif %} {% set
+edit_modal_size = edit_modal_size|default('lg') %} {% set edit_modal_title =
+edit_modal_title|default('') %} {% set edit_modal_chrome =
+edit_modal_chrome|default('default') %}
 
 <div class="d-flex align-items-center">
   <button

--- a/templates/partials/_actions_menu.html
+++ b/templates/partials/_actions_menu.html
@@ -13,6 +13,7 @@ filtered_actions.values = filtered_actions.values + [(value, label)] %} {% endif
 %} {% endfor %} {% set actions = filtered_actions.values %} {% endif %}
 {% set edit_modal_size = edit_modal_size|default('lg') %}
 {% set edit_modal_title = edit_modal_title|default('') %}
+{% set edit_modal_chrome = edit_modal_chrome|default('default') %}
 
 <div class="d-flex align-items-center">
   <button
@@ -34,6 +35,7 @@ filtered_actions.values = filtered_actions.values + [(value, label)] %} {% endif
     data-entity-key="{{ fault_entity_key or '' }}"
     data-edit-modal-size="{{ edit_modal_size }}"
     data-edit-modal-title="{{ edit_modal_title }}"
+    data-edit-modal-chrome="{{ edit_modal_chrome }}"
   >
     <option value="">Seçiniz...</option>
     {% for value, label in actions %}


### PR DESCRIPTION
## Summary
- allow action menu and modal triggers to declare the desired iframe chrome
- toggle a frameless style on the shared iframe modal shell when requested
- mark inventory edit triggers as frameless so the outer header disappears

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9350289d0832ba96b8f020cf5a51f