### PR TITLE
Refactor printer edit modal to reuse shared form fields

### DIFF
--- a/routers/printers.py
+++ b/routers/printers.py
@@ -348,6 +348,14 @@ def edit_printer_post(
     model: str = Form(None),
     seri_no: str = Form(None),
     notlar: str = Form(None),
+    envanter_no: str = Form(None),
+    ip_adresi: str = Form(None),
+    mac: str = Form(None),
+    hostname: str = Form(None),
+    ifs_no: str = Form(None),
+    marka_id: str = Form(None),
+    model_id: str = Form(None),
+    kullanim_alani_id: str = Form(None),
     modal: bool = False,
     db: Session = Depends(get_db),
     user=Depends(current_user),
@@ -356,7 +364,70 @@ def edit_printer_post(
     if not p:
         raise HTTPException(404, "Yazıcı bulunamadı")
 
-    new_vals = {"marka": marka, "model": model, "seri_no": seri_no, "notlar": notlar}
+    def parse_int(value: Optional[str]) -> Optional[int]:
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    new_vals: Dict[str, Any] = {}
+
+    if marka_id is not None or marka is not None:
+        brand_name = marka or None
+        brand_pk = parse_int(marka_id)
+        if marka_id == "":
+            brand_name = None
+        elif brand_pk is not None:
+            brand = db.get(Brand, brand_pk)
+            brand_name = brand.name if brand else brand_name
+        new_vals["marka"] = brand_name
+
+    if model_id is not None or model is not None:
+        model_name = model or None
+        model_pk = parse_int(model_id)
+        if model_id == "":
+            model_name = None
+        elif model_pk is not None:
+            model_row = db.get(Model, model_pk)
+            model_name = model_row.name if model_row else model_name
+        new_vals["model"] = model_name
+
+    if seri_no is not None:
+        new_vals["seri_no"] = seri_no or None
+
+    if notlar is not None:
+        new_vals["notlar"] = notlar or None
+
+    if envanter_no is not None:
+        new_vals["envanter_no"] = envanter_no or None
+
+    if ip_adresi is not None:
+        new_vals["ip_adresi"] = ip_adresi or None
+
+    if mac is not None:
+        new_vals["mac"] = mac or None
+
+    if hostname is not None:
+        new_vals["hostname"] = hostname or None
+
+    if ifs_no is not None:
+        new_vals["ifs_no"] = ifs_no or None
+
+    if kullanim_alani_id is not None:
+        usage_name = None
+        usage_pk = parse_int(kullanim_alani_id)
+        if kullanim_alani_id == "":
+            usage_name = None
+        elif usage_pk is not None:
+            area = db.get(UsageArea, usage_pk)
+            usage_name = area.name if area else None
+        new_vals["kullanim_alani"] = usage_name
+
+    if not new_vals:
+        new_vals = {"marka": marka, "model": model, "seri_no": seri_no, "notlar": notlar}
+
     changes = build_changes(p, new_vals)
     for k, v in new_vals.items():
         setattr(p, k, v)

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1485,10 +1485,18 @@ body .container-fluid {
 }
 
 .ctrl:disabled,
-.ctrl[readonly] {
+.ctrl[readonly],
+.form-control:disabled,
+.form-control[readonly],
+.form-select:disabled {
   background: var(--color-surface-elevated) !important;
   cursor: not-allowed;
   opacity: 0.6;
+}
+
+.printer-edit-modal .form-control[readonly] {
+  opacity: 1;
+  cursor: default;
 }
 
 /* Modal footer modern stil */

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -42,62 +42,40 @@ content %}
       </div>
 
       <div class="modal-body">
-        <div class="env-grid" id="printer-edit-grid">
-          <div class="field">
-            <label for="printerId">Kayıt No</label>
+        <div class="row g-3" id="printer-edit-grid">
+          <div class="col-lg-6">
+            <label for="printerId" class="form-label">Kayıt No</label>
             <input
               id="printerId"
               type="text"
-              class="ctrl"
+              class="form-control"
               value="#{{ p.id }}{{ ' • ' ~ p.envanter_no if p.envanter_no }}"
               readonly
             />
           </div>
-          <div class="field">
-            <label for="printerMarka">Marka</label>
-            <input
-              type="text"
-              name="marka"
-              id="printerMarka"
-              value="{{ p.marka or '' }}"
-              class="ctrl"
-              placeholder="Örn. HP"
-              autofocus
-            />
+          <div class="col-12">
+            {% include "_printer_form_fields.html" %}
           </div>
-          <div class="field">
-            <label for="printerModel">Model</label>
-            <input
-              type="text"
-              name="model"
-              id="printerModel"
-              value="{{ p.model or '' }}"
-              class="ctrl"
-              placeholder="Örn. LaserJet Pro 400"
-            />
-          </div>
-          <div class="field">
-            <label for="printerSerial">Seri No</label>
+          <div class="col-lg-6">
+            <label for="printerSerial" class="form-label">Seri No</label>
             <input
               type="text"
               name="seri_no"
               id="printerSerial"
               value="{{ p.seri_no or '' }}"
-              class="ctrl"
+              class="form-control"
               placeholder="Seri numarası"
             />
           </div>
-          <div class="field span-2">
-            <label for="printerNotes">Notlar</label>
+          <div class="col-12">
+            <label for="printerNotes" class="form-label">Notlar</label>
             <textarea
               name="notlar"
               id="printerNotes"
-              class="ctrl"
+              class="form-control"
               rows="4"
               placeholder="Bakım, toner değişimi veya diğer notlar..."
-            >
-{{ p.notlar or '' }}</textarea
-            >
+            >{{ p.notlar or '' }}</textarea>
           </div>
         </div>
       </div>
@@ -193,6 +171,78 @@ content %}
       .forEach((trigger) => {
         trigger.addEventListener("click", closeDialog);
       });
+
+    const form = document.getElementById("printer-edit-form");
+    const setFormValue = (name, value) => {
+      if (!form) return;
+      const field = form.querySelector(`[name="${name}"]`);
+      if (field) field.value = value ?? "";
+    };
+
+    if (form) {
+      setFormValue("envanter_no", {{ (p.envanter_no or '')|tojson }});
+      setFormValue("ip_adresi", {{ (p.ip_adresi or '')|tojson }});
+      setFormValue("mac", {{ (p.mac or '')|tojson }});
+      setFormValue("hostname", {{ (p.hostname or '')|tojson }});
+      setFormValue("ifs_no", {{ (p.ifs_no or '')|tojson }});
+
+      const setChoiceByLabel = (select, label) => {
+        if (!select) return null;
+        const targetLabel = String(label || "").trim().toLowerCase();
+        if (!targetLabel) return null;
+        const option = Array.from(select.options).find((opt) =>
+          opt.text.trim().toLowerCase() === targetLabel,
+        );
+        if (!option) return null;
+        const inst = select._choices;
+        if (inst && option.value !== undefined) {
+          inst.setChoiceByValue(String(option.value));
+        }
+        select.value = option.value;
+        return option.value;
+      };
+
+      const initSelects = async () => {
+        if (!window._selects) return;
+        const brandSelect = form.querySelector("#selYaziciMarka");
+        const modelSelect = form.querySelector("#selYaziciModel");
+        const usageSelect = form.querySelector("#selYaziciKullanim");
+
+        if (brandSelect) {
+          await window._selects.fillChoices({
+            endpoint: "/api/lookup/marka",
+            selectId: "selYaziciMarka",
+            placeholder: "Yazıcı markası seçiniz…",
+          });
+          setChoiceByLabel(brandSelect, {{ (p.marka or '')|tojson }});
+          await window._selects.bindMarkaModel(
+            "selYaziciMarka",
+            "selYaziciModel",
+          );
+          if (modelSelect) {
+            setChoiceByLabel(modelSelect, {{ (p.model or '')|tojson }});
+          }
+          window._selects.enableRemoteSearch(
+            "selYaziciModel",
+            "/api/lookup/model",
+            () => ({ marka_id: brandSelect.value || "" }),
+          );
+        }
+
+        if (usageSelect) {
+          await window._selects.fillChoices({
+            endpoint: "/api/lookup/kullanim-alani",
+            selectId: "selYaziciKullanim",
+            placeholder: "Kullanım alanı seçiniz…",
+          });
+          setChoiceByLabel(usageSelect, {{ (p.kullanim_alani or '')|tojson }});
+        }
+      };
+
+      initSelects().catch((err) => {
+        console.error("Printer edit modal init failed", err);
+      });
+    }
 
     document.addEventListener("keydown", (event) => {
       if (event.key === "Escape") {


### PR DESCRIPTION
## Summary
- refactor the printer edit modal to render the shared `_printer_form_fields.html` fragment with Bootstrap row/g-3 layout
- update the modal script to prefill Bootstrap inputs/selects via `_selects` helpers and match stored names to lookup options
- extend the printer edit endpoint to accept ID-based fields and additional attributes while aligning CSS with the new controls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcef60211c832bbc1e3fb4e2a28ba4