### PR TITLE
Hide talep row remove button when only one row remains

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -210,6 +210,18 @@ small,
   }
 }
 
+/* Talep modal action column */
+th.talep-action-col,
+td.talep-action-col {
+  width: 8%;
+}
+
+th.talep-action-col.talep-action-col--compact,
+td.talep-action-col.talep-action-col--compact {
+  width: 0;
+  white-space: nowrap;
+}
+
 .page-actions {
   display: flex;
   flex-wrap: wrap;

--- a/static/js/talep.js
+++ b/static/js/talep.js
@@ -10,6 +10,10 @@
     return;
   }
 
+  const actionHeader = document.querySelector(
+    "#rowsTable thead th.talep-action-col",
+  );
+
   // Basit cache
   const cache = {};
 
@@ -32,6 +36,27 @@
     const data = await r.json(); // [{id, name}]
     cache[key] = data;
     return data;
+  }
+
+  function updateRemoveButtons() {
+    if (!tableBody) return;
+    const rows = Array.from(tableBody.querySelectorAll("tr"));
+    const shouldHide = rows.length <= 1;
+
+    rows.forEach((tr) => {
+      const removeBtn = tr.querySelector(".btn-remove");
+      const actionCell = tr.querySelector(".talep-action-col");
+      if (removeBtn) {
+        removeBtn.classList.toggle("d-none", shouldHide);
+      }
+      if (actionCell) {
+        actionCell.classList.toggle("talep-action-col--compact", shouldHide);
+      }
+    });
+
+    if (actionHeader) {
+      actionHeader.classList.toggle("talep-action-col--compact", shouldHide);
+    }
   }
 
   function optionHtml(arr, placeholder = "Seçiniz…") {
@@ -84,7 +109,7 @@
       <td>
         <input type="text" class="form-control inp-aciklama" placeholder="Açıklama">
       </td>
-      <td class="text-end">
+      <td class="text-end talep-action-col">
         <button type="button" class="btn btn-outline-danger btn-sm btn-remove">Sil</button>
       </td>
     `;
@@ -135,7 +160,10 @@
     });
     removeButton?.addEventListener("click", () => {
       tr.remove();
+      updateRemoveButtons();
     });
+
+    updateRemoveButtons();
   }
 
   // Modal açıldığında ilk satırı garanti ekle
@@ -193,6 +221,8 @@
       alert("Talep kaydedilemedi.");
     }
   });
+
+  updateRemoveButtons();
 })();
 
 // Talep iptal

--- a/templates/talepler.html
+++ b/templates/talepler.html
@@ -179,7 +179,7 @@ footer=talep_modal_footer, ) %}
         <th style="width: 18%">Marka</th>
         <th style="width: 18%">Model</th>
         <th style="width: 28%">Açıklama</th>
-        <th style="width: 8%"></th>
+        <th class="text-end talep-action-col"></th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Summary
- add a helper that toggles talep row remove buttons and compacts the action column when only one row is left
- style the action column in both table header and body so the column shrinks when the button is hidden

## Testing
- not run (front-end change)


------
https://chatgpt.com/codex/tasks/task_e_68dcd0c7a6d8832ba6ddb6cf3f39fdf2