### PR TITLE
Fix bilgi modal photo preview layout

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1263,6 +1263,47 @@ tr[data-href] > td:first-child {
   width: 100%;
   object-fit: cover;
 }
+
+.bilgi-photo-preview-wrapper {
+  background-color: var(--bs-light, #f8f9fa);
+  border: 1px dashed var(--color-border, rgba(0, 0, 0, 0.1));
+  border-radius: var(--radius-sm, 0.5rem);
+  padding: 0.75rem;
+  max-height: 50vh;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bilgi-photo-preview-container {
+  max-height: 40vh;
+  overflow: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.bilgi-photo-preview-container::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.bilgi-photo-preview-container::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.2);
+  border-radius: 999px;
+}
+
+.bilgi-photo-preview-container::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+.bilgi-photo-preview-image {
+  max-width: 100%;
+  max-height: 100%;
+  height: auto;
+  width: auto;
+  object-fit: contain;
+}
 /* =============================================================================
    ENVANTER SAYFA DÜZELTMELERİ - TEK DOSYA
    Bu kodu static/css/custom.css dosyasının EN SONUNA ekleyin

--- a/templates/bilgiler/index.html
+++ b/templates/bilgiler/index.html
@@ -162,13 +162,21 @@ content %}
             <div class="form-text">
               En fazla 5MB. Dosya türleri: JPG, PNG veya GIF.
             </div>
-            <div class="mt-3 d-none" id="bilgiPhotoPreviewWrapper">
-              <img
-                src=""
-                alt="Fotoğraf önizlemesi"
-                class="img-fluid rounded shadow-sm"
-                id="bilgiPhotoPreview"
-              />
+            <div
+              class="mt-3 d-none bilgi-photo-preview-wrapper"
+              id="bilgiPhotoPreviewWrapper"
+            >
+              <div class="bilgi-photo-preview-container">
+                <img
+                  src=""
+                  alt="Fotoğraf önizlemesi"
+                  class="bilgi-photo-preview-image rounded shadow-sm"
+                  id="bilgiPhotoPreview"
+                />
+              </div>
+              <div class="form-text mt-2">
+                Fotoğrafı kaydırarak tamamını görüntüleyebilirsiniz.
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Wrap the bilgi modal photo preview in a dedicated container with helper text so the full image remains accessible
- Add CSS constraints and scrolling for the preview to prevent the modal footer from being pushed off screen

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e366897010832b8fe5ece10942e8e5