### PR TITLE
Fix bilgi photo preview not scrolling

### DIFF
--- a/static/js/bilgiler.js
+++ b/static/js/bilgiler.js
@@ -232,7 +232,10 @@
           typeof previewWrapper.scrollIntoView === "function" &&
           previewWrapper.isConnected
         ) {
-          previewWrapper.scrollIntoView({ behavior: "smooth", block: "nearest" });
+          previewWrapper.scrollIntoView({
+            behavior: "smooth",
+            block: "nearest",
+          });
         }
       }
     };

--- a/static/js/bilgiler.js
+++ b/static/js/bilgiler.js
@@ -218,7 +218,23 @@
     const reader = new FileReader();
     reader.onload = (ev) => {
       if (previewImg) previewImg.src = ev.target.result;
-      if (previewWrapper) previewWrapper.classList.remove("d-none");
+      if (previewWrapper) {
+        previewWrapper.classList.remove("d-none");
+        const scrollContainer =
+          previewWrapper.closest(".modal-body") ||
+          previewWrapper.closest(".modal-content");
+        if (scrollContainer && typeof scrollContainer.scrollTo === "function") {
+          scrollContainer.scrollTo({
+            top: scrollContainer.scrollHeight,
+            behavior: "smooth",
+          });
+        } else if (
+          typeof previewWrapper.scrollIntoView === "function" &&
+          previewWrapper.isConnected
+        ) {
+          previewWrapper.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        }
+      }
     };
     reader.readAsDataURL(file);
   }


### PR DESCRIPTION
## Summary
- ensure the bilgi photo preview section becomes visible by smoothly scrolling the modal body after rendering the preview
- keep the preview reveal responsive by falling back to scrollIntoView when the modal body is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd246d7580832b8d3f3161695a6722