### PR TITLE
Align add modals with inventory form styling

### DIFF
--- a/static/js/talep.js
+++ b/static/js/talep.js
@@ -237,8 +237,8 @@ window.talepIptal = async function (id, mevcut) {
   const selModel = document.getElementById("tkModel");
   const fldAcik = document.getElementById("tkAciklama");
   const selTur = document.getElementById("tkTur");
-  const markaWrap = selMarka?.closest(".mb-3");
-  const modelWrap = selModel?.closest(".mb-3");
+  const markaWrap = selMarka?.closest(".field, .mb-3");
+  const modelWrap = selModel?.closest(".field, .mb-3");
 
   let initialized = false;
   async function initSelects() {

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -193,31 +193,36 @@ content %}
         </div>
 
         <div class="modal-shell__body">
-          <div class="row g-3">
-            <div class="col-md-6">
-              <label for="selLisansAdi" class="form-label">Lisans Adı</label>
-              <select id="selLisansAdi" name="lisans_adi" class="form-select" required>
+          <div class="env-grid" id="lisans-ekle-grid">
+            <div class="field">
+              <label for="selLisansAdi">Lisans Adı</label>
+              <select
+                id="selLisansAdi"
+                name="lisans_adi"
+                class="ctrl"
+                required
+              >
                 <option value="">Seçiniz</option>
                 {% for ln in license_names %}
                 <option value="{{ ln.name }}">{{ ln.name }}</option>
                 {% endfor %}
               </select>
             </div>
-            <div class="col-md-6">
-              <label for="lisansAnahtari" class="form-label">Lisans Anahtarı</label>
+            <div class="field">
+              <label for="lisansAnahtari">Lisans Anahtarı</label>
               <input
                 id="lisansAnahtari"
                 name="lisans_anahtari"
                 type="text"
-                class="form-control"
+                class="ctrl"
                 required
                 placeholder="XXXX-XXXX-XXXX-XXXX"
               />
             </div>
 
-            <div class="col-md-6">
-              <label for="selPersonelAdd" class="form-label">Sorumlu Personel</label>
-              <select id="selPersonelAdd" name="sorumlu_personel" class="form-select">
+            <div class="field">
+              <label for="selPersonelAdd">Sorumlu Personel</label>
+              <select id="selPersonelAdd" name="sorumlu_personel" class="ctrl">
                 <option value="">Seçiniz</option>
                 {% for u in users %}
                 <option value="{{ u }}">{{ u }}</option>
@@ -225,12 +230,12 @@ content %}
               </select>
             </div>
 
-            <div class="col-md-6">
-              <label for="bagliEnvanter" class="form-label">Bağlı Olduğu Envanter No</label>
+            <div class="field">
+              <label for="bagliEnvanter">Bağlı Olduğu Envanter No</label>
               <select
                 id="bagliEnvanter"
                 name="bagli_envanter_no"
-                class="form-select"
+                class="ctrl"
                 required
               >
                 <option value="">Seçiniz...</option>
@@ -240,28 +245,28 @@ content %}
               </select>
             </div>
 
-            <div class="col-md-6">
-              <label for="ifsNo" class="form-label">
-                IFS No <span class="muted">(opsiyonel)</span>
-              </label>
+            <div class="field">
+              <label for="ifsNo"
+                >IFS No <span class="muted">(opsiyonel)</span></label
+              >
               <input
                 id="ifsNo"
                 name="ifs_no"
                 type="text"
-                class="form-control"
+                class="ctrl"
                 placeholder="IFS numarası"
               />
             </div>
 
-            <div class="col-md-6">
-              <label for="lisansEmail" class="form-label"
+            <div class="field">
+              <label for="lisansEmail"
                 >E-posta <span class="muted">(opsiyonel)</span></label
               >
               <input
                 id="lisansEmail"
                 name="mail_adresi"
                 type="email"
-                class="form-control"
+                class="ctrl"
                 placeholder="ornek@firma.com"
               />
             </div>

--- a/templates/printer_list.html
+++ b/templates/printer_list.html
@@ -94,50 +94,81 @@ content %}
           ></button>
         </div>
         <div class="modal-body">
-          <div class="row g-3">
-            <div class="col-md-6">
-              <label class="form-label">Marka</label>
+          <div class="env-grid" id="yazici-ekle-grid">
+            <div class="field">
+              <label for="selYaziciMarka">Marka</label>
               <select
                 id="selYaziciMarka"
                 name="marka_id"
-                class="form-select"
+                class="ctrl"
+                required
               ></select>
             </div>
-            <div class="col-md-6">
-              <label class="form-label">Model</label>
+            <div class="field">
+              <label for="selYaziciModel">Model</label>
               <select
                 id="selYaziciModel"
                 name="model_id"
-                class="form-select"
+                class="ctrl"
+                required
               ></select>
             </div>
-            <div class="col-md-6">
-              <label class="form-label">Kullanım Alanı</label>
+            <div class="field">
+              <label for="selYaziciKullanim">Kullanım Alanı</label>
               <select
                 id="selYaziciKullanim"
                 name="kullanim_alani_id"
-                class="form-select"
+                class="ctrl"
+                required
               ></select>
             </div>
-            <div class="col-md-6">
-              <label class="form-label">Envanter No</label>
-              <input name="envanter_no" class="form-control" required />
+            <div class="field">
+              <label for="printerEnvanterNo">Envanter No</label>
+              <input
+                id="printerEnvanterNo"
+                name="envanter_no"
+                class="ctrl"
+                required
+                placeholder="ENV-000123"
+              />
             </div>
-            <div class="col-md-4">
-              <label class="form-label">IP Adresi</label>
-              <input name="ip_adresi" class="form-control" />
+            <div class="field">
+              <label for="printerIp">IP Adresi</label>
+              <input
+                id="printerIp"
+                name="ip_adresi"
+                class="ctrl"
+                placeholder="10.0.0.10"
+              />
             </div>
-            <div class="col-md-4">
-              <label class="form-label">MAC</label>
-              <input name="mac" class="form-control" />
+            <div class="field">
+              <label for="printerMac">MAC</label>
+              <input
+                id="printerMac"
+                name="mac"
+                class="ctrl"
+                placeholder="AA:BB:CC:DD:EE:FF"
+              />
             </div>
-            <div class="col-md-4">
-              <label class="form-label">Hostname</label>
-              <input name="hostname" class="form-control" />
+            <div class="field">
+              <label for="printerHostname">Hostname</label>
+              <input
+                id="printerHostname"
+                name="hostname"
+                class="ctrl"
+                placeholder="PRN-OFIS-01"
+              />
             </div>
-            <div class="col-md-4">
-              <label class="form-label">IFS No</label>
-              <input name="ifs_no" class="form-control" />
+            <div class="field">
+              <label for="printerIfs"
+                >IFS No <span class="muted">(opsiyonel)</span></label
+              >
+              <input
+                id="printerIfs"
+                name="ifs_no"
+                class="ctrl"
+                placeholder="IFS-12345"
+              />
             </div>
           </div>
         </div>

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -207,9 +207,18 @@ block title %}Talep Takip{% endblock %} {% block content %}
 form_attrs={"id": "talepForm", "autocomplete": "off"},
 footer=talep_modal_footer, ) %}
 <!-- IFS -->
-<div class="mb-3">
-  <label class="form-label">IFS No</label>
-  <input id="ifs_no" name="ifs_no" class="form-control" placeholder="IFS No" />
+<div class="env-grid" id="talep-ekle-grid">
+  <div class="field span-2">
+    <label for="ifs_no"
+      >IFS No <span class="muted">(opsiyonel)</span></label
+    >
+    <input
+      id="ifs_no"
+      name="ifs_no"
+      class="ctrl"
+      placeholder="IFS-0001"
+    />
+  </div>
 </div>
 
 <!-- Kalemler tablosu -->
@@ -248,21 +257,45 @@ footer=talep_modal_footer, ) %}
 {% endset %} {% call modal( "talepKapatModal", "Stok Girişi", form_attrs={"id":
 "talepKapatForm"}, footer=talep_kapat_footer, ) %}
 <input type="hidden" id="tkTalepId" />
-<div class="mb-3">
-  <label class="form-label">Miktar</label>
-  <input type="number" id="tkAdet" class="form-control" min="1" value="1" />
-</div>
-<div class="mb-3">
-  <label class="form-label">Marka</label>
-  <select id="tkMarka" class="form-select"></select>
-</div>
-<div class="mb-3">
-  <label class="form-label">Model</label>
-  <select id="tkModel" class="form-select"></select>
-</div>
-<div class="mb-3">
-  <label class="form-label">Not (opsiyonel)</label>
-  <input type="text" id="tkAciklama" class="form-control" />
+<div class="env-grid" id="talep-kapat-grid">
+  <div class="field">
+    <label for="tkAdet">Miktar</label>
+    <input
+      type="number"
+      id="tkAdet"
+      class="ctrl"
+      min="1"
+      value="1"
+      required
+    />
+  </div>
+  <div class="field">
+    <label for="tkTur">Ürün Türü</label>
+    <select id="tkTur" class="ctrl">
+      <option value="envanter">Envanter</option>
+      <option value="yazici">Yazıcı</option>
+      <option value="lisans">Lisans</option>
+    </select>
+  </div>
+  <div class="field">
+    <label for="tkMarka">Marka</label>
+    <select id="tkMarka" class="ctrl"></select>
+  </div>
+  <div class="field">
+    <label for="tkModel">Model</label>
+    <select id="tkModel" class="ctrl"></select>
+  </div>
+  <div class="field span-2">
+    <label for="tkAciklama"
+      >Not <span class="muted">(opsiyonel)</span></label
+    >
+    <input
+      type="text"
+      id="tkAciklama"
+      class="ctrl"
+      placeholder="Ek bilgi"
+    />
+  </div>
 </div>
 {% endcall %}
 

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -454,102 +454,99 @@ content %}
               </div>
 
               <div id="hardwareFields">
-                <div class="form-grid form-grid--compact stok-row">
-                  <div class="form-group">
-                    <label class="form-label" for="stok_donanim_tipi"
-                      >Donanım Tipi</label
-                    >
+                <div class="env-grid stok-row" id="stok-donanim-grid">
+                  <div class="field">
+                    <label for="stok_donanim_tipi">Donanım Tipi</label>
                     <select
                       name="donanim_tipi"
-                      class="form-select"
+                      class="ctrl"
                       data-lookup="donanim_tipi"
                       id="stok_donanim_tipi"
                       required
                     ></select>
                   </div>
-                  <div class="form-group">
-                    <label class="form-label" for="stok_marka"
-                      >Marka (ops.)</label
+                  <div class="field">
+                    <label for="stok_marka"
+                      >Marka <span class="muted">(ops.)</span></label
                     >
                     <select
                       name="marka"
-                      class="form-select"
+                      class="ctrl"
                       data-lookup="marka"
                       id="stok_marka"
                     ></select>
                   </div>
-                  <div class="form-group">
-                    <label class="form-label" for="stok_model"
-                      >Model (ops.)</label
+                  <div class="field">
+                    <label for="stok_model"
+                      >Model <span class="muted">(ops.)</span></label
                     >
                     <select
                       name="model"
-                      class="form-select"
+                      class="ctrl"
                       data-lookup="model"
                       data-depends="#stok_marka"
                       id="stok_model"
                     ></select>
                   </div>
-                  <div class="form-group" id="rowMiktar">
-                    <label class="form-label" for="miktar">Miktar</label>
+                  <div class="field" id="rowMiktar">
+                    <label for="miktar">Miktar</label>
                     <input
                       type="number"
                       min="1"
                       id="miktar"
                       name="miktar"
-                      class="form-control"
+                      class="ctrl"
                       required
                     />
                   </div>
-                  <div class="form-group">
-                    <label class="form-label" for="ifs_no"
-                      >IFS No (opsiyonel)</label
+                  <div class="field">
+                    <label for="ifs_no"
+                      >IFS No <span class="muted">(opsiyonel)</span></label
                     >
                     <input
                       type="text"
                       id="ifs_no"
                       name="ifs_no"
-                      class="form-control"
+                      class="ctrl"
+                      placeholder="IFS numarası"
                     />
                   </div>
                 </div>
               </div>
 
               <div id="licenseFields" class="d-none">
-                <div class="form-grid form-grid--compact">
-                  <div class="form-group">
-                    <label class="form-label" for="lisans_adi"
-                      >Lisans Adı</label
-                    >
+                <div class="env-grid" id="stok-lisans-grid">
+                  <div class="field">
+                    <label for="lisans_adi">Lisans Adı</label>
                     <select
                       id="lisans_adi"
                       name="lisans_adi"
-                      class="form-select"
+                      class="ctrl"
                       data-lookup="lisans_adi"
                       required
                     ></select>
                   </div>
-                  <div class="form-group">
-                    <label class="form-label" for="lisans_anahtari"
-                      >Lisans Anahtarı</label
-                    >
+                  <div class="field">
+                    <label for="lisans_anahtari">Lisans Anahtarı</label>
                     <input
                       type="text"
                       id="lisans_anahtari"
                       name="lisans_anahtari"
-                      class="form-control"
+                      class="ctrl"
                       required
+                      placeholder="XXXX-XXXX-XXXX-XXXX"
                     />
                   </div>
-                  <div class="form-group">
-                    <label class="form-label" for="mail_adresi"
-                      >E-posta (opsiyonel)</label
+                  <div class="field">
+                    <label for="mail_adresi"
+                      >E-posta <span class="muted">(opsiyonel)</span></label
                     >
                     <input
                       type="email"
                       id="mail_adresi"
                       name="mail_adresi"
-                      class="form-control"
+                      class="ctrl"
+                      placeholder="ornek@firma.com"
                     />
                   </div>
                 </div>

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -151,9 +151,18 @@ endblock %} {% block content %}
 form_attrs={"id": "talepForm", "autocomplete": "off"},
 footer=talep_modal_footer, ) %}
 <!-- IFS -->
-<div class="mb-3">
-  <label class="form-label">IFS No</label>
-  <input id="ifs_no" name="ifs_no" class="form-control" placeholder="IFS No" />
+<div class="env-grid" id="talep-ekle-grid">
+  <div class="field span-2">
+    <label for="ifs_no"
+      >IFS No <span class="muted">(opsiyonel)</span></label
+    >
+    <input
+      id="ifs_no"
+      name="ifs_no"
+      class="ctrl"
+      placeholder="IFS-0001"
+    />
+  </div>
 </div>
 
 <!-- Kalemler tablosu -->
@@ -192,29 +201,45 @@ footer=talep_modal_footer, ) %}
 {% endset %} {% call modal( "talepKapatModal", "Stok Girişi", form_attrs={"id":
 "talepKapatForm"}, footer=talep_kapat_footer, ) %}
 <input type="hidden" id="tkTalepId" />
-<div class="mb-3">
-  <label class="form-label">Miktar</label>
-  <input type="number" id="tkAdet" class="form-control" min="1" value="1" />
-</div>
-<div class="mb-3">
-  <label class="form-label">Ürün Türü</label>
-  <select id="tkTur" class="form-select">
-    <option value="envanter">Envanter</option>
-    <option value="yazici">Yazıcı</option>
-    <option value="lisans">Lisans</option>
-  </select>
-</div>
-<div class="mb-3">
-  <label class="form-label">Marka</label>
-  <select id="tkMarka" class="form-select"></select>
-</div>
-<div class="mb-3">
-  <label class="form-label">Model</label>
-  <select id="tkModel" class="form-select"></select>
-</div>
-<div class="mb-3">
-  <label class="form-label">Not (opsiyonel)</label>
-  <input type="text" id="tkAciklama" class="form-control" />
+<div class="env-grid" id="talep-kapat-grid">
+  <div class="field">
+    <label for="tkAdet">Miktar</label>
+    <input
+      type="number"
+      id="tkAdet"
+      class="ctrl"
+      min="1"
+      value="1"
+      required
+    />
+  </div>
+  <div class="field">
+    <label for="tkTur">Ürün Türü</label>
+    <select id="tkTur" class="ctrl">
+      <option value="envanter">Envanter</option>
+      <option value="yazici">Yazıcı</option>
+      <option value="lisans">Lisans</option>
+    </select>
+  </div>
+  <div class="field">
+    <label for="tkMarka">Marka</label>
+    <select id="tkMarka" class="ctrl"></select>
+  </div>
+  <div class="field">
+    <label for="tkModel">Model</label>
+    <select id="tkModel" class="ctrl"></select>
+  </div>
+  <div class="field span-2">
+    <label for="tkAciklama"
+      >Not <span class="muted">(opsiyonel)</span></label
+    >
+    <input
+      type="text"
+      id="tkAciklama"
+      class="ctrl"
+      placeholder="Ek bilgi"
+    />
+  </div>
 </div>
 {% endcall %} {% endblock %} {% block scripts %} {{ super() }}
 <script src="/static/js/talep.js"></script>


### PR DESCRIPTION
## Summary
- restyle the printer, license, stock and request creation modals to use the shared envanter grid form layout
- add helper text and placeholders to match the inventory add experience
- update talep modal scripting to handle the new field wrappers

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9795abb48832b8d314bbbb5252f33