### PR TITLE
Fix request lookups fallback and modal layout

### DIFF
--- a/static/js/talep.js
+++ b/static/js/talep.js
@@ -16,6 +16,7 @@
 
   // Basit cache
   const cache = {};
+  const numericIdPattern = /^\d+$/;
 
   const fetchErrorState = { lookup: false, model: false };
 
@@ -134,9 +135,11 @@
     const key = `model_${brandId}`;
     if (cache[key]) return cache[key];
     try {
-      const r = await fetch(
-        `/api/lookup/model?marka_id=${encodeURIComponent(brandId)}`,
-      );
+      const isNumeric = numericIdPattern.test(String(brandId));
+      const searchParam = isNumeric
+        ? `marka_id=${encodeURIComponent(brandId)}`
+        : `marka=${encodeURIComponent(brandId)}`;
+      const r = await fetch(`/api/lookup/model?${searchParam}`);
       if (!r.ok) {
         const text = await r.text().catch(() => "");
         throw new Error(text || `HTTP ${r.status}`);
@@ -338,12 +341,36 @@
 
       const donanim_tipi_id = Number(donanimSelect?.value || 0);
       const miktar = Number(miktarInput?.value || 0);
-      const marka_id = Number(markaSelect?.value || 0);
-      const model_id = Number(modelSelect?.value || 0);
+      const markaValue = markaSelect?.value ?? "";
+      const modelValue = modelSelect?.value ?? "";
+      const marka_id = numericIdPattern.test(markaValue)
+        ? Number(markaValue)
+        : 0;
+      const model_id = numericIdPattern.test(modelValue)
+        ? Number(modelValue)
+        : 0;
+      const markaOption = markaSelect?.selectedOptions?.[0] || null;
+      const modelOption = modelSelect?.selectedOptions?.[0] || null;
+      const markaLabel = markaOption?.textContent
+        ? markaOption.textContent.trim()
+        : "";
+      const modelLabel = modelOption?.textContent
+        ? modelOption.textContent.trim()
+        : "";
+      const marka_adi = marka_id > 0 ? null : markaLabel || null;
+      const model_adi = model_id > 0 ? null : modelLabel || null;
       const aciklama = aciklamaInput?.value.trim() || null;
 
       if (donanim_tipi_id && miktar > 0) {
-        lines.push({ donanim_tipi_id, miktar, marka_id, model_id, aciklama });
+        lines.push({
+          donanim_tipi_id,
+          miktar,
+          marka_id,
+          marka_adi,
+          model_id,
+          model_adi,
+          aciklama,
+        });
       }
     });
 

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -204,21 +204,14 @@ block title %}Talep Takip{% endblock %} {% block content %}
 </button>
 <button type="submit" class="btn btn-primary">Gönder</button>
 {% endset %} {% call modal( "talepModal", "Talep Aç", dialog_class="modal-xl",
-form_attrs={"id": "talepForm", "autocomplete": "off"},
-content_class="stack-lg", footer=talep_modal_footer, ) %}
+form_attrs={"id": "talepForm", "autocomplete": "off"}, content_class="stack-lg",
+footer=talep_modal_footer, ) %}
 <div class="stack-md">
   <!-- IFS -->
   <div class="env-grid" id="talep-ekle-grid">
     <div class="field span-2">
-      <label for="ifs_no"
-        >IFS No <span class="muted">(opsiyonel)</span></label
-      >
-      <input
-        id="ifs_no"
-        name="ifs_no"
-        class="ctrl"
-        placeholder="IFS-0001"
-      />
+      <label for="ifs_no">IFS No <span class="muted">(opsiyonel)</span></label>
+      <input id="ifs_no" name="ifs_no" class="ctrl" placeholder="IFS-0001" />
     </div>
   </div>
 
@@ -226,7 +219,11 @@ content_class="stack-lg", footer=talep_modal_footer, ) %}
   <div class="stack-sm">
     <div class="d-flex justify-content-between align-items-center">
       <label class="form-label m-0">Kalemler</label>
-      <button type="button" id="btnAddRow" class="btn btn-outline-secondary btn-sm">
+      <button
+        type="button"
+        id="btnAddRow"
+        class="btn btn-outline-secondary btn-sm"
+      >
         Satır Ekle
       </button>
     </div>
@@ -264,14 +261,7 @@ content_class="stack-lg", footer=talep_modal_footer, ) %}
 <div class="env-grid" id="talep-kapat-grid">
   <div class="field">
     <label for="tkAdet">Miktar</label>
-    <input
-      type="number"
-      id="tkAdet"
-      class="ctrl"
-      min="1"
-      value="1"
-      required
-    />
+    <input type="number" id="tkAdet" class="ctrl" min="1" value="1" required />
   </div>
   <div class="field">
     <label for="tkTur">Ürün Türü</label>
@@ -290,15 +280,8 @@ content_class="stack-lg", footer=talep_modal_footer, ) %}
     <select id="tkModel" class="ctrl"></select>
   </div>
   <div class="field span-2">
-    <label for="tkAciklama"
-      >Not <span class="muted">(opsiyonel)</span></label
-    >
-    <input
-      type="text"
-      id="tkAciklama"
-      class="ctrl"
-      placeholder="Ek bilgi"
-    />
+    <label for="tkAciklama">Not <span class="muted">(opsiyonel)</span></label>
+    <input type="text" id="tkAciklama" class="ctrl" placeholder="Ek bilgi" />
   </div>
 </div>
 {% endcall %}

--- a/templates/requests/list.html
+++ b/templates/requests/list.html
@@ -205,46 +205,50 @@ block title %}Talep Takip{% endblock %} {% block content %}
 <button type="submit" class="btn btn-primary">Gönder</button>
 {% endset %} {% call modal( "talepModal", "Talep Aç", dialog_class="modal-xl",
 form_attrs={"id": "talepForm", "autocomplete": "off"},
-footer=talep_modal_footer, ) %}
-<!-- IFS -->
-<div class="env-grid" id="talep-ekle-grid">
-  <div class="field span-2">
-    <label for="ifs_no"
-      >IFS No <span class="muted">(opsiyonel)</span></label
-    >
-    <input
-      id="ifs_no"
-      name="ifs_no"
-      class="ctrl"
-      placeholder="IFS-0001"
-    />
+content_class="stack-lg", footer=talep_modal_footer, ) %}
+<div class="stack-md">
+  <!-- IFS -->
+  <div class="env-grid" id="talep-ekle-grid">
+    <div class="field span-2">
+      <label for="ifs_no"
+        >IFS No <span class="muted">(opsiyonel)</span></label
+      >
+      <input
+        id="ifs_no"
+        name="ifs_no"
+        class="ctrl"
+        placeholder="IFS-0001"
+      />
+    </div>
   </div>
-</div>
 
-<!-- Kalemler tablosu -->
-<div class="d-flex justify-content-between align-items-center mb-2">
-  <label class="form-label m-0">Kalemler</label>
-  <button type="button" id="btnAddRow" class="btn btn-outline-secondary btn-sm">
-    Satır Ekle
-  </button>
-</div>
+  <!-- Kalemler tablosu -->
+  <div class="stack-sm">
+    <div class="d-flex justify-content-between align-items-center">
+      <label class="form-label m-0">Kalemler</label>
+      <button type="button" id="btnAddRow" class="btn btn-outline-secondary btn-sm">
+        Satır Ekle
+      </button>
+    </div>
 
-<div class="table-responsive">
-  <table class="table table-sm align-middle table-rounded" id="rowsTable">
-    <thead>
-      <tr>
-        <th style="width: 20%">Donanım Tipi</th>
-        <th style="width: 8%">Miktar</th>
-        <th style="width: 18%">Marka</th>
-        <th style="width: 18%">Model</th>
-        <th style="width: 28%">Açıklama</th>
-        <th style="width: 8%"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <!-- JS dolduracak -->
-    </tbody>
-  </table>
+    <div class="table-responsive">
+      <table class="table table-sm align-middle table-rounded" id="rowsTable">
+        <thead>
+          <tr>
+            <th style="width: 20%">Donanım Tipi</th>
+            <th style="width: 8%">Miktar</th>
+            <th style="width: 18%">Marka</th>
+            <th style="width: 18%">Model</th>
+            <th style="width: 28%">Açıklama</th>
+            <th style="width: 8%"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <!-- JS dolduracak -->
+        </tbody>
+      </table>
+    </div>
+  </div>
 </div>
 {% endcall %}
 
@@ -255,7 +259,7 @@ footer=talep_modal_footer, ) %}
 </button>
 <button type="submit" class="btn btn-primary">Kaydet</button>
 {% endset %} {% call modal( "talepKapatModal", "Stok Girişi", form_attrs={"id":
-"talepKapatForm"}, footer=talep_kapat_footer, ) %}
+"talepKapatForm"}, content_class="stack-lg", footer=talep_kapat_footer, ) %}
 <input type="hidden" id="tkTalepId" />
 <div class="env-grid" id="talep-kapat-grid">
   <div class="field">


### PR DESCRIPTION
## Summary
- restore legacy lookup fallbacks for brand and model endpoints so empty tables still return values
- allow talep API and front-end to carry brand/model names when ids are unavailable and improve model fetching
- refresh request modals with stacked layout spacing for the updated design system

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd24d71fa0832bb02497a23a1bff92