### PR TITLE
Fix inventory edit modal close behavior

### DIFF
--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -7,7 +7,7 @@ block content %}
   role="dialog"
   aria-modal="true"
   aria-labelledby="inventory-edit-title"
-  style="display: block;"
+  style="display: block"
   data-bs-backdrop="static"
 >
   <div

--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -186,6 +186,7 @@ block content %}
   document.addEventListener("DOMContentLoaded", async () => {
     const applyModalOpen = () => document.body.classList.add("modal-open");
     const removeModalOpen = () => document.body.classList.remove("modal-open");
+    const isEmbedded = window.self !== window.top;
 
     applyModalOpen();
     window.addEventListener("beforeunload", removeModalOpen);
@@ -220,6 +221,13 @@ block content %}
       }
       closing = true;
       removeModalOpen();
+
+      if (isEmbedded) {
+        try {
+          window.parent.postMessage("modal-close", "*");
+        } catch (err) {}
+        return;
+      }
 
       if (window.history.length > 1 && hasUsableHistory()) {
         window.history.back();


### PR DESCRIPTION
## Summary
- ensure the inventory edit modal sends a close message to the parent window when embedded
- prevent the modal close button from redirecting users to the inventory list unnecessarily

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d97836a408832bacd5b83a92eb560f