### PR TITLE
Align frameless iframe modal styling

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -2140,6 +2140,19 @@ body.theme-dark .nav.nav-tabs {
   transform: rotate(90deg);
 }
 
+/* Frameless iframe modal */
+#iframeModal.iframe-modal--frameless .modal-content,
+#iframeModal.iframe-modal--frameless .modal-body {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+#iframeModal.iframe-modal--frameless .modal-header {
+  display: none !important;
+}
+
 /* Modal Body Padding */
 .modal-shell__body {
   padding: 2rem !important;

--- a/templates/base.html
+++ b/templates/base.html
@@ -272,18 +272,6 @@ window.addEventListener("message", (e) => {
     @media (hover:hover) {
       tr[data-href]:hover > td { transition: background-color .12s ease-in-out; }
     }
-    #iframeModal.iframe-modal--frameless .modal-content {
-      background: transparent;
-      border: 0;
-      box-shadow: none;
-    }
-    #iframeModal.iframe-modal--frameless .modal-body {
-      padding: 0;
-      background: transparent;
-    }
-    #iframeModal.iframe-modal--frameless .modal-header {
-      display: none;
-    }
     </style>
     {% endblock %}
 


### PR DESCRIPTION
## Summary
- move the frameless iframe modal overrides into the shared custom stylesheet
- ensure the frameless iframe modal content/body is transparent and hide its header

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d947f36bc0832bad654a97e780f3fc