### PR TITLE
Align inventory history collapse with list styling

### DIFF
--- a/templates/inventory_detail.html
+++ b/templates/inventory_detail.html
@@ -87,8 +87,8 @@ endblock %} {% block content %}
       </div>
       <div class="collapse w-100 mt-2 pt-3" id="inventoryChangeHistory">
         <div class="table-responsive">
-          {% set islem_map = { "assign": "Atama", "edit": "Düzenleme",
-          "scrap": "Hurdaya Ayır" } %}
+          {% set islem_map = { "assign": "Atama", "edit": "Düzenleme", "scrap":
+          "Hurdaya Ayır" } %}
           <table class="table table-sm table-striped mb-0 table-rounded">
             <thead>
               <tr>
@@ -108,18 +108,22 @@ endblock %} {% block content %}
 
                 <!-- Önce -->
                 <td>
-                  {% if log.before_json %} {% for k, v in log.before_json.items() %}
+                  {% if log.before_json %} {% for k, v in
+                  log.before_json.items() %}
                   <div>
-                    <strong>{{ k|replace("_"," ")|capitalize }}:</strong> {{ v }}
+                    <strong>{{ k|replace("_"," ")|capitalize }}:</strong> {{ v
+                    }}
                   </div>
                   {% endfor %} {% else %} Yok {% endif %}
                 </td>
 
                 <!-- Sonra -->
                 <td>
-                  {% if log.after_json %} {% for k, v in log.after_json.items() %}
+                  {% if log.after_json %} {% for k, v in log.after_json.items()
+                  %}
                   <div>
-                    <strong>{{ k|replace("_"," ")|capitalize }}:</strong> {{ v }}
+                    <strong>{{ k|replace("_"," ")|capitalize }}:</strong> {{ v
+                    }}
                   </div>
                   {% endfor %} {% else %} Yok {% endif %}
                 </td>

--- a/templates/inventory_detail.html
+++ b/templates/inventory_detail.html
@@ -70,26 +70,22 @@ endblock %} {% block content %}
     {% endfor %} {% else %}
     <li class="list-group-item text-muted">Kayıtlı lisans yok.</li>
     {% endif %}
-    <li class="list-group-item d-flex justify-content-between align-items-center">
-      <span>Değişiklik Geçmişi</span>
-      <button
-        class="btn btn-sm btn-outline-secondary d-flex align-items-center gap-1"
-        type="button"
-        data-bs-toggle="collapse"
-        data-bs-target="#inventoryChangeHistory"
-        aria-expanded="false"
-        aria-controls="inventoryChangeHistory"
-      >
-        <span>Göster</span>
-        <i class="bi bi-chevron-down collapse-chevron"></i>
-      </button>
-    </li>
-  </ul>
-
-  <div class="collapse mt-3" id="inventoryChangeHistory">
-    <div class="card">
-      <div class="card-header">Değişiklik Geçmişi</div>
-      <div class="card-body p-0">
+    <li class="list-group-item">
+      <div class="d-flex justify-content-between align-items-center">
+        <span>Değişiklik Geçmişi</span>
+        <button
+          class="btn btn-sm btn-outline-secondary d-flex align-items-center gap-1"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#inventoryChangeHistory"
+          aria-expanded="false"
+          aria-controls="inventoryChangeHistory"
+        >
+          <span>Göster</span>
+          <i class="bi bi-chevron-down collapse-chevron"></i>
+        </button>
+      </div>
+      <div class="collapse w-100 mt-2 pt-3" id="inventoryChangeHistory">
         <div class="table-responsive">
           {% set islem_map = { "assign": "Atama", "edit": "Düzenleme",
           "scrap": "Hurdaya Ayır" } %}
@@ -144,8 +140,8 @@ endblock %} {% block content %}
           </table>
         </div>
       </div>
-    </div>
-  </div>
+    </li>
+  </ul>
 
   <div class="modal fade" id="licenseDetailModal" tabindex="-1">
     <div class="modal-dialog">


### PR DESCRIPTION
## Summary
- embed the change history collapse within the list-group item to align with the toggle row
- simplify the collapse markup to remove the extra card wrapper and rely on list spacing utilities

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe2772248832b97d878b304b3c66f