### PR TITLE
Fix license form template equality checks

### DIFF
--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -50,13 +50,7 @@
               {% for ln in license_names %}
               <option
                 value="{{ ln.name }}"
-                {%
-                if
-                license.lisans_adi=""
-                ="ln.name"
-                %}selected{%
-                endif
-                %}
+                {% if license.lisans_adi == ln.name %}selected{% endif %}
               >
                 {{ ln.name }}
               </option>
@@ -82,13 +76,7 @@
               {% for u in users %}
               <option
                 value="{{ u }}"
-                {%
-                if
-                license.sorumlu_personel=""
-                ="u"
-                %}selected{%
-                endif
-                %}
+                {% if license.sorumlu_personel == u %}selected{% endif %}
               >
                 {{ u }}
               </option>
@@ -103,13 +91,7 @@
               {% for inv in envanterler %}
               <option
                 value="{{ inv.id }}"
-                {%
-                if
-                license.inventory_id=""
-                ="inv.id"
-                %}selected{%
-                endif
-                %}
+                {% if license.inventory_id|string == inv.id|string %}selected{% endif %}
               >
                 {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
               </option>
@@ -197,15 +179,7 @@
           {% for ln in license_names %}
           <option
             value="{{ ln.name }}"
-            {%
-            if
-            license
-            and
-            license.lisans_adi=""
-            ="ln.name"
-            %}selected{%
-            endif
-            %}
+            {% if license and license.lisans_adi == ln.name %}selected{% endif %}
           >
             {{ ln.name }}
           </option>
@@ -231,15 +205,7 @@
           {% for u in users %}
           <option
             value="{{ u }}"
-            {%
-            if
-            license
-            and
-            license.sorumlu_personel=""
-            ="u"
-            %}selected{%
-            endif
-            %}
+            {% if license and license.sorumlu_personel == u %}selected{% endif %}
           >
             {{ u }}
           </option>
@@ -256,15 +222,7 @@
           {% for inv in envanterler %}
           <option
             value="{{ inv.id }}"
-            {%
-            if
-            license
-            and
-            license.inventory_id=""
-            ="inv.id"
-            %}selected{%
-            endif
-            %}
+            {% if license and license.inventory_id|string == inv.id|string %}selected{% endif %}
           >
             {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
           </option>


### PR DESCRIPTION
## Summary
- replace malformed assignment expressions in the license form template with valid equality comparisons so options render correctly
- ensure inventory comparison coerces identifiers to strings when checking selected values

## Testing
- not run (template change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbdf9f78e0832ba261e173ccd7e2d2