### PR TITLE
Remove dropdown arrow icon from actions select

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1260,11 +1260,8 @@ body .container-fluid {
   cursor: pointer;
   min-width: 140px;
   appearance: none;
-  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%231f2937' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e") !important;
-  background-repeat: no-repeat;
-  background-position: right 0.5rem center;
-  background-size: 1rem;
-  padding-right: 2rem !important;
+  background-image: none !important;
+  padding-right: 1rem !important;
 }
 
 .action-select.js-actions:hover {


### PR DESCRIPTION
## Summary
- remove the custom background arrow from the actions select dropdown to eliminate the duplicate down-arrow icon
- adjust padding to keep spacing consistent after removing the arrow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d983d66d1c832b9917b93b73e1ea6e