### PR TITLE
Add modal-based HTML error handling for browser requests

### DIFF
--- a/templates/error_modal.html
+++ b/templates/error_modal.html
@@ -1,47 +1,48 @@
-{% extends "base.html" %}
-{% block title %}{{ error_title }} · Hata{% endblock %}
-{% block content %}
-  <div class="min-vh-60 d-flex align-items-center justify-content-center py-5">
-    <div class="soft-card shadow-sm p-4 text-center error-modal-card">
-      <div class="display-4 text-danger mb-3">
-        <i class="bi bi-exclamation-triangle-fill"></i>
-      </div>
-      <p class="text-uppercase small text-muted mb-1">{{ status_code }}</p>
-      <h1 class="h4 fw-semibold mb-3">{{ error_title }}</h1>
-      <p class="text-muted mb-4">{{ error_message }}</p>
-      <div class="d-flex flex-column flex-sm-row gap-2 justify-content-center">
-        <button type="button" class="btn btn-outline-secondary" onclick="history.back()">
-          <i class="bi bi-arrow-left"></i>
-          Önceki Sayfa
-        </button>
-        <a class="btn btn-danger" href="{{ back_url }}">
-          <i class="bi bi-house"></i>
-          Ana Sayfaya Dön
-        </a>
-      </div>
+{% extends "base.html" %} {% block title %}{{ error_title }} · Hata{% endblock
+%} {% block content %}
+<div class="min-vh-60 d-flex align-items-center justify-content-center py-5">
+  <div class="soft-card shadow-sm p-4 text-center error-modal-card">
+    <div class="display-4 text-danger mb-3">
+      <i class="bi bi-exclamation-triangle-fill"></i>
+    </div>
+    <p class="text-uppercase small text-muted mb-1">{{ status_code }}</p>
+    <h1 class="h4 fw-semibold mb-3">{{ error_title }}</h1>
+    <p class="text-muted mb-4">{{ error_message }}</p>
+    <div class="d-flex flex-column flex-sm-row gap-2 justify-content-center">
+      <button
+        type="button"
+        class="btn btn-outline-secondary"
+        onclick="history.back()"
+      >
+        <i class="bi bi-arrow-left"></i>
+        Önceki Sayfa
+      </button>
+      <a class="btn btn-danger" href="{{ back_url }}">
+        <i class="bi bi-house"></i>
+        Ana Sayfaya Dön
+      </a>
     </div>
   </div>
-  <style>
-    .error-modal-card {
-      max-width: 420px;
-      background: rgba(255, 255, 255, 0.9);
-      backdrop-filter: blur(6px);
+</div>
+<style>
+  .error-modal-card {
+    max-width: 420px;
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(6px);
+  }
+  body.theme-dark .error-modal-card {
+    background: rgba(33, 37, 41, 0.85);
+  }
+</style>
+{% endblock %} {% block scripts %} {{ super() }}
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    if (window.showAlert) {
+      window.showAlert({{ error_message|tojson }}, {
+        title: {{ error_title|tojson }},
+        variant: "danger",
+      });
     }
-    body.theme-dark .error-modal-card {
-      background: rgba(33, 37, 41, 0.85);
-    }
-  </style>
-{% endblock %}
-{% block scripts %}
-  {{ super() }}
-  <script>
-    document.addEventListener("DOMContentLoaded", () => {
-      if (window.showAlert) {
-        window.showAlert({{ error_message|tojson }}, {
-          title: {{ error_title|tojson }},
-          variant: "danger",
-        });
-      }
-    });
-  </script>
+  });
+</script>
 {% endblock %}

--- a/templates/error_modal.html
+++ b/templates/error_modal.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block title %}{{ error_title }} · Hata{% endblock %}
+{% block content %}
+  <div class="min-vh-60 d-flex align-items-center justify-content-center py-5">
+    <div class="soft-card shadow-sm p-4 text-center error-modal-card">
+      <div class="display-4 text-danger mb-3">
+        <i class="bi bi-exclamation-triangle-fill"></i>
+      </div>
+      <p class="text-uppercase small text-muted mb-1">{{ status_code }}</p>
+      <h1 class="h4 fw-semibold mb-3">{{ error_title }}</h1>
+      <p class="text-muted mb-4">{{ error_message }}</p>
+      <div class="d-flex flex-column flex-sm-row gap-2 justify-content-center">
+        <button type="button" class="btn btn-outline-secondary" onclick="history.back()">
+          <i class="bi bi-arrow-left"></i>
+          Önceki Sayfa
+        </button>
+        <a class="btn btn-danger" href="{{ back_url }}">
+          <i class="bi bi-house"></i>
+          Ana Sayfaya Dön
+        </a>
+      </div>
+    </div>
+  </div>
+  <style>
+    .error-modal-card {
+      max-width: 420px;
+      background: rgba(255, 255, 255, 0.9);
+      backdrop-filter: blur(6px);
+    }
+    body.theme-dark .error-modal-card {
+      background: rgba(33, 37, 41, 0.85);
+    }
+  </style>
+{% endblock %}
+{% block scripts %}
+  {{ super() }}
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      if (window.showAlert) {
+        window.showAlert({{ error_message|tojson }}, {
+          title: {{ error_title|tojson }},
+          variant: "danger",
+        });
+      }
+    });
+  </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add helper functions to render friendly HTML error responses for browser requests
- serve a new template that shows errors in a styled card and triggers the global alert modal
- keep API endpoints returning JSON responses for non-HTML clients

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e362931430832b831f802f54fe6062