### PR TITLE
Update talep modal actions and close button styling

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -2282,7 +2282,7 @@ body.theme-dark .nav.nav-tabs {
 /* ========== 4. TÜM MODALLER İÇİN ORTAK İYİLEŞTİRMELER ========== */
 
 /* Close Button - Tüm Modallerde */
-.modal-shell__header-actions .btn-close {
+.modal-shell__header-actions .btn-close.btn-close-danger {
   background: transparent !important;
   opacity: 1 !important;
   width: 32px;
@@ -2292,11 +2292,18 @@ body.theme-dark .nav.nav-tabs {
   color: var(--bs-danger);
   --bs-btn-close-color: var(--bs-danger);
   --bs-btn-close-opacity: 1;
+  --bs-btn-close-hover-opacity: 1;
+  --bs-btn-close-focus-shadow: 0 0 0 0.25rem rgba(220, 53, 69, 0.25);
+  --bs-btn-close-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23dc3545'%3e%3cpath d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414z'/%3e%3c/svg%3e");
 }
 
-.modal-shell__header-actions .btn-close:hover {
+.modal-shell__header-actions .btn-close.btn-close-danger:hover {
   background: rgba(220, 53, 69, 0.15) !important;
   transform: rotate(90deg);
+}
+
+.modal-shell__header-actions .btn-close.btn-close-danger:focus-visible {
+  box-shadow: var(--bs-btn-close-focus-shadow) !important;
 }
 
 /* Frameless iframe modal */

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -15,7 +15,12 @@
             {%- endif %}
           </div>
           <div class="modal-shell__header-actions">
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+            <button
+              type="button"
+              class="btn-close btn-close-danger"
+              data-bs-dismiss="modal"
+              aria-label="Kapat"
+            ></button>
           </div>
         </div>
         <div class="modal-shell__body{% if content_class %} {{ content_class }}{% endif %}">

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -143,9 +143,6 @@ endblock %} {% block content %}
 
 <!-- Talep Aç Modal -->
 {% set talep_modal_footer %}
-<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-  Kapat
-</button>
 <button type="submit" class="btn btn-primary">Gönder</button>
 {% endset %} {% call modal( "talepModal", "Talep Aç", dialog_class="modal-xl",
 form_attrs={"id": "talepForm", "autocomplete": "off"},


### PR DESCRIPTION
## Summary
- remove the dismiss button from the Talep modal footer so only the submit action remains
- add a dedicated danger close-button class to the reusable modal component
- style the new close button class for a red icon and hover feedback in custom CSS

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcce8b3ed8832b943d61f421fc4e08