### PR TITLE
Revamp license assign header gradient

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1601,7 +1601,7 @@ body .container-fluid {
 .assign-card {
   background: var(--color-surface, #ffffff);
   border-radius: 1.25rem;
-  border: 1px solid var(--color-border, #e5e7eb);
+  border: none;
   box-shadow: 0 24px 60px rgba(15, 23, 42, 0.16);
   overflow: hidden;
 }
@@ -1611,8 +1611,8 @@ body .container-fluid {
   align-items: flex-start;
   justify-content: space-between;
   gap: 1.5rem;
-  padding: 1.75rem 2rem;
-  background: linear-gradient(135deg, #7c3aed 0%, #4c1d95 100%);
+  padding: 1.85rem 2.25rem;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 45%, #312e81 100%);
   color: #ffffff;
 }
 
@@ -1626,7 +1626,7 @@ body .container-fluid {
 .assign-card__subtitle {
   margin: 0.35rem 0 0;
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.85);
+  color: #ffffff;
 }
 
 .assign-card__close {
@@ -1686,6 +1686,7 @@ body .container-fluid {
   .assign-card__header {
     flex-direction: column;
     align-items: stretch;
+    padding: 1.75rem 1.85rem;
   }
 
   .assign-card__close {


### PR DESCRIPTION
## Summary
- restyle the license assignment card header with a blue gradient and white typography for better contrast
- remove the card border and tweak padding so the gradient header blends smoothly into the neutral body
- adjust responsive padding so the header spacing remains balanced on smaller screens

## Testing
- Manual verification: viewed `/lisans/2/assign`


------
https://chatgpt.com/codex/tasks/task_e_68dbc67f0a1c832b96d80e100e174c4c