### PR TITLE
Replace native alerts with Bootstrap dialogs

### DIFF
--- a/static/js/bilgiler.js
+++ b/static/js/bilgiler.js
@@ -137,7 +137,12 @@
     if (!card) return;
     const id = button.dataset.id;
     if (!id) return;
-    if (!confirm("Bu bilgiyi silmek istediğinizden emin misiniz?")) return;
+    const confirmed = await showConfirm({
+      message: "Bu bilgiyi silmek istediğinizden emin misiniz?",
+      confirmLabel: "Sil",
+      confirmVariant: "danger",
+    });
+    if (!confirmed) return;
 
     try {
       const response = await fetch(`/bilgiler/${id}`, { method: "DELETE" });

--- a/static/js/mini-picker.js
+++ b/static/js/mini-picker.js
@@ -346,7 +346,12 @@
       closeModal();
     } else if (e.target.classList.contains("picker-del")) {
       if (!current.allowDelete) return;
-      if (!confirm("Silinsin mi?")) return;
+      const confirmed = await showConfirm({
+        message: "Silinsin mi?",
+        confirmLabel: "Sil",
+        confirmVariant: "danger",
+      });
+      if (!confirmed) return;
       const url = `${current.endpoint}/${encodeURIComponent(row.dataset.id)}`;
       const delRes = await fetch(url, { method: "DELETE" });
       if (delRes.ok) {

--- a/static/js/mini-picker.js
+++ b/static/js/mini-picker.js
@@ -153,7 +153,10 @@
 
     if ((!data || !data.length) && current.fallbackEndpoint) {
       const fallbackParams = { ...(current.fallbackParams || {}) };
-      let fallbackData = await fetchOptions(current.fallbackEndpoint, fallbackParams);
+      let fallbackData = await fetchOptions(
+        current.fallbackEndpoint,
+        fallbackParams,
+      );
       if (q && fallbackData && fallbackData.length) {
         const qNormalized = q.trim().toLowerCase();
         fallbackData = fallbackData.filter((item) =>
@@ -247,12 +250,12 @@
   function dispatchChange(detail) {
     if (current.hidden) {
       current.hidden.dispatchEvent(
-        new CustomEvent("picker:change", { bubbles: true, detail })
+        new CustomEvent("picker:change", { bubbles: true, detail }),
       );
     }
     if (current.display) {
       current.display.dispatchEvent(
-        new CustomEvent("picker:change", { bubbles: true, detail })
+        new CustomEvent("picker:change", { bubbles: true, detail }),
       );
     }
   }
@@ -330,8 +333,7 @@
         entity: current.entity,
         storedAs: current.storeAs,
       };
-      const storedValue =
-        current.storeAs === "text" ? detail.text : detail.id;
+      const storedValue = current.storeAs === "text" ? detail.text : detail.id;
       if (current.hidden) {
         current.hidden.value = storedValue || "";
         current.hidden.dataset.id = detail.id;
@@ -372,7 +374,7 @@
   // ≡ butonlarını bağla (admin/kullanıcı fark etmez; kapsayıcı id’ni değiştir)
   document
     .querySelectorAll(
-      "#admin-urun-ekle .pick-btn, #urun-ekle .pick-btn, .inventory-edit-modal .pick-btn"
+      "#admin-urun-ekle .pick-btn, #urun-ekle .pick-btn, .inventory-edit-modal .pick-btn",
     )
     .forEach((btn) => {
       btn.addEventListener("click", () => {
@@ -399,7 +401,8 @@
     const input = e.target.closest("input.lookup-display");
     if (!input) return;
     const entity =
-      input.dataset.entity || (input.id ? input.id.replace("_display", "") : null);
+      input.dataset.entity ||
+      (input.id ? input.id.replace("_display", "") : null);
     if (!entity) return;
     const hiddenId = input.dataset.target || entity;
     const chipKey = input.dataset.chip || hiddenId || entity;

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -1,0 +1,196 @@
+(() => {
+  const alertModalEl = document.getElementById("globalAlertModal");
+  const confirmModalEl = document.getElementById("globalConfirmModal");
+  if (!alertModalEl || !confirmModalEl) return;
+
+  const alertModal = new bootstrap.Modal(alertModalEl);
+  const confirmModal = new bootstrap.Modal(confirmModalEl);
+
+  const alertTitleEl = document.getElementById("globalAlertTitle");
+  const alertBodyEl = document.getElementById("globalAlertBody");
+  const alertOkBtn = document.getElementById("globalAlertOk");
+
+  const confirmTitleEl = document.getElementById("globalConfirmTitle");
+  const confirmBodyEl = document.getElementById("globalConfirmBody");
+  const confirmCancelBtn = document.getElementById("globalConfirmCancel");
+  const confirmOkBtn = document.getElementById("globalConfirmOk");
+
+  const toastContainer = document.getElementById("globalToastContainer");
+
+  const VARIANT_DEFAULTS = {
+    primary: "Bilgi",
+    secondary: "Bilgi",
+    success: "Başarılı",
+    danger: "Hata",
+    warning: "Uyarı",
+    info: "Bilgi",
+    light: "Bilgi",
+    dark: "Bilgi",
+  };
+
+  function detectVariant(message) {
+    const text = (message == null ? "" : String(message)).toLowerCase();
+    if (!text) return "primary";
+    if (/başarı|tamamlandı|kaydedildi|oldu/.test(text)) return "success";
+    if (/uyarı|dikkat|emin misiniz|onay/.test(text)) return "warning";
+    if (/hata|başarısız|geçersiz|olmadı|silinemez|sınırı aşıyor|fail/.test(text))
+      return "danger";
+    return "primary";
+  }
+
+  function setButtonVariant(button, variant, fallback = "primary") {
+    if (!button) return;
+    const finalVariant = variant && VARIANT_DEFAULTS[variant] ? variant : fallback;
+    button.className = `btn btn-${finalVariant}`;
+  }
+
+  function setModalBody(element, message) {
+    if (!element) return;
+    const text = message == null ? "" : String(message);
+    element.innerHTML = "";
+    const lines = text.split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (index) element.appendChild(document.createElement("br"));
+      element.appendChild(document.createTextNode(line));
+    });
+  }
+
+  function resolveOnHide(modalEl, callback) {
+    const handler = () => {
+      modalEl.removeEventListener("hidden.bs.modal", handler);
+      callback();
+    };
+    modalEl.addEventListener("hidden.bs.modal", handler);
+  }
+
+  window.showAlert = function showAlert(message, options = {}) {
+    const resolvedVariant = options.variant || detectVariant(message);
+    const { title, okLabel = "Tamam" } = options;
+    alertTitleEl.textContent = title || VARIANT_DEFAULTS[resolvedVariant] || "Bilgi";
+    alertOkBtn.textContent = okLabel;
+    setButtonVariant(alertOkBtn, resolvedVariant, "primary");
+    setModalBody(alertBodyEl, message);
+    return new Promise((resolve) => {
+      resolveOnHide(alertModalEl, resolve);
+      alertModal.show();
+    });
+  };
+
+  window.alert = (message) => {
+    window.showAlert(message);
+  };
+
+  window.showToast = function showToast(message, options = {}) {
+    if (!toastContainer) return;
+    const resolvedVariant = options.variant || detectVariant(message);
+    const { title = "", delay = 5000 } = options;
+    const effectiveVariant = VARIANT_DEFAULTS[resolvedVariant] ? resolvedVariant : "primary";
+    const toastEl = document.createElement("div");
+    toastEl.className = `toast text-bg-${effectiveVariant} border-0`;
+    toastEl.setAttribute("role", "status");
+    toastEl.setAttribute("aria-live", "polite");
+    toastEl.setAttribute("aria-atomic", "true");
+    toastEl.innerHTML = `
+      <div class="toast-header text-bg-${effectiveVariant} border-0">
+        <strong class="me-auto">${title || VARIANT_DEFAULTS[effectiveVariant] || "Bilgi"}</strong>
+        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Kapat"></button>
+      </div>
+      <div class="toast-body"></div>
+    `;
+    const body = toastEl.querySelector(".toast-body");
+    setModalBody(body, message);
+    toastContainer.appendChild(toastEl);
+    const toast = new bootstrap.Toast(toastEl, { delay });
+    toastEl.addEventListener("hidden.bs.toast", () => {
+      toast.dispose();
+      toastEl.remove();
+    });
+    toast.show();
+    return toast;
+  };
+
+  window.showConfirm = function showConfirm(message, options = {}) {
+    const opts = typeof message === "object" ? { ...message } : { ...options, message };
+    const {
+      message: finalMessage = "",
+      title = "Onay",
+      confirmLabel = "Evet",
+      cancelLabel = "İptal",
+      confirmVariant = "primary",
+      cancelVariant = "secondary",
+    } = opts;
+
+    confirmTitleEl.textContent = title;
+    confirmOkBtn.textContent = confirmLabel;
+    confirmCancelBtn.textContent = cancelLabel;
+    setButtonVariant(confirmOkBtn, confirmVariant, "primary");
+    setButtonVariant(confirmCancelBtn, cancelVariant, "secondary");
+    setModalBody(confirmBodyEl, finalMessage);
+
+    return new Promise((resolve) => {
+      const cleanup = () => {
+        confirmOkBtn.removeEventListener("click", onOk);
+        confirmCancelBtn.removeEventListener("click", onCancel);
+        confirmModalEl.removeEventListener("hidden.bs.modal", onCancel);
+      };
+
+      const onOk = () => {
+        cleanup();
+        confirmModal.hide();
+        resolve(true);
+      };
+
+      const onCancel = () => {
+        cleanup();
+        resolve(false);
+      };
+
+      confirmOkBtn.addEventListener("click", onOk, { once: true });
+      confirmCancelBtn.addEventListener("click", onCancel, { once: true });
+      confirmModalEl.addEventListener("hidden.bs.modal", onCancel, { once: true });
+
+      confirmModal.show();
+    });
+  };
+
+  window.handleConfirm = function handleConfirm(trigger, event, options = {}) {
+    if (event) event.preventDefault();
+    const opts = typeof options === "string" ? { message: options } : { ...options };
+    if (!opts.message) {
+      opts.message = trigger?.getAttribute("data-confirm-message") || "Onaylıyor musunuz?";
+    }
+    window.showConfirm(opts).then((confirmed) => {
+      if (!confirmed) return;
+      if (typeof opts.onConfirm === "function") {
+        opts.onConfirm.call(trigger);
+        return;
+      }
+      const targetForm = trigger?.form || trigger?.closest?.("form");
+      if (targetForm && trigger?.type === "submit") {
+        if (typeof targetForm.requestSubmit === "function") {
+          targetForm.requestSubmit(trigger);
+        } else {
+          targetForm.submit();
+        }
+        return;
+      }
+      const href = trigger?.getAttribute?.("href");
+      if (href) {
+        const target = trigger.getAttribute("target");
+        if (target && target !== "_self") {
+          window.open(href, target);
+        } else {
+          window.location.href = href;
+        }
+        return;
+      }
+      const submitTarget = opts.submitTarget
+        ? document.querySelector(opts.submitTarget)
+        : null;
+      if (submitTarget && typeof submitTarget.submit === "function") {
+        submitTarget.submit();
+      }
+    });
+    return false;
+  };
+})();

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -33,14 +33,17 @@
     if (!text) return "primary";
     if (/başarı|tamamlandı|kaydedildi|oldu/.test(text)) return "success";
     if (/uyarı|dikkat|emin misiniz|onay/.test(text)) return "warning";
-    if (/hata|başarısız|geçersiz|olmadı|silinemez|sınırı aşıyor|fail/.test(text))
+    if (
+      /hata|başarısız|geçersiz|olmadı|silinemez|sınırı aşıyor|fail/.test(text)
+    )
       return "danger";
     return "primary";
   }
 
   function setButtonVariant(button, variant, fallback = "primary") {
     if (!button) return;
-    const finalVariant = variant && VARIANT_DEFAULTS[variant] ? variant : fallback;
+    const finalVariant =
+      variant && VARIANT_DEFAULTS[variant] ? variant : fallback;
     button.className = `btn btn-${finalVariant}`;
   }
 
@@ -66,7 +69,8 @@
   window.showAlert = function showAlert(message, options = {}) {
     const resolvedVariant = options.variant || detectVariant(message);
     const { title, okLabel = "Tamam" } = options;
-    alertTitleEl.textContent = title || VARIANT_DEFAULTS[resolvedVariant] || "Bilgi";
+    alertTitleEl.textContent =
+      title || VARIANT_DEFAULTS[resolvedVariant] || "Bilgi";
     alertOkBtn.textContent = okLabel;
     setButtonVariant(alertOkBtn, resolvedVariant, "primary");
     setModalBody(alertBodyEl, message);
@@ -84,7 +88,9 @@
     if (!toastContainer) return;
     const resolvedVariant = options.variant || detectVariant(message);
     const { title = "", delay = 5000 } = options;
-    const effectiveVariant = VARIANT_DEFAULTS[resolvedVariant] ? resolvedVariant : "primary";
+    const effectiveVariant = VARIANT_DEFAULTS[resolvedVariant]
+      ? resolvedVariant
+      : "primary";
     const toastEl = document.createElement("div");
     toastEl.className = `toast text-bg-${effectiveVariant} border-0`;
     toastEl.setAttribute("role", "status");
@@ -110,7 +116,8 @@
   };
 
   window.showConfirm = function showConfirm(message, options = {}) {
-    const opts = typeof message === "object" ? { ...message } : { ...options, message };
+    const opts =
+      typeof message === "object" ? { ...message } : { ...options, message };
     const {
       message: finalMessage = "",
       title = "Onay",
@@ -147,7 +154,9 @@
 
       confirmOkBtn.addEventListener("click", onOk, { once: true });
       confirmCancelBtn.addEventListener("click", onCancel, { once: true });
-      confirmModalEl.addEventListener("hidden.bs.modal", onCancel, { once: true });
+      confirmModalEl.addEventListener("hidden.bs.modal", onCancel, {
+        once: true,
+      });
 
       confirmModal.show();
     });
@@ -155,9 +164,11 @@
 
   window.handleConfirm = function handleConfirm(trigger, event, options = {}) {
     if (event) event.preventDefault();
-    const opts = typeof options === "string" ? { message: options } : { ...options };
+    const opts =
+      typeof options === "string" ? { message: options } : { ...options };
     if (!opts.message) {
-      opts.message = trigger?.getAttribute("data-confirm-message") || "Onaylıyor musunuz?";
+      opts.message =
+        trigger?.getAttribute("data-confirm-message") || "Onaylıyor musunuz?";
     }
     window.showConfirm(opts).then((confirmed) => {
       if (!confirmed) return;

--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -111,7 +111,6 @@
 
   const API_ROOT_META = getMetaApiRoot();
   const STOCK_STATUS_URL = `${API_ROOT_META}/stock/status`;
-  
 
   function baseSourceType(value) {
     if (!value) return "";
@@ -131,11 +130,13 @@
       return text ? text : null;
     };
     return {
-     item_type: ['envanter', 'lisans', 'yazici'].includes(type) ? type : 'envanter',
-     donanim_tipi: String(item.donanim_tipi || '').trim(),
-     marka: clean(item.marka),
-     model: clean(item.model),
-     ifs_no: clean(item.ifs_no),
+      item_type: ["envanter", "lisans", "yazici"].includes(type)
+        ? type
+        : "envanter",
+      donanim_tipi: String(item.donanim_tipi || "").trim(),
+      marka: clean(item.marka),
+      model: clean(item.model),
+      ifs_no: clean(item.ifs_no),
     };
   }
 
@@ -246,8 +247,10 @@
     }
 
     function detectInitialType() {
-     const active = dom.one('[data-stock-add-type].active');
-     return active?.dataset.stockAddType === 'license' ? 'license' : 'inventory';
+      const active = dom.one("[data-stock-add-type].active");
+      return active?.dataset.stockAddType === "license"
+        ? "license"
+        : "inventory";
     }
 
     function updateSectionVisibility(isLicense) {
@@ -464,7 +467,10 @@
                 item.seri_no,
               ]
                 .filter((part) => part)
-                .join(" - ") || item.envanter_no || item.id || "",
+                .join(" - ") ||
+              item.envanter_no ||
+              item.id ||
+              "",
           }));
         } catch (err) {
           printersRes = { data: [], error: err };
@@ -1675,9 +1681,7 @@
       statusTab?.addEventListener("shown.bs.tab", refreshStockStatus);
 
       dom.one("#sa_submit")?.addEventListener("click", submitAssignment);
-      dom
-        .one("#stockAssignForm")
-        ?.addEventListener("submit", submitAssignment);
+      dom.one("#stockAssignForm")?.addEventListener("submit", submitAssignment);
       bindTabChange();
       applyFieldRules();
 

--- a/static/js/stock.js
+++ b/static/js/stock.js
@@ -1065,8 +1065,12 @@
         alert("Geçersiz miktar");
         return;
       }
-      if (!window.confirm(`${qty} adet hurdaya ayrılacak. Onaylıyor musunuz?`))
-        return;
+      const confirmed = await showConfirm({
+        message: `${qty} adet hurdaya ayrılacak. Onaylıyor musunuz?`,
+        confirmLabel: "Onayla",
+        confirmVariant: "danger",
+      });
+      if (!confirmed) return;
       const payload = {
         donanim_tipi: item.donanim_tipi,
         marka: item.marka,

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -131,7 +131,7 @@ content %}
                     <button
                       type="submit"
                       class="btn btn-outline-danger btn-sm"
-                      onclick="return confirm('\'{{ u.username }}\' kullanıcısını silmek istediğinize emin misiniz?')"
+                      onclick="return window.handleConfirm(this, event, { message: '\"{{ u.username }}\" kullanıcısını silmek istediğinize emin misiniz?', confirmLabel: 'Sil', confirmVariant: 'danger' })"
                     >
                       Sil
                     </button>
@@ -928,7 +928,14 @@ content %}
     });
 
     async function delItem(id, value) {
-      if (!confirm(`Silinsin mi?\n${value}`)) return;
+      if (
+        !(await showConfirm({
+          message: `Silinsin mi?\n${value}`,
+          confirmLabel: "Sil",
+          confirmVariant: "danger",
+        }))
+      )
+        return;
       try {
         const r = await fetch(
           `/api/ref/${encodeURIComponent(current.type)}/${id}`,

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -288,8 +288,7 @@ block content %}
         confirmLabel: "Sil",
         confirmVariant: "danger",
       });
-      if (!confirmed)
-        return;
+      if (!confirmed) return;
       const id = row.dataset.id;
       deleteForm.setAttribute("action", `/admin/users/${id}/delete`);
       deleteForm.submit();

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -271,7 +271,7 @@ block content %}
   const btnDelete = document.getElementById("btnDeleteUser");
   const deleteForm = document.getElementById("deleteForm");
   if (btnDelete && deleteForm) {
-    btnDelete.addEventListener("click", (ev) => {
+    btnDelete.addEventListener("click", async (ev) => {
       ev.preventDefault();
       const row = getSelectedRow();
       if (!row) {
@@ -283,11 +283,12 @@ block content %}
         alert("Admin hesabı silinemez.");
         return;
       }
-      if (
-        !confirm(
-          `'${username}' kullanıcısını silmek istediğinize emin misiniz?`,
-        )
-      )
+      const confirmed = await showConfirm({
+        message: `"${username}" kullanıcısını silmek istediğinize emin misiniz?`,
+        confirmLabel: "Sil",
+        confirmVariant: "danger",
+      });
+      if (!confirmed)
         return;
       const id = row.dataset.id;
       deleteForm.setAttribute("action", `/admin/users/${id}/delete`);

--- a/templates/base.html
+++ b/templates/base.html
@@ -133,7 +133,61 @@
       </div>
     </div>
 
+    <!-- global alert modal -->
+    <div
+      class="modal fade"
+      id="globalAlertModal"
+      tabindex="-1"
+      aria-labelledby="globalAlertTitle"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="globalAlertTitle">Bilgi</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body" id="globalAlertBody"></div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" id="globalAlertOk" data-bs-dismiss="modal">
+              Tamam
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- global confirm modal -->
+    <div
+      class="modal fade"
+      id="globalConfirmModal"
+      tabindex="-1"
+      aria-labelledby="globalConfirmTitle"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="globalConfirmTitle">Onay</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body" id="globalConfirmBody"></div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" id="globalConfirmCancel" data-bs-dismiss="modal">
+              İptal
+            </button>
+            <button type="button" class="btn btn-primary" id="globalConfirmOk">
+              Onayla
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast-container position-fixed top-0 end-0 p-3" id="globalToastContainer"></div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', path='js/notifications.js') }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
     <script src="{{ url_for('static', path='js/picker.js') }}"></script>
     <script defer src="/static/js/selects.js"></script>


### PR DESCRIPTION
## Summary
- add shared Bootstrap modals and toast container to the base layout
- provide a notifications helper that replaces window.alert/confirm with styled Bootstrap dialogs
- update delete flows to use the new confirmation modal across admin and stock pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd137e7cf4832b8a294671fd99dc94