### PR TITLE
Refactor license forms with shared Bootstrap partial

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1602,18 +1602,6 @@ body .container-fluid {
   background: var(--color-surface, #ffffff) !important;
 }
 
-#assignModal .modal-body .env-grid {
-  gap: 1.5rem !important;
-}
-
-#assignModal .modal-body .field {
-  margin: 0 !important;
-}
-
-#assignModal .ctrl {
-  border-radius: var(--radius-sm) !important;
-}
-
 /* ========== Lisans atama sayfası ========== */
 
 .assign-page {

--- a/templates/license_form.html
+++ b/templates/license_form.html
@@ -42,86 +42,39 @@
       </div>
 
       <div class="modal-body">
-        <div class="env-grid" id="license-edit-grid">
-          <div class="field">
-            <label for="licenseAdi">Lisans Adı</label>
-            <select id="licenseAdi" name="adi" class="ctrl" required>
-              <option value="">Seçiniz...</option>
-              {% for ln in license_names %}
-              <option
-                value="{{ ln.name }}"
-                {% if license.lisans_adi == ln.name %}selected{% endif %}
-              >
-                {{ ln.name }}
-              </option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div class="field">
-            <label for="licenseKey">Lisans Anahtarı</label>
-            <input
-              id="licenseKey"
-              name="anahtar"
-              class="ctrl"
-              value="{{ license.anahtar or '' }}"
-              placeholder="XXXX-XXXX-XXXX-XXXX"
-            />
-          </div>
-
-          <div class="field">
-            <label for="licenseSorumlu">Sorumlu Personel</label>
-            <select id="licenseSorumlu" name="sorumlu_personel" class="ctrl">
-              <option value="">(Seçiniz)</option>
-              {% for u in users %}
-              <option
-                value="{{ u }}"
-                {% if license.sorumlu_personel == u %}selected{% endif %}
-              >
-                {{ u }}
-              </option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div class="field">
-            <label for="selBagliEnvanter">Bağlı Olduğu Envanter</label>
-            <select id="selBagliEnvanter" name="inventory_id" class="ctrl">
-              <option value="">Seçimsiz</option>
-              {% for inv in envanterler %}
-              <option
-                value="{{ inv.id }}"
-                {% if license.inventory_id|string == inv.id|string %}selected{% endif %}
-              >
-                {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
-              </option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div class="field">
-            <label for="licenseIfs">IFS No</label>
-            <input
-              id="licenseIfs"
-              name="ifs_no"
-              class="ctrl"
-              value="{{ license.ifs_no or '' }}"
-              placeholder="IFS referansı"
-            />
-          </div>
-
-          <div class="field">
-            <label for="licenseMail">Mail Adresi</label>
-            <input
-              id="licenseMail"
-              type="email"
-              name="mail_adresi"
-              class="ctrl"
-              value="{{ license.mail_adresi or '' }}"
-              placeholder="ornek@firma.com"
-            />
-          </div>
-        </div>
+        {% set license_form_config = {
+          "ids": {
+            "license_name": "licenseAdi",
+            "license_key": "licenseKey",
+            "responsible": "licenseSorumlu",
+            "inventory": "selBagliEnvanter",
+            "ifs": "licenseIfs",
+            "email": "licenseMail",
+          },
+          "names": {
+            "license_name": "adi",
+            "license_key": "anahtar",
+            "responsible": "sorumlu_personel",
+            "inventory": "inventory_id",
+            "ifs": "ifs_no",
+            "email": "mail_adresi",
+          },
+          "values": {
+            "license_name": license.lisans_adi if license else "",
+            "license_key": license.anahtar if license else "",
+            "responsible": license.sorumlu_personel if license else "",
+            "inventory": license.inventory_id if license else "",
+            "ifs": license.ifs_no if license else "",
+            "email": license.mail_adresi if license else "",
+          },
+          "required": ["license_name"],
+          "labels": {
+            "inventory": "Bağlı Olduğu Envanter",
+          },
+          "license_placeholder": "Seçiniz...",
+          "inventory_empty_label": "Seçimsiz",
+        } %}
+        {% include "partials/license_form_fields.html" %}
       </div>
 
       <div
@@ -170,94 +123,48 @@
     <form
       method="post"
       action="{{ form_action }}{{ '?modal=1' if modal else '' }}"
-      class="env-grid"
+      class="needs-validation"
+      novalidate
     >
-      <div class="field">
-        <label for="licenseAdi" class="form-label">Lisans Adı</label>
-        <select id="licenseAdi" name="adi" class="ctrl" required>
-          <option value="">Seçiniz...</option>
-          {% for ln in license_names %}
-          <option
-            value="{{ ln.name }}"
-            {% if license and license.lisans_adi == ln.name %}selected{% endif %}
-          >
-            {{ ln.name }}
-          </option>
-          {% endfor %}
-        </select>
-      </div>
+      {% set license_form_config = {
+        "ids": {
+          "license_name": "licenseAdi",
+          "license_key": "licenseKey",
+          "responsible": "licenseSorumlu",
+          "inventory": "selBagliEnvanter",
+          "ifs": "licenseIfs",
+          "email": "licenseMail",
+        },
+        "names": {
+          "license_name": "adi",
+          "license_key": "anahtar",
+          "responsible": "sorumlu_personel",
+          "inventory": "inventory_id",
+          "ifs": "ifs_no",
+          "email": "mail_adresi",
+        },
+        "values": {
+          "license_name": license.lisans_adi if license else "",
+          "license_key": license.anahtar if license else "",
+          "responsible": license.sorumlu_personel if license else "",
+          "inventory": license.inventory_id if license else "",
+          "ifs": license.ifs_no if license else "",
+          "email": license.mail_adresi if license else "",
+        },
+        "required": ["license_name"],
+        "labels": {
+          "inventory": "Bağlı Olduğu Envanter No",
+        },
+        "license_placeholder": "Seçiniz...",
+        "inventory_empty_label": "(Seçimsiz)",
+      } %}
+      {% include "partials/license_form_fields.html" %}
 
-      <div class="field">
-        <label for="licenseKey" class="form-label">Lisans Anahtarı</label>
-        <input
-          id="licenseKey"
-          name="anahtar"
-          class="ctrl"
-          value="{{ license.anahtar if license else '' }}"
-          placeholder="XXXX-XXXX-XXXX-XXXX"
-        />
-      </div>
-
-      <div class="field">
-        <label for="licenseSorumlu" class="form-label">Sorumlu Personel</label>
-        <select id="licenseSorumlu" name="sorumlu_personel" class="ctrl">
-          <option value="">(Seçiniz)</option>
-          {% for u in users %}
-          <option
-            value="{{ u }}"
-            {% if license and license.sorumlu_personel == u %}selected{% endif %}
-          >
-            {{ u }}
-          </option>
-          {% endfor %}
-        </select>
-      </div>
-
-      <div class="field">
-        <label for="selBagliEnvanter" class="form-label"
-          >Bağlı Olduğu Envanter No</label
-        >
-        <select id="selBagliEnvanter" name="inventory_id" class="ctrl">
-          <option value="">(Seçimsiz)</option>
-          {% for inv in envanterler %}
-          <option
-            value="{{ inv.id }}"
-            {% if license and license.inventory_id|string == inv.id|string %}selected{% endif %}
-          >
-            {{ inv.no }} — {{ inv.marka }} {{ inv.model }}
-          </option>
-          {% endfor %}
-        </select>
-      </div>
-
-      <div class="field">
-        <label for="licenseIfs" class="form-label">IFS No</label>
-        <input
-          id="licenseIfs"
-          name="ifs_no"
-          class="ctrl"
-          value="{{ license.ifs_no if license else '' }}"
-          placeholder="IFS referansı"
-        />
-      </div>
-
-      <div class="field">
-        <label for="licenseMail" class="form-label">Mail Adresi</label>
-        <input
-          id="licenseMail"
-          type="email"
-          name="mail_adresi"
-          class="ctrl"
-          value="{{ license.mail_adresi if license else '' }}"
-          placeholder="ornek@firma.com"
-        />
-      </div>
-
-      <div class="field span-2">
-        <div class="d-flex gap-2 justify-content-end">
+      <div class="row g-3 mt-1">
+        <div class="col-12 d-flex justify-content-end gap-2">
           <button class="btn btn-primary" type="submit">Kaydet</button>
           {% if not modal %}
-          <a class="btn btn-secondary" href="{{ url_for('license_list') }}"
+          <a class="btn btn-outline-secondary" href="{{ url_for('license_list') }}"
             >İptal</a
           >
           {% endif %}

--- a/templates/license_list.html
+++ b/templates/license_list.html
@@ -174,79 +174,45 @@ content %}
         </div>
 
         <div class="modal-shell__body">
-          <div class="env-grid" id="lisans-ekle-grid">
-            <div class="field">
-              <label for="selLisansAdi">Lisans Adı</label>
-              <select id="selLisansAdi" name="lisans_adi" class="ctrl" required>
-                <option value="">Seçiniz</option>
-                {% for ln in license_names %}
-                <option value="{{ ln.name }}">{{ ln.name }}</option>
-                {% endfor %}
-              </select>
-            </div>
-            <div class="field">
-              <label for="lisansAnahtari">Lisans Anahtarı</label>
-              <input
-                id="lisansAnahtari"
-                name="lisans_anahtari"
-                type="text"
-                class="ctrl"
-                required
-                placeholder="XXXX-XXXX-XXXX-XXXX"
-              />
-            </div>
-
-            <div class="field">
-              <label for="selPersonelAdd">Sorumlu Personel</label>
-              <select id="selPersonelAdd" name="sorumlu_personel" class="ctrl">
-                <option value="">Seçiniz</option>
-                {% for u in users %}
-                <option value="{{ u }}">{{ u }}</option>
-                {% endfor %}
-              </select>
-            </div>
-
-            <div class="field">
-              <label for="bagliEnvanter">Bağlı Olduğu Envanter No</label>
-              <select
-                id="bagliEnvanter"
-                name="bagli_envanter_no"
-                class="ctrl"
-                required
-              >
-                <option value="">Seçiniz...</option>
-                {% for inv in envanterler %}
-                <option value="{{ inv.no }}">{{ inv.no }}</option>
-                {% endfor %}
-              </select>
-            </div>
-
-            <div class="field">
-              <label for="ifsNo"
-                >IFS No <span class="muted">(opsiyonel)</span></label
-              >
-              <input
-                id="ifsNo"
-                name="ifs_no"
-                type="text"
-                class="ctrl"
-                placeholder="IFS numarası"
-              />
-            </div>
-
-            <div class="field">
-              <label for="lisansEmail"
-                >E-posta <span class="muted">(opsiyonel)</span></label
-              >
-              <input
-                id="lisansEmail"
-                name="mail_adresi"
-                type="email"
-                class="ctrl"
-                placeholder="ornek@firma.com"
-              />
-            </div>
-          </div>
+          {% set license_form_config = {
+            "ids": {
+              "license_name": "selLisansAdi",
+              "license_key": "lisansAnahtari",
+              "responsible": "selPersonelAdd",
+              "inventory": "bagliEnvanter",
+              "ifs": "ifsNo",
+              "email": "lisansEmail",
+            },
+            "names": {
+              "license_name": "lisans_adi",
+              "license_key": "lisans_anahtari",
+              "responsible": "sorumlu_personel",
+              "inventory": "bagli_envanter_no",
+              "ifs": "ifs_no",
+              "email": "mail_adresi",
+            },
+            "values": {},
+            "required": ["license_name", "license_key", "inventory"],
+            "labels": {
+              "inventory": "Bağlı Olduğu Envanter No",
+              "email": "E-posta",
+            },
+            "optional_texts": {
+              "ifs": "(opsiyonel)",
+              "email": "(opsiyonel)",
+            },
+            "license_placeholder": "Seçiniz",
+            "responsible_placeholder": "Seçiniz",
+            "inventory_empty_label": "Seçiniz...",
+            "inventory_value_attr": "no",
+            "inventory_label_variant": "no_only",
+            "placeholders": {
+              "license_key": "XXXX-XXXX-XXXX-XXXX",
+              "ifs": "IFS numarası",
+              "email": "ornek@firma.com",
+            },
+          } %}
+          {% include "partials/license_form_fields.html" %}
         </div>
 
         <div class="modal-shell__footer">

--- a/templates/partials/license_form_fields.html
+++ b/templates/partials/license_form_fields.html
@@ -1,0 +1,143 @@
+{% set cfg = license_form_config %}
+{% set ids = cfg.ids %}
+{% set names = cfg.names %}
+{% set values = cfg.values if cfg.values is defined else {} %}
+{% set required = cfg.required if cfg.required is defined else [] %}
+{% set labels = cfg.labels if cfg.labels is defined else {} %}
+{% set optional_texts = cfg.optional_texts if cfg.optional_texts is defined else {} %}
+{% set placeholders = cfg.placeholders if cfg.placeholders is defined else {} %}
+{% set license_placeholder = cfg.license_placeholder if cfg.license_placeholder is defined else 'Seçiniz...' %}
+{% set responsible_placeholder = cfg.responsible_placeholder if cfg.responsible_placeholder is defined else '(Seçiniz)' %}
+{% set inventory_empty_label = cfg.inventory_empty_label if cfg.inventory_empty_label is defined else 'Seçiniz...' %}
+{% set inventory_empty_value = cfg.inventory_empty_value if cfg.inventory_empty_value is defined else '' %}
+{% set inventory_value_attr = cfg.inventory_value_attr if cfg.inventory_value_attr is defined else 'id' %}
+{% set inventory_label_variant = cfg.inventory_label_variant if cfg.inventory_label_variant is defined else 'detailed' %}
+{% set license_value = values.license_name if values.license_name is defined and values.license_name is not none else '' %}
+{% set license_key_value = values.license_key if values.license_key is defined and values.license_key is not none else '' %}
+{% set responsible_value = values.responsible if values.responsible is defined and values.responsible is not none else '' %}
+{% set inventory_value = values.inventory if values.inventory is defined else '' %}
+{% if inventory_value is none %}
+{% set inventory_value = '' %}
+{% endif %}
+{% set ifs_value = values.ifs if values.ifs is defined and values.ifs is not none else '' %}
+{% set email_value = values.email if values.email is defined and values.email is not none else '' %}
+<div class="row g-3 license-form-fields">
+  <div class="col-12 col-md-6">
+    <label for="{{ ids.license_name }}" class="form-label">
+      {{ labels.license_name if labels.license_name is defined and labels.license_name is not none else 'Lisans Adı' }}
+      {% if optional_texts.license_name is defined %}
+      <span class="text-muted">{{ optional_texts.license_name }}</span>
+      {% endif %}
+    </label>
+    <select
+      id="{{ ids.license_name }}"
+      name="{{ names.license_name }}"
+      class="form-select"
+      {% if 'license_name' in required %}required{% endif %}
+    >
+      <option value="">{{ license_placeholder }}</option>
+      {% for ln in license_names %}
+      <option value="{{ ln.name }}" {% if ln.name == license_value %}selected{% endif %}>{{ ln.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-12 col-md-6">
+    <label for="{{ ids.license_key }}" class="form-label">
+      {{ labels.license_key if labels.license_key is defined and labels.license_key is not none else 'Lisans Anahtarı' }}
+      {% if optional_texts.license_key is defined %}
+      <span class="text-muted">{{ optional_texts.license_key }}</span>
+      {% endif %}
+    </label>
+    <input
+      id="{{ ids.license_key }}"
+      name="{{ names.license_key }}"
+      type="text"
+      class="form-control"
+      value="{{ license_key_value }}"
+      placeholder="{{ placeholders.license_key if placeholders.license_key is defined else 'XXXX-XXXX-XXXX-XXXX' }}"
+      {% if 'license_key' in required %}required{% endif %}
+    />
+  </div>
+  <div class="col-12 col-md-6">
+    <label for="{{ ids.responsible }}" class="form-label">
+      {{ labels.responsible if labels.responsible is defined and labels.responsible is not none else 'Sorumlu Personel' }}
+      {% if optional_texts.responsible is defined %}
+      <span class="text-muted">{{ optional_texts.responsible }}</span>
+      {% endif %}
+    </label>
+    <select
+      id="{{ ids.responsible }}"
+      name="{{ names.responsible }}"
+      class="form-select"
+      {% if 'responsible' in required %}required{% endif %}
+    >
+      <option value="">{{ responsible_placeholder }}</option>
+      {% for u in users %}
+      <option value="{{ u }}" {% if u == responsible_value %}selected{% endif %}>{{ u }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-12 col-md-6">
+    <label for="{{ ids.inventory }}" class="form-label">
+      {{ labels.inventory if labels.inventory is defined and labels.inventory is not none else 'Bağlı Olduğu Envanter' }}
+      {% if optional_texts.inventory is defined %}
+      <span class="text-muted">{{ optional_texts.inventory }}</span>
+      {% endif %}
+    </label>
+    <select
+      id="{{ ids.inventory }}"
+      name="{{ names.inventory }}"
+      class="form-select"
+      {% if 'inventory' in required %}required{% endif %}
+    >
+      <option value="{{ inventory_empty_value }}">{{ inventory_empty_label }}</option>
+      {% for inv in envanterler %}
+      {% set option_value = inv|attr(inventory_value_attr) %}
+      <option
+        value="{{ option_value }}"
+        {% if option_value|string == inventory_value|string %}selected{% endif %}
+      >
+        {% if inventory_label_variant == 'no_only' %}
+          {{ inv.no }}
+        {% else %}
+          {{ inv.no }}{% if inv.marka %} — {{ inv.marka }}{% endif %}{% if inv.model %} {{ inv.model }}{% endif %}
+        {% endif %}
+      </option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-12 col-md-6">
+    <label for="{{ ids.ifs }}" class="form-label">
+      {{ labels.ifs if labels.ifs is defined and labels.ifs is not none else 'IFS No' }}
+      {% if optional_texts.ifs is defined %}
+      <span class="text-muted">{{ optional_texts.ifs }}</span>
+      {% endif %}
+    </label>
+    <input
+      id="{{ ids.ifs }}"
+      name="{{ names.ifs }}"
+      type="text"
+      class="form-control"
+      value="{{ ifs_value }}"
+      placeholder="{{ placeholders.ifs if placeholders.ifs is defined else 'IFS referansı' }}"
+      {% if 'ifs' in required %}required{% endif %}
+    />
+  </div>
+  <div class="col-12 col-md-6">
+    <label for="{{ ids.email }}" class="form-label">
+      {{ labels.email if labels.email is defined and labels.email is not none else 'Mail Adresi' }}
+      {% if optional_texts.email is defined %}
+      <span class="text-muted">{{ optional_texts.email }}</span>
+      {% endif %}
+    </label>
+    <input
+      id="{{ ids.email }}"
+      name="{{ names.email }}"
+      type="email"
+      class="form-control"
+      value="{{ email_value }}"
+      placeholder="{{ placeholders.email if placeholders.email is defined else 'ornek@firma.com' }}"
+      {% if 'email' in required %}required{% endif %}
+    />
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- replace the license edit and creation forms with a shared partial that renders Bootstrap `row`/`col` markup and standard form classes
- update the license list modal to consume the new partial and ensure field metadata (labels, placeholders, required flags) matches previous behaviour
- drop unused license-specific `.ctrl` overrides from the custom stylesheet to rely on Bootstrap defaults

## Testing
- pytest tests/test_license_stock.py

------
https://chatgpt.com/codex/tasks/task_e_68dced3a86b8832b8fa09eb6b50b2c27