### PR TITLE
Refine modal form spacing for Bootstrap 5

### DIFF
--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -206,7 +206,7 @@ content %}
 
         <div class="modal-shell__body">
           <div class="modal-form-grid">
-            <div class="form-group">
+            <div class="mb-3">
               <label class="form-label" for="printerEnvanter"
                 >Envanter No</label
               >
@@ -220,7 +220,7 @@ content %}
               />
             </div>
 
-            <div class="form-group">
+            <div class="mb-3">
               <label class="form-label" for="selYaziciMarka"
                 >Yazıcı Markası</label
               >
@@ -237,7 +237,7 @@ content %}
               </select>
             </div>
 
-            <div class="form-group">
+            <div class="mb-3">
               <label class="form-label" for="selYaziciModel"
                 >Yazıcı Modeli</label
               >
@@ -255,7 +255,7 @@ content %}
               >
             </div>
 
-            <div class="form-group">
+            <div class="mb-3">
               <label class="form-label" for="printerUsage"
                 >Kullanım Alanı</label
               >
@@ -272,7 +272,7 @@ content %}
               </select>
             </div>
 
-            <div class="form-group">
+            <div class="mb-3">
               <label class="form-label" for="printerIp">IP Adresi</label>
               <input
                 id="printerIp"
@@ -283,7 +283,7 @@ content %}
                 placeholder="10.0.0.10"
               />
             </div>
-            <div class="form-group">
+            <div class="mb-3">
               <label class="form-label" for="printerMac">MAC</label>
               <input
                 id="printerMac"
@@ -294,7 +294,7 @@ content %}
                 placeholder="AA:BB:CC:DD:EE:FF"
               />
             </div>
-            <div class="form-group">
+            <div class="mb-3">
               <label class="form-label" for="printerHostname">Hostname</label>
               <input
                 id="printerHostname"
@@ -306,7 +306,7 @@ content %}
               />
             </div>
 
-            <div class="form-group">
+            <div class="mb-3">
               <label class="form-label" for="printerIfs">
                 IFS No <small class="text-muted">(opsiyonel)</small>
               </label>
@@ -458,7 +458,7 @@ content %}
           <input type="hidden" id="scrapPrinterId" />
           <p class="mb-2">Bu envanter hurdaya ayrılacak. Onaylıyor musunuz?</p>
           <div class="modal-form-grid">
-            <div class="form-group modal-form-grid--full">
+            <div class="modal-form-grid--full mb-3">
               <label class="form-label" for="scrapReason"
                 >Açıklama (opsiyonel)</label
               >

--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -708,7 +708,7 @@ content %}
                       role="tabpanel"
                     >
                       <div class="form-grid form-grid--compact">
-                        <div class="form-group">
+                        <div class="mb-3">
                           <label class="form-label">Lisans Adı</label>
                           <select
                             class="form-select"
@@ -717,7 +717,7 @@ content %}
                             data-stock-assign="license"
                           ></select>
                         </div>
-                        <div class="form-group">
+                        <div class="mb-3">
                           <label class="form-label">Sorumlu</label>
                           <select
                             class="form-select"
@@ -725,7 +725,7 @@ content %}
                             name="sa_license_owner"
                           ></select>
                         </div>
-                        <div class="form-group form-grid__full">
+                        <div class="form-grid__full mb-3">
                           <label class="form-label">Açıklama</label>
                           <textarea
                             class="form-control"
@@ -744,7 +744,7 @@ content %}
                       role="tabpanel"
                     >
                       <div class="form-grid form-grid--compact">
-                        <div class="form-group">
+                        <div class="mb-3">
                           <label class="form-label">Envanter No</label>
                           <select
                             class="form-select"
@@ -753,7 +753,7 @@ content %}
                             data-stock-assign="inventory"
                           ></select>
                         </div>
-                        <div class="form-group">
+                        <div class="mb-3">
                           <label class="form-label">Sorumlu</label>
                           <select
                             class="form-select"
@@ -770,7 +770,7 @@ content %}
                       role="tabpanel"
                     >
                       <div class="form-grid form-grid--compact">
-                        <div class="form-group">
+                        <div class="mb-3">
                           <label class="form-label">Yazıcı</label>
                           <select
                             class="form-select"
@@ -779,7 +779,7 @@ content %}
                             data-stock-assign="printer"
                           ></select>
                         </div>
-                        <div class="form-group">
+                        <div class="mb-3">
                           <label class="form-label">Atama Notu</label>
                           <input
                             type="text"


### PR DESCRIPTION
## Summary
- replace legacy `form-group` wrappers in the stock assignment modal with Bootstrap 5 spacing utilities while retaining the custom grid helpers
- do the same conversion for the printer add and scrap modals so fields align with the rest of the Bootstrap 5 layout
- remove the remaining `.form-group` usages from the templates to avoid regressions with future Bootstrap updates

## Testing
- playwright script to capture stock and printer modal screenshots after manual verification 【qsibcydm†L1-L1】

------
https://chatgpt.com/codex/tasks/task_e_68d9810a8810832b8d7a5586941de74e