### PR TITLE
Fix inventory picker options and engine pool configuration

### DIFF
--- a/templates/inventory_add.html
+++ b/templates/inventory_add.html
@@ -134,17 +134,62 @@
 
 <script>
   (async function () {
-    async function loadOptions(sel, url) {
-      const res = await fetch(url);
-      const data = await res.json();
+    function normalisePickerItems(data) {
+      if (!Array.isArray(data)) return [];
+      return data
+        .map((item) => {
+          if (typeof item === "string") {
+            const value = item.trim();
+            if (!value) return null;
+            return { id: value, text: value };
+          }
+          if (!item || typeof item !== "object") return null;
+          const text =
+            item.text ||
+            item.name ||
+            item.label ||
+            item.value ||
+            item.ad ||
+            item.adi ||
+            "";
+          const id = item.id ?? text;
+          if (!text) return null;
+          return { id, text };
+        })
+        .filter(Boolean);
+    }
+
+    async function fetchPickerItems(url) {
+      try {
+        const res = await fetch(url, { headers: { Accept: "application/json" } });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const payload = await res.json();
+        return normalisePickerItems(payload);
+      } catch (error) {
+        console.warn("fetchPickerItems failed", { url, error });
+        return [];
+      }
+    }
+
+    async function loadOptions(sel, url, options = {}) {
+      if (!sel) return [];
+      const { placeholder = "Seçiniz...", fallbackUrl } = options;
+      let items = await fetchPickerItems(url);
+      if (!items.length && fallbackUrl) {
+        items = await fetchPickerItems(fallbackUrl);
+      }
       sel.innerHTML =
-        '<option value="">Seçiniz...</option>' +
-        data
-          .map(
-            (o) =>
-              `<option value="${o.text}" data-id="${o.id}">${o.text}</option>`,
-          )
+        `<option value="">${placeholder}</option>` +
+        items
+          .map((o) => {
+            const dataId =
+              o.id !== undefined && o.id !== null ? ` data-id="${o.id}"` : "";
+            return `<option value="${o.text}"${dataId}>${o.text}</option>`;
+          })
           .join("");
+      return items;
     }
 
     const fabrikaSel = document.getElementById("fabrika");
@@ -155,7 +200,9 @@
     const modelSel = document.getElementById("model");
 
     await loadOptions(fabrikaSel, "/api/picker/fabrika");
-    await loadOptions(departmanSel, "/api/picker/kullanim_alani");
+    await loadOptions(departmanSel, "/api/picker/kullanim_alani", {
+      fallbackUrl: "/inventory/assign/sources?type=departman",
+    });
     await loadOptions(donanimSel, "/api/picker/donanim_tipi");
     if (window._selects) {
       await _selects.fillChoices({
@@ -173,15 +220,15 @@
       await loadOptions(personelSel, "/api/picker/kullanici");
     }
 
-    const brandRes = await fetch("/api/picker/marka");
-    const brands = await brandRes.json();
+    const brands = await fetchPickerItems("/api/picker/marka");
     markaSel.innerHTML =
       '<option value="">Seçiniz...</option>' +
       brands
-        .map(
-          (b) =>
-            `<option value="${b.text}" data-id="${b.id}">${b.text}</option>`,
-        )
+        .map((b) => {
+          const dataId =
+            b.id !== undefined && b.id !== null ? ` data-id="${b.id}"` : "";
+          return `<option value="${b.text}"${dataId}>${b.text}</option>`;
+        })
         .join("");
 
     markaSel.addEventListener("change", async () => {

--- a/templates/inventory_list.html
+++ b/templates/inventory_list.html
@@ -643,19 +643,65 @@ block content %}
       });
     }
 
+    function normalisePickerItems(data) {
+      if (!Array.isArray(data)) return [];
+      return data
+        .map((item) => {
+          if (typeof item === "string") {
+            const value = item.trim();
+            if (!value) return null;
+            return { id: value, text: value };
+          }
+          if (!item || typeof item !== "object") return null;
+          const text =
+            item.text ||
+            item.name ||
+            item.label ||
+            item.value ||
+            item.ad ||
+            item.adi ||
+            "";
+          const id = item.id ?? text;
+          if (!text) return null;
+          return { id, text };
+        })
+        .filter(Boolean);
+    }
+
+    async function fetchPickerItems(url) {
+      try {
+        const response = await fetch(url, {
+          headers: { Accept: "application/json" },
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = await response.json();
+        return normalisePickerItems(payload);
+      } catch (error) {
+        console.warn("fetchPickerItems failed", { url, error });
+        return [];
+      }
+    }
+
     async function loadInventoryFormOptions() {
-      async function loadOptions(selectEl, url) {
-        if (!selectEl) return;
-        const response = await fetch(url);
-        const data = await response.json();
+      async function loadOptions(selectEl, url, options = {}) {
+        if (!selectEl) return [];
+        const { placeholder = "Seçiniz...", fallbackUrl } = options;
+        let items = await fetchPickerItems(url);
+        if (!items.length && fallbackUrl) {
+          items = await fetchPickerItems(fallbackUrl);
+        }
         selectEl.innerHTML =
-          '<option value="">Seçiniz...</option>' +
-          data
-            .map(
-              (item) =>
-                `<option value="${item.text}" data-id="${item.id}">${item.text}</option>`,
-            )
+          `<option value="">${placeholder}</option>` +
+          items
+            .map((item) => {
+              const dataId =
+                item.id !== undefined && item.id !== null ? ` data-id="${item.id}"` : "";
+              return `<option value="${item.text}"${dataId}>${item.text}</option>`;
+            })
             .join("");
+        return items;
       }
 
       const fabrikaSel = document.getElementById("fabrika");
@@ -666,7 +712,9 @@ block content %}
       const modelSel = document.getElementById("model");
 
       await loadOptions(fabrikaSel, "/api/picker/fabrika");
-      await loadOptions(departmanSel, "/api/picker/kullanim_alani");
+      await loadOptions(departmanSel, "/api/picker/kullanim_alani", {
+        fallbackUrl: "/inventory/assign/sources?type=departman",
+      });
       await loadOptions(donanimSel, "/api/picker/donanim_tipi");
 
       if (personelSel && window._selects) {
@@ -684,15 +732,17 @@ block content %}
       }
 
       if (markaSel) {
-        const response = await fetch("/api/picker/marka");
-        const brands = await response.json();
+        const brands = await fetchPickerItems("/api/picker/marka");
         markaSel.innerHTML =
           '<option value="">Seçiniz...</option>' +
           brands
-            .map(
-              (brand) =>
-                `<option value="${brand.text}" data-id="${brand.id}">${brand.text}</option>`,
-            )
+            .map((brand) => {
+              const dataId =
+                brand.id !== undefined && brand.id !== null
+                  ? ` data-id="${brand.id}"`
+                  : "";
+              return `<option value="${brand.text}"${dataId}>${brand.text}</option>`;
+            })
             .join("");
         markaSel.addEventListener("change", async () => {
           const option = markaSel.options[markaSel.selectedIndex];
@@ -715,11 +765,16 @@ block content %}
     }
 
     async function preloadAssignDropdowns(itemId) {
-      const [factories, departments, users] = await Promise.all([
-        fetch("/api/picker/fabrika").then((r) => r.json()),
-        fetch("/api/picker/kullanim_alani").then((r) => r.json()),
-        fetch("/api/picker/kullanici").then((r) => r.json()),
+      const [factories, departmentsPrimary, departmentsFallback, users] = await Promise.all([
+        fetchPickerItems("/api/picker/fabrika"),
+        fetchPickerItems("/api/picker/kullanim_alani"),
+        fetchPickerItems("/inventory/assign/sources?type=departman"),
+        fetchPickerItems("/api/picker/kullanici"),
       ]);
+
+      const departments = departmentsPrimary.length
+        ? departmentsPrimary
+        : departmentsFallback;
 
       fillSelect("selFabrika", factories);
       fillSelect("selDepartman", departments);


### PR DESCRIPTION
## Summary
- normalise picker API responses in the inventory add/list modals and add a fallback data source so dropdowns populate even when primary endpoints return no rows
- split SQLite engine pool configuration into a separate helper so tests and callers can override the pool class without conflicts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbe044b358832ba88996d8090bcc80