### PR TITLE
Update modal close button styling

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -2132,11 +2132,13 @@ body.theme-dark .nav.nav-tabs {
   height: 32px;
   border-radius: 8px;
   transition: all 0.2s ease;
-  filter: brightness(0) invert(1);
+  color: var(--bs-danger);
+  --bs-btn-close-color: var(--bs-danger);
+  --bs-btn-close-opacity: 1;
 }
 
 .modal-shell__header-actions .btn-close:hover {
-  background: rgba(255, 255, 255, 0.2) !important;
+  background: rgba(220, 53, 69, 0.15) !important;
   transform: rotate(90deg);
 }
 


### PR DESCRIPTION
## Summary
- update the modal close button to use the Bootstrap danger color so the icon renders red by default
- adjust the hover state to use a light red overlay while retaining the rotation animation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9542d6ce8832ba600e8bf44099a78