### PR TITLE
Refactor request exports to shared utility

### DIFF
--- a/utils/requests_export.py
+++ b/utils/requests_export.py
@@ -1,0 +1,51 @@
+"""Utilities for exporting request data to Excel workbooks."""
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Any, Callable, Iterable, Sequence
+
+from fastapi.responses import StreamingResponse
+from openpyxl import Workbook
+
+RowBuilder = Callable[[Any], Sequence[Any]]
+
+
+def export_requests_workbook(
+    rows: Iterable[Any],
+    headers: Sequence[str],
+    row_builder: RowBuilder,
+    filename: str = "talepler.xlsx",
+) -> StreamingResponse:
+    """Create a StreamingResponse containing the request export workbook.
+
+    Args:
+        rows: Iterable of database rows that will be exported. Each row is passed to
+            ``row_builder`` to create the Excel row content.
+        headers: Column titles to be written as the first row of the workbook.
+        row_builder: Callable that receives each row and returns a sequence of values
+            representing a single Excel row.
+        filename: Name of the exported file suggested to the client.
+
+    Returns:
+        A ``StreamingResponse`` containing the generated workbook.
+    """
+
+    wb = Workbook()
+    ws = wb.active
+    ws.append(list(headers))
+
+    for row in rows:
+        ws.append(list(row_builder(row)))
+
+    stream = BytesIO()
+    wb.save(stream)
+    stream.seek(0)
+
+    headers_dict = {
+        "Content-Disposition": f"attachment; filename={filename}",
+    }
+    return StreamingResponse(
+        stream,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers=headers_dict,
+    )


### PR DESCRIPTION
## Summary
- add a reusable helper for generating request export workbooks
- update both request export endpoints to delegate Excel creation to the shared helper

## Testing
- python - <<'PY'
import asyncio

from models import SessionLocal
from routes.talepler import export_excel
from routers.requests import export_requests


async def read_response(response):
    body = b""
    async for chunk in response.body_iterator:
        body += chunk
    return body


async def main():
    db = SessionLocal()
    try:
        response = export_excel(db)
        data = await read_response(response)
        print("/talepler/export.xlsx", len(data), response.headers.get("content-disposition"))
    finally:
        db.close()

    db = SessionLocal()
    try:
        response = await export_requests(db)
        data = await read_response(response)
        print("/requests/export", len(data), response.headers.get("content-disposition"))
    finally:
        db.close()


asyncio.run(main())
PY

------
https://chatgpt.com/codex/tasks/task_e_68dcdf138038832b877a88ff642b3f03