### PR TITLE
Fix mini picker delete endpoint resolution

### DIFF
--- a/static/js/mini-picker.js
+++ b/static/js/mini-picker.js
@@ -354,8 +354,29 @@
         confirmVariant: "danger",
       });
       if (!confirmed) return;
-      const url = `${current.endpoint}/${encodeURIComponent(row.dataset.id)}`;
-      const delRes = await fetch(url, { method: "DELETE" });
+
+      const id = row.dataset.id;
+      if (!id) {
+        console.warn("[mini-picker] Silinecek kayıt için id bulunamadı.");
+        alert("Silme başarısız!");
+        return;
+      }
+
+      const endpoint = current.endpoint || current.fallbackEndpoint || null;
+      if (!endpoint) {
+        console.warn(
+          "[mini-picker] Silme isteği için endpoint bulunamadı:",
+          current,
+        );
+        alert("Silme desteklenmiyor!");
+        return;
+      }
+
+      const baseUrl = new URL(endpoint, location.origin);
+      if (!baseUrl.pathname.endsWith("/")) baseUrl.pathname += "/";
+      baseUrl.pathname += encodeURIComponent(id);
+
+      const delRes = await fetch(baseUrl, { method: "DELETE" });
       if (delRes.ok) {
         row.remove();
         if (!$list.children.length)


### PR DESCRIPTION
## Summary
- ensure the mini picker resolves a valid endpoint before sending delete requests
- guard against missing row identifiers so the delete handler fails gracefully

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd233cac88832b8daf6bccd5ba1175