### PR TITLE
Tighten admin table actions column spacing

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -755,6 +755,12 @@ small,
   color: var(--color-muted);
 }
 
+.table td.text-break {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .table-striped tbody tr:nth-of-type(odd) {
   background-color: rgba(15, 23, 42, 0.03);
 }
@@ -1293,8 +1299,16 @@ body .container-fluid {
 /* İşlemler kolonu genişliği */
 .table td:last-child,
 .table th:last-child {
-  width: 220px;
-  min-width: 220px;
+  width: 150px;
+  min-width: 150px;
+}
+
+.table td:last-child form {
+  margin: 0;
+}
+
+.table td:last-child .btn {
+  padding-inline: 0.5rem;
 }
 
 /* ========== 5. RESPONSIVE AYARLAR ========== */

--- a/templates/admin/_kullanici.html
+++ b/templates/admin/_kullanici.html
@@ -20,7 +20,7 @@
         <td>{{ u.username }}</td>
         <td>{{ u.first_name or '' }}</td>
         <td>{{ u.last_name or '' }}</td>
-        <td>{{ u.email or '' }}</td>
+        <td class="text-break">{{ u.email or '' }}</td>
         <td>{{ u.role }}</td>
       </tr>
       {% else %}

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -102,7 +102,7 @@ content %}
                 <td>{{ u.username }}</td>
                 <td>{{ u.first_name or '' }}</td>
                 <td>{{ u.last_name or '' }}</td>
-                <td>{{ u.email or '' }}</td>
+                <td class="text-break">{{ u.email or '' }}</td>
                 <td>
                   <span
                     class="badge bg-{{ 'primary' if u.role=='admin' else 'secondary' }}"

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -204,7 +204,7 @@ block content %}
               <td>{{ u.username }}</td>
               <td>{{ u.first_name or '' }}</td>
               <td>{{ u.last_name or '' }}</td>
-              <td>{{ u.email or '' }}</td>
+              <td class="text-break">{{ u.email or '' }}</td>
             </tr>
             {% else %}
             <tr>

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -467,7 +467,7 @@ content %}
                       <td>{{ u.username }}</td>
                       <td>{{ u.first_name or '' }}</td>
                       <td>{{ u.last_name or '' }}</td>
-                      <td>{{ u.email or '' }}</td>
+                      <td class="text-break">{{ u.email or '' }}</td>
                     </tr>
                     {% else %}
                     <tr>


### PR DESCRIPTION
## Summary
- shrink the default actions column width across tables to 150px so buttons sit closer to the content
- remove extra spacing around inline action buttons to keep the controls compact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbe32985ec832ba69b3d37c72b73d1