### PR TITLE
Align inventory edit pickers with add page data source

### DIFF
--- a/templates/inventory/edit.html
+++ b/templates/inventory/edit.html
@@ -676,7 +676,7 @@ block content %}
       );
     }
 
-    async function resolveOption(endpoint, text, params = {}) {
+    async function resolveOption(endpoint, text, params = {}, fallback) {
       if (!text) return null;
       const base = await fetchOptions(endpoint, params);
       let match = findExactMatch(base, text);
@@ -687,6 +687,13 @@ block content %}
           q: text,
         });
         match = findExactMatch(withQuery, text);
+      }
+      if (!match && fallback && fallback.endpoint) {
+        const fallbackOptions = await fetchOptions(
+          fallback.endpoint,
+          fallback.params || {},
+        );
+        match = findExactMatch(fallbackOptions, text);
       }
       return match || null;
     }
@@ -705,6 +712,7 @@ block content %}
         displayId: "edit_departman_display",
         currentKey: "departman",
         endpoint: "/api/picker/kullanim_alani",
+        fallbackEndpoint: "/inventory/assign/sources?type=departman",
       },
       {
         entity: "donanim_tipi",
@@ -743,7 +751,14 @@ block content %}
       if (!textValue) {
         return null;
       }
-      const match = await resolveOption(field.endpoint, textValue, field.params);
+      const match = await resolveOption(
+        field.endpoint,
+        textValue,
+        field.params,
+        field.fallbackEndpoint
+          ? { endpoint: field.fallbackEndpoint, params: field.fallbackParams }
+          : null,
+      );
       if (match) {
         hidden.value = match.id;
         hidden.dataset.id = match.id;


### PR DESCRIPTION
## Summary
- add fallback inventory department source so the picker loads values even when the primary endpoint is empty
- update the inventory edit form prefill logic to reuse the fallback data source, matching the behaviour of the add screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc6ddc964832b8ecddeb76ca77946