### PR TITLE
Revamp license assignment layout

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1591,6 +1591,125 @@ body .container-fluid {
   border-radius: var(--radius-sm) !important;
 }
 
+/* ========== Lisans atama sayfası ========== */
+
+.assign-page {
+  max-width: 920px;
+  margin: 0 auto;
+}
+
+.assign-card {
+  background: var(--color-surface, #ffffff);
+  border-radius: 1.25rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.16);
+  overflow: hidden;
+}
+
+.assign-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.75rem 2rem;
+  background: var(--color-surface, #ffffff);
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+
+.assign-card__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-heading, #111827);
+  margin: 0;
+}
+
+.assign-card__subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+  color: var(--color-muted, #6b7280);
+}
+
+.assign-card__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  background: #ef4444;
+  color: #ffffff;
+  font-size: 1.5rem;
+  text-decoration: none;
+  box-shadow: 0 18px 30px rgba(239, 68, 68, 0.35);
+  transition: all var(--transition-fast, 0.2s ease);
+}
+
+.assign-card__close:hover {
+  background: #dc2626;
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.assign-card__close:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.35);
+}
+
+.assign-card__body {
+  padding: 2rem;
+  background: var(--color-surface, #ffffff);
+}
+
+.assign-form {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.assign-card__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+@media (max-width: 992px) {
+  .assign-page {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .assign-card {
+    border-radius: 1rem;
+  }
+
+  .assign-card__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .assign-card__close {
+    align-self: flex-end;
+  }
+}
+
+@media (max-width: 576px) {
+  .assign-card__body {
+    padding: 1.5rem;
+  }
+
+  .assign-card__close {
+    width: 38px;
+    height: 38px;
+    font-size: 1.35rem;
+  }
+
+  .assign-card__actions {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+}
+
 /* ========== 3. KULLANICI YÖNETİMİ TAB TASARIMI ========== */
 
 /* Tab container modern yapı */

--- a/templates/license_assign.html
+++ b/templates/license_assign.html
@@ -1,45 +1,72 @@
 {% extends "base.html" %} {% block title %}Lisans Atama{% endblock %} {% block
 content %}
-<div class="container-fluid p-3 content">
-  <div class="d-flex align-items-center justify-content-between mb-3">
-    <h4 class="mb-0">Lisans Atama</h4>
-    <a class="btn btn-light" href="{{ url_for('license_list') }}">← Listeye Dön</a>
-  </div>
-  <div class="card shadow-sm">
-    <div class="card-body">
-      <form method="post" action="/lisans/{{ license.id }}/assign" class="row g-3">
-        <input
-          type="hidden"
-          name="islem_yapan"
-          value="{{ current_user.full_name if current_user else 'system' }}"
-        />
-        <div class="col-md-6">
-          <label for="assignSorumlu" class="form-label">Sorumlu Personel</label>
-          <select id="assignSorumlu" name="sorumlu_personel" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for u in users %}
-            <option value="{{ u }}" {% if license and license.sorumlu_personel==u %}selected{% endif %}>
-              {{ u }}
-            </option>
-            {% endfor %}
-          </select>
+<div class="container-fluid content p-4">
+  <div class="assign-page">
+    <div class="assign-card">
+      <div class="assign-card__header">
+        <div>
+          <h4 class="assign-card__title">Lisans Atama</h4>
+          <p class="assign-card__subtitle">
+            Lisansı ilgili personel ve envanter kaydıyla eşleştirin.
+          </p>
         </div>
-        <div class="col-md-6">
-          <label for="assignInventory" class="form-label">Bağlı Olduğu Envanter No</label>
-          <select id="assignInventory" name="bagli_envanter_no" class="form-select">
-            <option value="">Seçiniz</option>
-            {% for inv in envanterler %}
-            <option value="{{ inv.no }}" {% if license and license.bagli_envanter_no==inv.no %}selected{% endif %}>
-              {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
-            </option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="col-12 d-flex gap-2 mt-3">
-          <button class="btn btn-primary" type="submit">Kaydet</button>
-          <a class="btn btn-secondary" href="{{ url_for('license_list') }}">İptal</a>
-        </div>
-      </form>
+        <a
+          href="{{ url_for('license_list') }}"
+          class="assign-card__close"
+          aria-label="Listeye dön"
+        >
+          <span aria-hidden="true">&times;</span>
+        </a>
+      </div>
+      <div class="assign-card__body">
+        <form
+          method="post"
+          action="/lisans/{{ license.id }}/assign"
+          class="assign-form"
+        >
+          <input
+            type="hidden"
+            name="islem_yapan"
+            value="{{ current_user.full_name if current_user else 'system' }}"
+          />
+          <div class="env-grid" id="license-assign-grid">
+            <div class="field">
+              <label for="assignSorumlu">Sorumlu Personel</label>
+              <select id="assignSorumlu" name="sorumlu_personel" class="ctrl">
+                <option value="">Seçiniz</option>
+                {% for u in users %}
+                <option
+                  value="{{ u }}"
+                  {% if license and license.sorumlu_personel==u %}selected{% endif %}
+                >
+                  {{ u }}
+                </option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="field">
+              <label for="assignInventory"
+                >Bağlı Olduğu Envanter <span class="muted">(Opsiyonel)</span></label
+              >
+              <select id="assignInventory" name="bagli_envanter_no" class="ctrl">
+                <option value="">Seçiniz</option>
+                {% for inv in envanterler %}
+                <option
+                  value="{{ inv.no }}"
+                  {% if license and license.bagli_envanter_no==inv.no %}selected{% endif %}
+                >
+                  {{ inv.no }} - {{ inv.bilgisayar_adi or inv.marka }}
+                </option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="assign-card__actions">
+            <a class="btn btn-secondary" href="{{ url_for('license_list') }}">İptal</a>
+            <button class="btn btn-primary" type="submit">Atamayı Kaydet</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- restyle the license assignment page with the modern assignment card layout and close action
- add dedicated styling for the standalone license assignment view, including responsive behavior

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68dbb7bac624832bbddcb8404f752250