### PR TITLE
Adjust picker modal responsiveness

### DIFF
--- a/templates/product_add.html
+++ b/templates/product_add.html
@@ -202,18 +202,21 @@ content %}
     position: fixed;
     inset: 0;
     display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(15, 23, 42, 0.4);
+    align-items: stretch;
+    justify-content: flex-end;
+    background: rgba(15, 23, 42, 0.45);
     z-index: 1085;
   }
   .picker-card {
-    width: 420px;
-    max-width: 92vw;
+    width: 100%;
+    max-width: 480px;
+    height: 100%;
     background: #fff;
     border-radius: 14px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
   }
   .picker-head {
     display: flex;
@@ -257,8 +260,8 @@ content %}
     cursor: not-allowed;
   }
   .picker-list {
-    max-height: 320px;
     overflow: auto;
+    flex: 1 1 auto;
   }
   .picker-row {
     display: flex;
@@ -310,6 +313,29 @@ content %}
     justify-content: flex-end;
     gap: 8px;
     border-top: 1px solid #eef2f7;
+  }
+  @media (min-width: 641px) {
+    .picker-modal {
+      padding: 24px 32px;
+    }
+    .picker-list {
+      max-height: none;
+    }
+  }
+  @media (max-width: 640px) {
+    .picker-modal {
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+      background: rgba(15, 23, 42, 0.4);
+    }
+    .picker-card {
+      height: auto;
+      max-width: 92vw;
+    }
+    .picker-list {
+      max-height: 320px;
+    }
   }
 </style>
 


### PR DESCRIPTION
## Summary
- align the picker modal to the right with a translucent full-height overlay on larger screens
- resize the picker card for desktop layouts and make the list area scroll with full-height content
- preserve the centered modal behaviour on mobile by updating the small-screen media query

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd19ea60d0832ba40676cf17a0d5f5