### PR TITLE
Handle optional bilgi category form values

### DIFF
--- a/routers/bilgiler.py
+++ b/routers/bilgiler.py
@@ -138,7 +138,7 @@ def bilgi_index(
 async def bilgi_create(
     request: Request,
     baslik: str = Form(...),
-    kategori_id: int | None = Form(None),
+    kategori_id: str | None = Form(None),
     icerik: str = Form(""),
     foto: UploadFile | None = File(None),
     db: Session = Depends(get_db),
@@ -154,7 +154,12 @@ async def bilgi_create(
 
     kategori_ref = None
     if kategori_id:
-        kategori_ref = db.get(BilgiKategori, kategori_id)
+        try:
+            kategori_key = int(kategori_id)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="Geçersiz kategori seçimi")
+
+        kategori_ref = db.get(BilgiKategori, kategori_key)
         if not kategori_ref:
             raise HTTPException(status_code=400, detail="Geçersiz kategori seçimi")
 


### PR DESCRIPTION
## Summary
- allow the bilgi creation endpoint to accept empty category selections from the form
- validate and coerce non-empty category ids before looking up the record

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd100bd88c832ba3a62f31d2e4eb26