### PR TITLE
Handle license stock state display and filtering

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -73,7 +73,8 @@ def printer_models(
 @router.get("/licenses/list")
 def licenses_list(db: Session = Depends(get_db)):
     active_licenses = or_(
-        models.License.durum.is_(None), models.License.durum != "hurda"
+        models.License.durum.is_(None),
+        ~models.License.durum.in_(["hurda", "stok"]),
     )
     rows = (
         db.query(models.License)

--- a/routers/home.py
+++ b/routers/home.py
@@ -28,7 +28,9 @@ def dashboard(request: Request, db: Session = Depends(get_db)):
 
     active_inventory = or_(Inventory.durum.is_(None), Inventory.durum != "hurda")
     active_printers = or_(Printer.durum.is_(None), Printer.durum != "hurda")
-    active_licenses = or_(License.durum.is_(None), License.durum != "hurda")
+    active_licenses = or_(
+        License.durum.is_(None), ~License.durum.in_(["hurda", "stok"])
+    )
 
     total_inventory = (
         db.query(func.count(Inventory.id)).filter(active_inventory).scalar()

--- a/routers/license.py
+++ b/routers/license.py
@@ -318,6 +318,7 @@ def stock_license(
     lic.sorumlu_personel = None
     lic.bagli_envanter_no = None
     lic.inventory_id = None
+    lic.durum = "stok"
 
     create_stock_log(
         db,
@@ -420,7 +421,9 @@ def edit_quick_license(
 def license_list(
     request: Request, db: Session = Depends(get_db), current_user=Depends(current_user)
 ):
-    active_licenses = or_(License.durum.is_(None), License.durum != "hurda")
+    active_licenses = or_(
+        License.durum.is_(None), ~License.durum.in_(["hurda", "stok"])
+    )
     items = db.query(License).filter(active_licenses).all()
     users = [
         r[0]

--- a/templates/license_detail.html
+++ b/templates/license_detail.html
@@ -46,7 +46,17 @@ content %}
         </tr>
         <tr>
           <th>Durum</th>
-          <td>{{ item.durum }}</td>
+          <td>
+            {% if item.durum == 'hurda' %}
+            <span class="badge bg-secondary">Hurda</span>
+            {% elif item.durum == 'stok' %}
+            <span class="badge text-bg-info text-dark">Stokta</span>
+            {% elif item.durum == 'arızalı' %}
+            <span class="badge text-bg-warning text-dark">Arızalı</span>
+            {% else %}
+            <span class="badge bg-success">Aktif</span>
+            {% endif %}
+          </td>
         </tr>
       </tbody>
     </table>

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -198,12 +198,7 @@ content %}
           <div class="env-grid" id="lisans-ekle-grid">
             <div class="field">
               <label for="selLisansAdi">Lisans Adı</label>
-              <select
-                id="selLisansAdi"
-                name="lisans_adi"
-                class="ctrl"
-                required
-              >
+              <select id="selLisansAdi" name="lisans_adi" class="ctrl" required>
                 <option value="">Seçiniz</option>
                 {% for ln in license_names %}
                 <option value="{{ ln.name }}">{{ ln.name }}</option>
@@ -326,8 +321,14 @@ content %}
           />
           <div class="row g-3">
             <div class="col-md-6">
-              <label for="selPersonel" class="form-label">Sorumlu Personel</label>
-              <select name="sorumlu_personel" class="form-select" id="selPersonel">
+              <label for="selPersonel" class="form-label"
+                >Sorumlu Personel</label
+              >
+              <select
+                name="sorumlu_personel"
+                class="form-select"
+                id="selPersonel"
+              >
                 <option value="">Seçiniz</option>
                 {% for u in users %}
                 <option value="{{ u }}">{{ u }}</option>
@@ -335,8 +336,14 @@ content %}
               </select>
             </div>
             <div class="col-md-6">
-              <label for="selBagli" class="form-label">Bağlı Olduğu Envanter No</label>
-              <select name="bagli_envanter_no" class="form-select" id="selBagli">
+              <label for="selBagli" class="form-label"
+                >Bağlı Olduğu Envanter No</label
+              >
+              <select
+                name="bagli_envanter_no"
+                class="form-select"
+                id="selBagli"
+              >
                 <option value="">Seçiniz</option>
                 {% for inv in envanterler %}
                 <option value="{{ inv.no }}">

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -139,6 +139,8 @@ content %}
               <td>
                 {% if row.durum == 'hurda' %}
                 <span class="badge bg-secondary">Hurda</span>
+                {% elif row.durum == 'stok' %}
+                <span class="badge text-bg-info text-dark">Stokta</span>
                 {% elif row.durum == 'arızalı' %}
                 <span class="badge text-bg-warning text-dark">Arızalı</span>
                 {% else %}


### PR DESCRIPTION
## Summary
- mark licenses as `stok` when they are sent back to stock while keeping existing stock logs intact
- exclude both `hurda` and `stok` entries from active license queries used in the web list, API list, and dashboard counters
- display a dedicated "Stokta" badge for stock licenses and note the model default that keeps new licenses active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d98e179d20832b985a18605fb40201