### PR TITLE
Restrict admin edit permissions

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -128,11 +128,14 @@ def user_edit_post(
     email: str = Form(""),
     password: str = Form(""),
     is_admin: bool = Form(False),
+    user: SessionUser = Depends(current_user),
     db: Session = Depends(get_db),
 ):
     u = db.get(User, uid)
     if not u:
         raise HTTPException(404, "Kullanıcı bulunamadı")
+    if u.role == "admin" and user.id != u.id and user.username.lower() != "admin":
+        raise HTTPException(403, "Adminler birbirini güncelleyemez")
     u.username = username
     u.first_name = first_name
     u.last_name = last_name

--- a/tests/test_user_edit.py
+++ b/tests/test_user_edit.py
@@ -1,0 +1,87 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import pytest
+from fastapi import HTTPException
+
+import models
+from routes.admin import user_edit_post
+from security import SessionUser
+
+
+@pytest.fixture()
+def db_session():
+    models.Base.metadata.create_all(models.engine)
+    db = models.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        models.Base.metadata.drop_all(models.engine)
+
+
+def add_user(db, username, role="user"):
+    u = models.User(username=username, password_hash="x", role=role)
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def edit_user(
+    uid,
+    acting_user,
+    db,
+    username=None,
+    first_name="",
+    last_name="",
+    email="",
+    password="",
+    is_admin=None,
+):
+    target = db.get(models.User, uid)
+    return user_edit_post(
+        uid,
+        username=username or target.username,
+        first_name=first_name,
+        last_name=last_name,
+        email=email,
+        password=password,
+        is_admin=is_admin if is_admin is not None else target.role == "admin",
+        user=SessionUser(acting_user.id, acting_user.username, acting_user.role),
+        db=db,
+    )
+
+
+def test_admin_edit_permissions(db_session):
+    db = db_session
+    admin = add_user(db, "admin", "admin")
+    other_admin = add_user(db, "mod", "admin")
+    third_admin = add_user(db, "ops", "admin")
+    normal_user = add_user(db, "alice", "user")
+
+    # Admin can edit normal users
+    edit_user(normal_user.id, admin, db, first_name="Alice")
+    updated = db.get(models.User, normal_user.id)
+    assert updated.first_name == "Alice"
+
+    # Other admins cannot edit the primary admin
+    with pytest.raises(HTTPException):
+        edit_user(admin.id, other_admin, db, first_name="Root")
+
+    # Other admins cannot edit each other
+    with pytest.raises(HTTPException):
+        edit_user(third_admin.id, other_admin, db, first_name="Ops")
+
+    # Admin user can edit all other admins
+    edit_user(third_admin.id, admin, db, first_name="Operations")
+    refreshed = db.get(models.User, third_admin.id)
+    assert refreshed.first_name == "Operations"
+
+    # Admins can edit themselves
+    edit_user(other_admin.id, other_admin, db, first_name="Moderator")
+    assert db.get(models.User, other_admin.id).first_name == "Moderator"


### PR DESCRIPTION
## Summary
- restrict updates to admin accounts so only the root admin or the owner can modify them
- add tests covering admin edit permission scenarios

## Testing
- pytest tests/test_user_delete.py tests/test_user_edit.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2251e810832ba9594f00f5d4de2d