### PR TITLE
Remove unused stock transaction table

### DIFF
--- a/alembic/versions/e6c1d9b8f4d1_drop_stock_transactions_table.py
+++ b/alembic/versions/e6c1d9b8f4d1_drop_stock_transactions_table.py
@@ -1,0 +1,39 @@
+"""Drop unused stock_transactions table
+
+Revision ID: e6c1d9b8f4d1
+Revises: 1e4c12f4b1b9
+Create Date: 2025-02-17
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "e6c1d9b8f4d1"
+down_revision = "1e4c12f4b1b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "stock_transactions" in inspector.get_table_names():
+        op.drop_table("stock_transactions")
+
+
+def downgrade():
+    op.create_table(
+        "stock_transactions",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("donanim_tipi", sa.String(length=120), nullable=False),
+        sa.Column("islem", sa.String(length=16), nullable=False),
+        sa.Column("miktar", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("ifs_no", sa.String(length=64), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index(
+        "ix_stock_transactions_donanim_tipi",
+        "stock_transactions",
+        ["donanim_tipi"],
+    )

--- a/models.py
+++ b/models.py
@@ -477,18 +477,6 @@ class FaultRecord(Base):
         return data
 
 
-# Yeni stok hareketi tablosu
-class StockTransaction(Base):
-    __tablename__ = "stock_transactions"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    donanim_tipi: Mapped[str] = mapped_column(String(120), index=True)
-    islem: Mapped[str] = mapped_column(String(16))
-    miktar: Mapped[int] = mapped_column(Integer, default=0)
-    ifs_no: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    created_at: Mapped[str] = mapped_column(DateTime, server_default=func.now())
-
-
 class StockLog(Base):
     __tablename__ = "stock_logs"
     id = Column(Integer, primary_key=True, index=True)

--- a/sql/seed_stock_transactions.sql
+++ b/sql/seed_stock_transactions.sql
@@ -1,6 +1,0 @@
-INSERT INTO stock_transactions (donanim_tipi, islem, miktar, ifs_no)
-VALUES
-('Laptop', 'girdi', 10, 'IFS-1001'),
-('Laptop', 'cikti', 2,  'IFS-1002'),
-('Monitör', 'girdi', 8, 'IFS-2001'),
-('Monitör', 'hurda', 1, 'IFS-2002');

--- a/tests/test_stock_transactions_removed.py
+++ b/tests/test_stock_transactions_removed.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from pathlib import Path
+
+from sqlalchemy import inspect
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import models  # noqa: E402
+
+
+def test_stock_transactions_model_removed():
+    models.Base.metadata.create_all(models.engine)
+    try:
+        inspector = inspect(models.engine)
+        assert "stock_transactions" not in inspector.get_table_names()
+        assert not hasattr(models, "StockTransaction")
+    finally:
+        models.Base.metadata.drop_all(models.engine)


### PR DESCRIPTION
## Summary
- remove the unused StockTransaction ORM model and its seed data
- add an Alembic migration that drops the legacy stock_transactions table
- add a regression test to ensure the table/model stay removed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd15f82d60832ba19ec73a1cc10131