### PR TITLE
Update stock status license tab handling

### DIFF
--- a/templates/stock_list.html
+++ b/templates/stock_list.html
@@ -192,7 +192,7 @@ content %}
                     aria-controls="stock-status-license"
                     aria-selected="false"
                   >
-                    Yazılım
+                    Lisanslar
                   </button>
                 </li>
                 <li class="nav-item" role="presentation">


### PR DESCRIPTION
## Summary
- rename the stock status tab label from “Yazılım” to “Lisanslar”
- improve client-side stock categorisation so licence entries land in the licence tab
- allow the lisanslar module query param to focus the licence tab

## Testing
- pytest tests/test_stock_status_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d990eebce0832b9b2da711d0e285e0