### PR TITLE
Unify modal infrastructure for asset workflows

### DIFF
--- a/static/css/modal-ux.css
+++ b/static/css/modal-ux.css
@@ -1,119 +1,31 @@
-.modal-ux .modal-header {
-  background: linear-gradient(90deg, #0ea5ea, #2b6cb0);
-  color: #fff;
-  border-bottom: none;
-  border-top-left-radius: 0.8rem;
-  border-top-right-radius: 0.8rem;
+.modal-ux{border:0;border-radius:.9rem;box-shadow:0 12px 36px rgba(0,0,0,.14)}
+.modal-ux .modal-header{color:#fff;border:0;border-top-left-radius:.9rem;border-top-right-radius:.9rem;padding:18px 22px}
+.modal-ux .modal-title{margin:0}
+.modal-ux .eyebrow{letter-spacing:.14em;font-weight:700;opacity:.9}
+.modal-ux .subtitle{opacity:.95;margin-top:4px}
+.modal-ux .form-label{font-weight:600}
+.modal-ux .form-select,.modal-ux .form-control{height:44px}
+.modal-ux .btn-primary{border:0}
+.modal-ux .info-alert{background:#eff6ff;border:1px solid #dbeafe;border-radius:.6rem;padding:.6rem .8rem;color:#1e3a8a;font-size:.9rem}
+.modal-ux .help-text{font-size:.85rem;color:#6b7280;margin-top:4px}
+
+/* Tema renkleri */
+.modal-ux[data-theme="purple"] .modal-header{
+  background: linear-gradient(90deg,#7c3aed,#9333ea);
+}
+.modal-ux[data-theme="orange"] .modal-header{
+  background: linear-gradient(90deg,#f59e0b,#ea580c);
+}
+.modal-ux[data-theme="blue"] .modal-header{
+  background: linear-gradient(90deg,#0ea5ea,#2b6cb0);
 }
 
-.modal-ux .modal-header .modal-title {
-  font-weight: 600;
-}
+/* Grid */
+.form-grid{display:grid;grid-template-columns:1fr 1fr;gap:20px}
+.form-grid .col-2{grid-column:1 / -1}
+@media (max-width: 992px){ .form-grid{grid-template-columns:1fr} }
 
-.modal-ux .modal-header .modal-subtitle {
-  margin-bottom: 0;
-  color: rgba(255, 255, 255, 0.85);
-  font-size: 0.95rem;
-}
-
-.modal-ux .modal-content {
-  border: 0;
-  border-radius: 0.8rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
-}
-
-.modal-ux .modal-body {
-  padding: 1.75rem;
-}
-
-.modal-ux .modal-footer {
-  border-top: none;
-  padding: 1.5rem;
-  background-color: #f8fafc;
-  border-bottom-left-radius: 0.8rem;
-  border-bottom-right-radius: 0.8rem;
-}
-
-.modal-ux .form-label {
-  font-weight: 600;
-}
-
-.modal-ux .form-select,
-.modal-ux .form-control {
-  height: 44px;
-  border-radius: 0.55rem;
-}
-
-.modal-ux .form-control[type="number"] {
-  padding-right: 1rem;
-}
-
-.modal-ux .btn-primary {
-  background: linear-gradient(90deg, #7c3aed, #9333ea);
-  border: 0;
-  box-shadow: 0 10px 20px rgba(124, 58, 237, 0.25);
-}
-
-.modal-ux .btn-primary:hover,
-.modal-ux .btn-primary:focus {
-  filter: brightness(0.95);
-}
-
-.form-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 20px;
-}
-
-.form-grid .col-span-2 {
-  grid-column: span 2;
-}
-
-@media (max-width: 992px) {
-  .form-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .form-grid .col-span-2 {
-    grid-column: span 1;
-  }
-}
-
-.tab-lite {
-  display: inline-flex;
-  gap: 12px;
-  padding: 6px;
-  background-color: #eef2ff;
-  border-radius: 999px;
-  margin-bottom: 18px;
-}
-
-.tab-lite .btn {
-  border-radius: 999px;
-  padding: 0.35rem 0.95rem;
-  border: 1px solid transparent;
-  background: transparent;
-  color: #4338ca;
-  font-weight: 600;
-}
-
-.tab-lite .btn.active {
-  background: #4338ca;
-  color: #fff;
-  border-color: #4338ca;
-  box-shadow: 0 8px 20px rgba(67, 56, 202, 0.25);
-}
-
-.help-text {
-  font-size: 0.85rem;
-  color: #6b7280;
-}
-
-.modal-ux .modal-body .section-title {
-  font-size: 0.95rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #64748b;
-  margin-bottom: 0.75rem;
-}
+/* Sekmeli gövde (stok atama gibi) */
+.tab-lite{display:flex;gap:12px;margin-bottom:14px}
+.tab-lite .btn{border-radius:999px;padding:.35rem .9rem;border:1px solid #e5e7eb;background:#fff}
+.tab-lite .btn.active{background:#eef2ff;border-color:#c7d2fe;color:#4338ca}

--- a/static/css/modal-ux.css
+++ b/static/css/modal-ux.css
@@ -1,31 +1,91 @@
-.modal-ux{border:0;border-radius:.9rem;box-shadow:0 12px 36px rgba(0,0,0,.14)}
-.modal-ux .modal-header{color:#fff;border:0;border-top-left-radius:.9rem;border-top-right-radius:.9rem;padding:18px 22px}
-.modal-ux .modal-title{margin:0}
-.modal-ux .eyebrow{letter-spacing:.14em;font-weight:700;opacity:.9}
-.modal-ux .subtitle{opacity:.95;margin-top:4px}
-.modal-ux .form-label{font-weight:600}
-.modal-ux .form-select,.modal-ux .form-control{height:44px}
-.modal-ux .btn-primary{border:0}
-.modal-ux .info-alert{background:#eff6ff;border:1px solid #dbeafe;border-radius:.6rem;padding:.6rem .8rem;color:#1e3a8a;font-size:.9rem}
-.modal-ux .help-text{font-size:.85rem;color:#6b7280;margin-top:4px}
+.modal-ux {
+  border: 0;
+  border-radius: 0.9rem;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.14);
+}
+.modal-ux .modal-header {
+  color: #fff;
+  border: 0;
+  border-top-left-radius: 0.9rem;
+  border-top-right-radius: 0.9rem;
+  padding: 18px 22px;
+}
+.modal-ux .modal-title {
+  margin: 0;
+}
+.modal-ux .eyebrow {
+  letter-spacing: 0.14em;
+  font-weight: 700;
+  opacity: 0.9;
+}
+.modal-ux .subtitle {
+  opacity: 0.95;
+  margin-top: 4px;
+}
+.modal-ux .form-label {
+  font-weight: 600;
+}
+.modal-ux .form-select,
+.modal-ux .form-control {
+  height: 44px;
+}
+.modal-ux .btn-primary {
+  border: 0;
+}
+.modal-ux .info-alert {
+  background: #eff6ff;
+  border: 1px solid #dbeafe;
+  border-radius: 0.6rem;
+  padding: 0.6rem 0.8rem;
+  color: #1e3a8a;
+  font-size: 0.9rem;
+}
+.modal-ux .help-text {
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin-top: 4px;
+}
 
 /* Tema renkleri */
-.modal-ux[data-theme="purple"] .modal-header{
-  background: linear-gradient(90deg,#7c3aed,#9333ea);
+.modal-ux[data-theme="purple"] .modal-header {
+  background: linear-gradient(90deg, #7c3aed, #9333ea);
 }
-.modal-ux[data-theme="orange"] .modal-header{
-  background: linear-gradient(90deg,#f59e0b,#ea580c);
+.modal-ux[data-theme="orange"] .modal-header {
+  background: linear-gradient(90deg, #f59e0b, #ea580c);
 }
-.modal-ux[data-theme="blue"] .modal-header{
-  background: linear-gradient(90deg,#0ea5ea,#2b6cb0);
+.modal-ux[data-theme="blue"] .modal-header {
+  background: linear-gradient(90deg, #0ea5ea, #2b6cb0);
 }
 
 /* Grid */
-.form-grid{display:grid;grid-template-columns:1fr 1fr;gap:20px}
-.form-grid .col-2{grid-column:1 / -1}
-@media (max-width: 992px){ .form-grid{grid-template-columns:1fr} }
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+.form-grid .col-2 {
+  grid-column: 1 / -1;
+}
+@media (max-width: 992px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+}
 
 /* Sekmeli gövde (stok atama gibi) */
-.tab-lite{display:flex;gap:12px;margin-bottom:14px}
-.tab-lite .btn{border-radius:999px;padding:.35rem .9rem;border:1px solid #e5e7eb;background:#fff}
-.tab-lite .btn.active{background:#eef2ff;border-color:#c7d2fe;color:#4338ca}
+.tab-lite {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.tab-lite .btn {
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+}
+.tab-lite .btn.active {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+  color: #4338ca;
+}

--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -1,12 +1,14 @@
 // basit sekme davranışı: .tab-lite içindeki .btn'lere data-target="#id"
-document.addEventListener('click', (e)=>{
-  const btn = e.target.closest('.tab-lite .btn[data-target]');
-  if(!btn) return;
-  const wrap = btn.closest('.tabbed');
-  if(!wrap) return;
-  wrap.querySelectorAll('.tab-lite .btn').forEach(b=>b.classList.remove('active'));
-  btn.classList.add('active');
+document.addEventListener("click", (e) => {
+  const btn = e.target.closest(".tab-lite .btn[data-target]");
+  if (!btn) return;
+  const wrap = btn.closest(".tabbed");
+  if (!wrap) return;
+  wrap
+    .querySelectorAll(".tab-lite .btn")
+    .forEach((b) => b.classList.remove("active"));
+  btn.classList.add("active");
   const target = btn.dataset.target;
-  wrap.querySelectorAll('.tab-pane').forEach(p=>p.classList.add('d-none'));
-  wrap.querySelector(target)?.classList.remove('d-none');
+  wrap.querySelectorAll(".tab-pane").forEach((p) => p.classList.add("d-none"));
+  wrap.querySelector(target)?.classList.remove("d-none");
 });

--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -1,0 +1,12 @@
+// basit sekme davranışı: .tab-lite içindeki .btn'lere data-target="#id"
+document.addEventListener('click', (e)=>{
+  const btn = e.target.closest('.tab-lite .btn[data-target]');
+  if(!btn) return;
+  const wrap = btn.closest('.tabbed');
+  if(!wrap) return;
+  wrap.querySelectorAll('.tab-lite .btn').forEach(b=>b.classList.remove('active'));
+  btn.classList.add('active');
+  const target = btn.dataset.target;
+  wrap.querySelectorAll('.tab-pane').forEach(p=>p.classList.add('d-none'));
+  wrap.querySelector(target)?.classList.remove('d-none');
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -195,6 +195,7 @@
     <script src="{{ url_for('static', path='js/actions.js') }}"></script>
     <script src="{{ url_for('static', path='js/faults.js') }}"></script>
     <script src="{{ url_for('static', path='js/unified-filters.js') }}"></script>
+    <script defer src="{{ url_for('static', path='js/modals.js') }}"></script>
   {% block scripts %}
   <script>
 document.addEventListener("DOMContentLoaded", () => {

--- a/templates/components/form_macros.html
+++ b/templates/components/form_macros.html
@@ -1,24 +1,49 @@
-{% macro select(name, label, options, value='', required=False, placeholder='Seçiniz...', hint=None) -%}
+{% macro select(name, label, options, value='', required=False,
+placeholder='Seçiniz...', hint=None) -%}
 <div>
   <label class="form-label">{{ label }}</label>
-  <select class="form-select" name="{{ name }}" {% if required %}required{% endif %}>
+  <select
+    class="form-select"
+    name="{{ name }}"
+    {%
+    if
+    required
+    %}required{%
+    endif
+    %}
+  >
     <option value="">{{ placeholder }}</option>
     {% for o in options %}
-      <option value="{{ o.id }}" {% if value==o.id %}selected{% endif %}>{{ o.name }}</option>
+    <option value="{{ o.id }}" {% if value="" ="o.id" %}selected{% endif %}>
+      {{ o.name }}
+    </option>
     {% endfor %}
   </select>
-  {% if hint %}<div class="help-text">{{ hint }}</div>{% endif %}
+  {% if hint %}
+  <div class="help-text">{{ hint }}</div>
+  {% endif %}
 </div>
-{%- endmacro %}
-
-{% macro input(name, label, type='text', value='', required=False, placeholder='', hint=None) -%}
+{%- endmacro %} {% macro input(name, label, type='text', value='',
+required=False, placeholder='', hint=None) -%}
 <div>
   <label class="form-label">{{ label }}</label>
-  <input class="form-control" type="{{ type }}" name="{{ name }}" value="{{ value }}" placeholder="{{ placeholder }}" {% if required %}required{% endif %}/>
-  {% if hint %}<div class="help-text">{{ hint }}</div>{% endif %}
+  <input
+    class="form-control"
+    type="{{ type }}"
+    name="{{ name }}"
+    value="{{ value }}"
+    placeholder="{{ placeholder }}"
+    {%
+    if
+    required
+    %}required{%
+    endif
+    %}
+  />
+  {% if hint %}
+  <div class="help-text">{{ hint }}</div>
+  {% endif %}
 </div>
-{%- endmacro %}
-
-{% macro info(text) -%}
+{%- endmacro %} {% macro info(text) -%}
 <div class="info-alert"><i class="bi bi-info-circle"></i> {{ text }}</div>
 {%- endmacro %}

--- a/templates/components/form_macros.html
+++ b/templates/components/form_macros.html
@@ -1,0 +1,24 @@
+{% macro select(name, label, options, value='', required=False, placeholder='Seçiniz...', hint=None) -%}
+<div>
+  <label class="form-label">{{ label }}</label>
+  <select class="form-select" name="{{ name }}" {% if required %}required{% endif %}>
+    <option value="">{{ placeholder }}</option>
+    {% for o in options %}
+      <option value="{{ o.id }}" {% if value==o.id %}selected{% endif %}>{{ o.name }}</option>
+    {% endfor %}
+  </select>
+  {% if hint %}<div class="help-text">{{ hint }}</div>{% endif %}
+</div>
+{%- endmacro %}
+
+{% macro input(name, label, type='text', value='', required=False, placeholder='', hint=None) -%}
+<div>
+  <label class="form-label">{{ label }}</label>
+  <input class="form-control" type="{{ type }}" name="{{ name }}" value="{{ value }}" placeholder="{{ placeholder }}" {% if required %}required{% endif %}/>
+  {% if hint %}<div class="help-text">{{ hint }}</div>{% endif %}
+</div>
+{%- endmacro %}
+
+{% macro info(text) -%}
+<div class="info-alert"><i class="bi bi-info-circle"></i> {{ text }}</div>
+{%- endmacro %}

--- a/templates/components/modal_base.html
+++ b/templates/components/modal_base.html
@@ -1,39 +1,50 @@
 {% macro close_btn() -%}
-<button
-  type="button"
-  class="btn-close"
-  data-bs-dismiss="modal"
-  aria-label="Kapat"
-></button>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
 {%- endmacro %}
 
-<div
-  class="modal fade"
-  id="{% block modal_id %}{% endblock %}"
-  tabindex="-1"
-  aria-hidden="true"
->
-  <div
-    class="modal-dialog modal-dialog-centered {% block modal_dialog_classes %}modal-xl{% endblock %}"
-  >
-    <div class="modal-content modal-ux">
-      <div class="modal-header align-items-start gap-3">
-        <div class="flex-grow-1">
-          <h5 class="modal-title mb-1">
-            {% block modal_title %}{% endblock %}
-          </h5>
-          {% block modal_subtitle %}{% endblock %}
+<div class="modal fade" id="{% block modal_id %}{% endblock %}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered {% block modal_dialog_classes %}modal-xl{% endblock %}">
+    <div class="modal-content modal-ux" data-theme="{% block modal_theme %}{{ theme|default('purple') }}{% endblock %}">
+      <div class="modal-header">
+        <div>
+          {% set eyebrow_content -%}
+            {% block modal_eyebrow %}{% if eyebrow is defined %}{{ eyebrow }}{% endif %}{% endblock %}
+          {%- endset %}
+          {% if eyebrow_content|trim %}
+          <div class="eyebrow">{{ eyebrow_content|trim|safe }}</div>
+          {% endif %}
+
+          {% set title_content -%}
+            {% block modal_title %}{% if title is defined %}{{ title }}{% endif %}{% endblock %}
+          {%- endset %}
+          {% if title_content|trim %}
+          <h5 class="modal-title">{{ title_content|trim|safe }}</h5>
+          {% endif %}
+
+          {% set subtitle_content -%}
+            {% block modal_subtitle %}{% if subtitle is defined %}{{ subtitle }}{% endif %}{% endblock %}
+          {%- endset %}
+          {% if subtitle_content|trim %}
+          <div class="subtitle">{{ subtitle_content|trim|safe }}</div>
+          {% endif %}
         </div>
-        <div class="flex-shrink-0 d-flex align-items-start">
-          {% block modal_header_actions %}{{ close_btn() }}{% endblock %}
-        </div>
+        {% block modal_header_actions %}{{ close_btn() }}{% endblock %}
       </div>
-      <div class="modal-body">{% block modal_body %}{% endblock %}</div>
+
+      <div class="modal-body">
+        {% block body %}
+          {% block modal_body %}{% endblock %}
+        {% endblock %}
+      </div>
+
       <div class="modal-footer">
-        {% block modal_footer %}
-        <button type="button" class="btn btn-light" data-bs-dismiss="modal">
-          Kapat
-        </button>
+        {% block footer %}
+          {% block modal_footer %}
+            <button type="button" class="btn btn-light" data-bs-dismiss="modal">İptal</button>
+            <button type="submit" class="btn btn-primary"{% if form_id is defined %} form="{{ form_id }}"{% endif %}>
+              {{ submit_text|default('Kaydet') }}
+            </button>
+          {% endblock %}
         {% endblock %}
       </div>
     </div>

--- a/templates/components/modal_base.html
+++ b/templates/components/modal_base.html
@@ -1,30 +1,38 @@
 {% macro close_btn() -%}
-  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+<button
+  type="button"
+  class="btn-close"
+  data-bs-dismiss="modal"
+  aria-label="Kapat"
+></button>
 {%- endmacro %}
 
-<div class="modal fade" id="{% block modal_id %}{% endblock %}" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered {% block modal_dialog_classes %}modal-xl{% endblock %}">
-    <div class="modal-content modal-ux" data-theme="{% block modal_theme %}{{ theme|default('purple') }}{% endblock %}">
+<div
+  class="modal fade"
+  id="{% block modal_id %}{% endblock %}"
+  tabindex="-1"
+  aria-hidden="true"
+>
+  <div
+    class="modal-dialog modal-dialog-centered {% block modal_dialog_classes %}modal-xl{% endblock %}"
+  >
+    <div
+      class="modal-content modal-ux"
+      data-theme="{% block modal_theme %}{{ theme|default('purple') }}{% endblock %}"
+    >
       <div class="modal-header">
         <div>
-          {% set eyebrow_content -%}
-            {% block modal_eyebrow %}{% if eyebrow is defined %}{{ eyebrow }}{% endif %}{% endblock %}
-          {%- endset %}
-          {% if eyebrow_content|trim %}
+          {% set eyebrow_content -%} {% block modal_eyebrow %}{% if eyebrow is
+          defined %}{{ eyebrow }}{% endif %}{% endblock %} {%- endset %} {% if
+          eyebrow_content|trim %}
           <div class="eyebrow">{{ eyebrow_content|trim|safe }}</div>
-          {% endif %}
-
-          {% set title_content -%}
-            {% block modal_title %}{% if title is defined %}{{ title }}{% endif %}{% endblock %}
-          {%- endset %}
+          {% endif %} {% set title_content -%} {% block modal_title %}{% if
+          title is defined %}{{ title }}{% endif %}{% endblock %} {%- endset %}
           {% if title_content|trim %}
           <h5 class="modal-title">{{ title_content|trim|safe }}</h5>
-          {% endif %}
-
-          {% set subtitle_content -%}
-            {% block modal_subtitle %}{% if subtitle is defined %}{{ subtitle }}{% endif %}{% endblock %}
-          {%- endset %}
-          {% if subtitle_content|trim %}
+          {% endif %} {% set subtitle_content -%} {% block modal_subtitle %}{%
+          if subtitle is defined %}{{ subtitle }}{% endif %}{% endblock %} {%-
+          endset %} {% if subtitle_content|trim %}
           <div class="subtitle">{{ subtitle_content|trim|safe }}</div>
           {% endif %}
         </div>
@@ -32,20 +40,31 @@
       </div>
 
       <div class="modal-body">
-        {% block body %}
-          {% block modal_body %}{% endblock %}
-        {% endblock %}
+        {% block body %} {% block modal_body %}{% endblock %} {% endblock %}
       </div>
 
       <div class="modal-footer">
-        {% block footer %}
-          {% block modal_footer %}
-            <button type="button" class="btn btn-light" data-bs-dismiss="modal">İptal</button>
-            <button type="submit" class="btn btn-primary"{% if form_id is defined %} form="{{ form_id }}"{% endif %}>
-              {{ submit_text|default('Kaydet') }}
-            </button>
-          {% endblock %}
-        {% endblock %}
+        {% block footer %} {% block modal_footer %}
+        <button type="button" class="btn btn-light" data-bs-dismiss="modal">
+          İptal
+        </button>
+        <button
+          type="submit"
+          class="btn btn-primary"
+          {%
+          if
+          form_id
+          is
+          defined
+          %}
+          form="{{ form_id }}"
+          {%
+          endif
+          %}
+        >
+          {{ submit_text|default('Kaydet') }}
+        </button>
+        {% endblock %} {% endblock %}
       </div>
     </div>
   </div>

--- a/templates/inventory/_assign_modal.html
+++ b/templates/inventory/_assign_modal.html
@@ -1,11 +1,13 @@
-{% extends "components/modal_base.html" %} {% block modal_id %}assignModal{%
-endblock %} {% block modal_dialog_classes %}modal-lg modal-dialog-scrollable{%
-endblock %} {% block modal_title %}Envanter Atama{% endblock %} {% block
-modal_subtitle %}
-<p class="modal-subtitle">
-  Envanteri ilgili personel ve departmanla eşleştirin.
-</p>
-{% endblock %} {% block modal_body %}
+{% extends "components/modal_base.html" %}
+
+{% block modal_id %}assignModal{% endblock %}
+{% block modal_dialog_classes %}modal-lg modal-dialog-scrollable{% endblock %}
+{% block modal_theme %}blue{% endblock %}
+{% block modal_eyebrow %}ENVANTER YÖNETİMİ{% endblock %}
+{% block modal_title %}Envanter Atama{% endblock %}
+{% block modal_subtitle %}Envanteri ilgili personel ve departmanla eşleştirin.{% endblock %}
+
+{% block modal_body %}
 <form id="assignForm" class="form-grid" novalidate>
   <input type="hidden" name="item_id" id="assign_item_id" />
   <div class="field">
@@ -48,7 +50,9 @@ modal_subtitle %}
     />
   </div>
 </form>
-{% endblock %} {% block modal_footer %}
+{% endblock %}
+
+{% block modal_footer %}
 <button type="button" class="btn btn-light" data-bs-dismiss="modal">
   Kapat
 </button>

--- a/templates/inventory/_assign_modal.html
+++ b/templates/inventory/_assign_modal.html
@@ -1,13 +1,9 @@
-{% extends "components/modal_base.html" %}
-
-{% block modal_id %}assignModal{% endblock %}
-{% block modal_dialog_classes %}modal-lg modal-dialog-scrollable{% endblock %}
-{% block modal_theme %}blue{% endblock %}
-{% block modal_eyebrow %}ENVANTER YÖNETİMİ{% endblock %}
-{% block modal_title %}Envanter Atama{% endblock %}
-{% block modal_subtitle %}Envanteri ilgili personel ve departmanla eşleştirin.{% endblock %}
-
-{% block modal_body %}
+{% extends "components/modal_base.html" %} {% block modal_id %}assignModal{%
+endblock %} {% block modal_dialog_classes %}modal-lg modal-dialog-scrollable{%
+endblock %} {% block modal_theme %}blue{% endblock %} {% block modal_eyebrow
+%}ENVANTER YÖNETİMİ{% endblock %} {% block modal_title %}Envanter Atama{%
+endblock %} {% block modal_subtitle %}Envanteri ilgili personel ve departmanla
+eşleştirin.{% endblock %} {% block modal_body %}
 <form id="assignForm" class="form-grid" novalidate>
   <input type="hidden" name="item_id" id="assign_item_id" />
   <div class="field">
@@ -50,9 +46,7 @@
     />
   </div>
 </form>
-{% endblock %}
-
-{% block modal_footer %}
+{% endblock %} {% block modal_footer %}
 <button type="button" class="btn btn-light" data-bs-dismiss="modal">
   Kapat
 </button>

--- a/templates/licenses/_add_modal.html
+++ b/templates/licenses/_add_modal.html
@@ -1,21 +1,21 @@
-{% extends "components/modal_base.html" %}
-{% import "components/form_macros.html" as F %}
-{% set form_id = "licenseAddForm" %}
-{% set submit_text = "Kaydet" %}
-
-{% block modal_id %}licenseAddModal{% endblock %}
-{% block modal_theme %}purple{% endblock %}
-{% block modal_eyebrow %}LİSANS YÖNETİMİ{% endblock %}
-{% block modal_title %}Lisans Ekle{% endblock %}
-{% block modal_subtitle %}Yeni bir lisans kaydı oluşturarak stoğunuzu güncel tutun.{% endblock %}
-
-{% block modal_body %}
-<form id="{{ form_id }}" class="form-grid" method="post" action="/licenses/create">
-  {{ F.select('license_id','Lisans Adı', licenses, required=True) }}
-  {{ F.input('license_key','Lisans Anahtarı','text','',True,'XXXX-XXXX-XXXX-XXXX') }}
-  {{ F.select('owner_id','Sorumlu Personel', people) }}
-  {{ F.input('inventory_no','Bağlı Olduğu Envanter No','text') }}
-  {{ F.input('ifs_no','IFS No','text','',False,'','Opsiyonel') }}
-  {{ F.input('email','E-posta','email','',False,'','Opsiyonel') }}
+{% extends "components/modal_base.html" %} {% import
+"components/form_macros.html" as F %} {% set form_id = "licenseAddForm" %} {%
+set submit_text = "Kaydet" %} {% block modal_id %}licenseAddModal{% endblock %}
+{% block modal_theme %}purple{% endblock %} {% block modal_eyebrow %}LİSANS
+YÖNETİMİ{% endblock %} {% block modal_title %}Lisans Ekle{% endblock %} {% block
+modal_subtitle %}Yeni bir lisans kaydı oluşturarak stoğunuzu güncel tutun.{%
+endblock %} {% block modal_body %}
+<form
+  id="{{ form_id }}"
+  class="form-grid"
+  method="post"
+  action="/licenses/create"
+>
+  {{ F.select('license_id','Lisans Adı', licenses, required=True) }} {{
+  F.input('license_key','Lisans Anahtarı','text','',True,'XXXX-XXXX-XXXX-XXXX')
+  }} {{ F.select('owner_id','Sorumlu Personel', people) }} {{
+  F.input('inventory_no','Bağlı Olduğu Envanter No','text') }} {{
+  F.input('ifs_no','IFS No','text','',False,'','Opsiyonel') }} {{
+  F.input('email','E-posta','email','',False,'','Opsiyonel') }}
 </form>
 {% endblock %}

--- a/templates/licenses/_add_modal.html
+++ b/templates/licenses/_add_modal.html
@@ -1,0 +1,21 @@
+{% extends "components/modal_base.html" %}
+{% import "components/form_macros.html" as F %}
+{% set form_id = "licenseAddForm" %}
+{% set submit_text = "Kaydet" %}
+
+{% block modal_id %}licenseAddModal{% endblock %}
+{% block modal_theme %}purple{% endblock %}
+{% block modal_eyebrow %}LİSANS YÖNETİMİ{% endblock %}
+{% block modal_title %}Lisans Ekle{% endblock %}
+{% block modal_subtitle %}Yeni bir lisans kaydı oluşturarak stoğunuzu güncel tutun.{% endblock %}
+
+{% block modal_body %}
+<form id="{{ form_id }}" class="form-grid" method="post" action="/licenses/create">
+  {{ F.select('license_id','Lisans Adı', licenses, required=True) }}
+  {{ F.input('license_key','Lisans Anahtarı','text','',True,'XXXX-XXXX-XXXX-XXXX') }}
+  {{ F.select('owner_id','Sorumlu Personel', people) }}
+  {{ F.input('inventory_no','Bağlı Olduğu Envanter No','text') }}
+  {{ F.input('ifs_no','IFS No','text','',False,'','Opsiyonel') }}
+  {{ F.input('email','E-posta','email','',False,'','Opsiyonel') }}
+</form>
+{% endblock %}

--- a/templates/licenses/_assign_modal.html
+++ b/templates/licenses/_assign_modal.html
@@ -1,0 +1,17 @@
+{% extends "components/modal_base.html" %}
+{% import "components/form_macros.html" as F %}
+{% set form_id = "licenseAssignForm" %}
+{% set submit_text = "Kaydet" %}
+
+{% block modal_id %}licenseAssignModal{% endblock %}
+{% block modal_theme %}purple{% endblock %}
+{% block modal_title %}Lisansı Ata{% endblock %}
+{% block modal_subtitle %}Lisansı bir personele veya envanter kaydına bağlayın.{% endblock %}
+
+{% block modal_body %}
+<form id="{{ form_id }}" class="form-grid" method="post" action="/licenses/assign">
+  {{ F.select('owner_id','Sorumlu Personel', people, value=default_owner_id) }}
+  {{ F.select('inventory_id','Bağlı Olduğu Envanter', inventories, value=default_inventory_id) }}
+  <div class="col-2">{{ F.info('Bu işlem lisansın geçmiş kayıtlarına eklenecek.') }}</div>
+</form>
+{% endblock %}

--- a/templates/licenses/_assign_modal.html
+++ b/templates/licenses/_assign_modal.html
@@ -1,17 +1,20 @@
-{% extends "components/modal_base.html" %}
-{% import "components/form_macros.html" as F %}
-{% set form_id = "licenseAssignForm" %}
-{% set submit_text = "Kaydet" %}
-
-{% block modal_id %}licenseAssignModal{% endblock %}
-{% block modal_theme %}purple{% endblock %}
-{% block modal_title %}Lisansı Ata{% endblock %}
-{% block modal_subtitle %}Lisansı bir personele veya envanter kaydına bağlayın.{% endblock %}
-
-{% block modal_body %}
-<form id="{{ form_id }}" class="form-grid" method="post" action="/licenses/assign">
+{% extends "components/modal_base.html" %} {% import
+"components/form_macros.html" as F %} {% set form_id = "licenseAssignForm" %} {%
+set submit_text = "Kaydet" %} {% block modal_id %}licenseAssignModal{% endblock
+%} {% block modal_theme %}purple{% endblock %} {% block modal_title %}Lisansı
+Ata{% endblock %} {% block modal_subtitle %}Lisansı bir personele veya envanter
+kaydına bağlayın.{% endblock %} {% block modal_body %}
+<form
+  id="{{ form_id }}"
+  class="form-grid"
+  method="post"
+  action="/licenses/assign"
+>
   {{ F.select('owner_id','Sorumlu Personel', people, value=default_owner_id) }}
-  {{ F.select('inventory_id','Bağlı Olduğu Envanter', inventories, value=default_inventory_id) }}
-  <div class="col-2">{{ F.info('Bu işlem lisansın geçmiş kayıtlarına eklenecek.') }}</div>
+  {{ F.select('inventory_id','Bağlı Olduğu Envanter', inventories,
+  value=default_inventory_id) }}
+  <div class="col-2">
+    {{ F.info('Bu işlem lisansın geçmiş kayıtlarına eklenecek.') }}
+  </div>
 </form>
 {% endblock %}

--- a/templates/licenses/_edit_modal.html
+++ b/templates/licenses/_edit_modal.html
@@ -1,22 +1,26 @@
-{% extends "components/modal_base.html" %}
-{% import "components/form_macros.html" as F %}
-{% set form_id = "licenseEditForm" %}
-{% set submit_text = "Kaydet" %}
-
-{% block modal_id %}licenseEditModal{% endblock %}
-{% block modal_theme %}purple{% endblock %}
-{% block modal_eyebrow %}LİSANS YÖNETİMİ{% endblock %}
-{% block modal_title %}Lisans Bilgilerini Güncelleyin{% endblock %}
-{% block modal_subtitle %}Lisans kayıtlarını güncel tutarak kullanım ve atama geçmişini netleştirin.{% endblock %}
-
-{% block modal_body %}
-<form id="{{ form_id }}" class="form-grid" method="post" action="/licenses/{{ license.id }}/update">
-  {{ F.select('license_id','Lisans Adı', licenses, value=license.license_id, required=True) }}
-  {{ F.input('license_key','Lisans Anahtarı','text',license.license_key,True,'XXXX-XXXX-XXXX-XXXX') }}
-  {{ F.select('owner_id','Sorumlu Personel', people, value=license.owner_id) }}
-  {{ F.select('inventory_id','Bağlı Olduğu Envanter', inventories, value=license.inventory_id, hint='Seçimsiz') }}
-  {{ F.input('ifs_no','IFS No','text',license.ifs_no) }}
-  {{ F.input('email','Mail Adresi','email',license.email) }}
-  <div class="col-2">{{ F.info('Değişiklikler lisans geçmişine kaydedilecektir.') }}</div>
+{% extends "components/modal_base.html" %} {% import
+"components/form_macros.html" as F %} {% set form_id = "licenseEditForm" %} {%
+set submit_text = "Kaydet" %} {% block modal_id %}licenseEditModal{% endblock %}
+{% block modal_theme %}purple{% endblock %} {% block modal_eyebrow %}LİSANS
+YÖNETİMİ{% endblock %} {% block modal_title %}Lisans Bilgilerini Güncelleyin{%
+endblock %} {% block modal_subtitle %}Lisans kayıtlarını güncel tutarak kullanım
+ve atama geçmişini netleştirin.{% endblock %} {% block modal_body %}
+<form
+  id="{{ form_id }}"
+  class="form-grid"
+  method="post"
+  action="/licenses/{{ license.id }}/update"
+>
+  {{ F.select('license_id','Lisans Adı', licenses, value=license.license_id,
+  required=True) }} {{ F.input('license_key','Lisans
+  Anahtarı','text',license.license_key,True,'XXXX-XXXX-XXXX-XXXX') }} {{
+  F.select('owner_id','Sorumlu Personel', people, value=license.owner_id) }} {{
+  F.select('inventory_id','Bağlı Olduğu Envanter', inventories,
+  value=license.inventory_id, hint='Seçimsiz') }} {{ F.input('ifs_no','IFS
+  No','text',license.ifs_no) }} {{ F.input('email','Mail
+  Adresi','email',license.email) }}
+  <div class="col-2">
+    {{ F.info('Değişiklikler lisans geçmişine kaydedilecektir.') }}
+  </div>
 </form>
 {% endblock %}

--- a/templates/licenses/_edit_modal.html
+++ b/templates/licenses/_edit_modal.html
@@ -1,0 +1,22 @@
+{% extends "components/modal_base.html" %}
+{% import "components/form_macros.html" as F %}
+{% set form_id = "licenseEditForm" %}
+{% set submit_text = "Kaydet" %}
+
+{% block modal_id %}licenseEditModal{% endblock %}
+{% block modal_theme %}purple{% endblock %}
+{% block modal_eyebrow %}LİSANS YÖNETİMİ{% endblock %}
+{% block modal_title %}Lisans Bilgilerini Güncelleyin{% endblock %}
+{% block modal_subtitle %}Lisans kayıtlarını güncel tutarak kullanım ve atama geçmişini netleştirin.{% endblock %}
+
+{% block modal_body %}
+<form id="{{ form_id }}" class="form-grid" method="post" action="/licenses/{{ license.id }}/update">
+  {{ F.select('license_id','Lisans Adı', licenses, value=license.license_id, required=True) }}
+  {{ F.input('license_key','Lisans Anahtarı','text',license.license_key,True,'XXXX-XXXX-XXXX-XXXX') }}
+  {{ F.select('owner_id','Sorumlu Personel', people, value=license.owner_id) }}
+  {{ F.select('inventory_id','Bağlı Olduğu Envanter', inventories, value=license.inventory_id, hint='Seçimsiz') }}
+  {{ F.input('ifs_no','IFS No','text',license.ifs_no) }}
+  {{ F.input('email','Mail Adresi','email',license.email) }}
+  <div class="col-2">{{ F.info('Değişiklikler lisans geçmişine kaydedilecektir.') }}</div>
+</form>
+{% endblock %}

--- a/templates/printers/_add_modal.html
+++ b/templates/printers/_add_modal.html
@@ -1,0 +1,22 @@
+{% extends "components/modal_base.html" %}
+{% import "components/form_macros.html" as F %}
+{% set form_id = "printerAddForm" %}
+{% set submit_text = "Kaydet" %}
+
+{% block modal_id %}printerAddModal{% endblock %}
+{% block modal_theme %}purple{% endblock %}
+{% block modal_eyebrow %}YAZICI YÖNETİMİ{% endblock %}
+{% block modal_title %}Yazıcı Ekle{% endblock %}
+{% block modal_subtitle %}Yeni bir yazıcıyı envantere ekleyin ve temel yapılandırmasını belirleyin.{% endblock %}
+
+{% block modal_body %}
+<form id="{{ form_id }}" class="form-grid" method="post" action="/printers/create">
+  {{ F.input('inventory_no','Envanter No','text', new_inventory_code, True) }}
+  {{ F.select('brand_id','Yazıcı Markası', brands, required=True) }}
+  {{ F.select('model_id','Yazıcı Modeli', models, hint='Model listesi seçilen markaya göre filtrelenir.') }}
+  {{ F.select('usage_area_id','Kullanım Alanı', usage_areas) }}
+  {{ F.input('ip','IP Adresi','text') }}
+  {{ F.input('mac','MAC','text','',False,'AA:BB:CC:DD:EE:FF') }}
+  {{ F.input('hostname','Hostname','text') }}
+</form>
+{% endblock %}

--- a/templates/printers/_add_modal.html
+++ b/templates/printers/_add_modal.html
@@ -1,22 +1,22 @@
-{% extends "components/modal_base.html" %}
-{% import "components/form_macros.html" as F %}
-{% set form_id = "printerAddForm" %}
-{% set submit_text = "Kaydet" %}
-
-{% block modal_id %}printerAddModal{% endblock %}
-{% block modal_theme %}purple{% endblock %}
-{% block modal_eyebrow %}YAZICI YÖNETİMİ{% endblock %}
-{% block modal_title %}Yazıcı Ekle{% endblock %}
-{% block modal_subtitle %}Yeni bir yazıcıyı envantere ekleyin ve temel yapılandırmasını belirleyin.{% endblock %}
-
-{% block modal_body %}
-<form id="{{ form_id }}" class="form-grid" method="post" action="/printers/create">
+{% extends "components/modal_base.html" %} {% import
+"components/form_macros.html" as F %} {% set form_id = "printerAddForm" %} {%
+set submit_text = "Kaydet" %} {% block modal_id %}printerAddModal{% endblock %}
+{% block modal_theme %}purple{% endblock %} {% block modal_eyebrow %}YAZICI
+YÖNETİMİ{% endblock %} {% block modal_title %}Yazıcı Ekle{% endblock %} {% block
+modal_subtitle %}Yeni bir yazıcıyı envantere ekleyin ve temel yapılandırmasını
+belirleyin.{% endblock %} {% block modal_body %}
+<form
+  id="{{ form_id }}"
+  class="form-grid"
+  method="post"
+  action="/printers/create"
+>
   {{ F.input('inventory_no','Envanter No','text', new_inventory_code, True) }}
-  {{ F.select('brand_id','Yazıcı Markası', brands, required=True) }}
-  {{ F.select('model_id','Yazıcı Modeli', models, hint='Model listesi seçilen markaya göre filtrelenir.') }}
-  {{ F.select('usage_area_id','Kullanım Alanı', usage_areas) }}
-  {{ F.input('ip','IP Adresi','text') }}
-  {{ F.input('mac','MAC','text','',False,'AA:BB:CC:DD:EE:FF') }}
-  {{ F.input('hostname','Hostname','text') }}
+  {{ F.select('brand_id','Yazıcı Markası', brands, required=True) }} {{
+  F.select('model_id','Yazıcı Modeli', models, hint='Model listesi seçilen
+  markaya göre filtrelenir.') }} {{ F.select('usage_area_id','Kullanım Alanı',
+  usage_areas) }} {{ F.input('ip','IP Adresi','text') }} {{
+  F.input('mac','MAC','text','',False,'AA:BB:CC:DD:EE:FF') }} {{
+  F.input('hostname','Hostname','text') }}
 </form>
 {% endblock %}

--- a/templates/printers/_assign_modal.html
+++ b/templates/printers/_assign_modal.html
@@ -1,0 +1,18 @@
+{% extends "components/modal_base.html" %}
+{% import "components/form_macros.html" as F %}
+{% set form_id = "printerAssignForm" %}
+{% set submit_text = "Atamayı Kaydet" %}
+
+{% block modal_id %}printerAssignModal{% endblock %}
+{% block modal_theme %}purple{% endblock %}
+{% block modal_title %}Yazıcıyı Ata — {{ printer.id }}{% endblock %}
+{% block modal_subtitle %}Yazıcı için fabrika, kullanım alanı ve sorumlu bilgilerini güncelleyin.{% endblock %}
+
+{% block modal_body %}
+<form id="{{ form_id }}" class="form-grid" method="post" action="/printers/{{ printer.id }}/assign">
+  {{ F.select('factory_id','Fabrika', factories, value=printer.factory_id, required=True) }}
+  {{ F.select('usage_area_id','Kullanım Alanı', usage_areas, value=printer.usage_area_id, required=True) }}
+  {{ F.select('owner_id','Sorumlu Personel', people, value=printer.owner_id) }}
+  {{ F.select('inventory_id','Bağlı Olduğu Envanter', inventories, value=printer.inventory_id) }}
+</form>
+{% endblock %}

--- a/templates/printers/_assign_modal.html
+++ b/templates/printers/_assign_modal.html
@@ -1,18 +1,21 @@
-{% extends "components/modal_base.html" %}
-{% import "components/form_macros.html" as F %}
-{% set form_id = "printerAssignForm" %}
-{% set submit_text = "Atamayı Kaydet" %}
-
-{% block modal_id %}printerAssignModal{% endblock %}
-{% block modal_theme %}purple{% endblock %}
-{% block modal_title %}Yazıcıyı Ata — {{ printer.id }}{% endblock %}
-{% block modal_subtitle %}Yazıcı için fabrika, kullanım alanı ve sorumlu bilgilerini güncelleyin.{% endblock %}
-
+{% extends "components/modal_base.html" %} {% import
+"components/form_macros.html" as F %} {% set form_id = "printerAssignForm" %} {%
+set submit_text = "Atamayı Kaydet" %} {% block modal_id %}printerAssignModal{%
+endblock %} {% block modal_theme %}purple{% endblock %} {% block modal_title
+%}Yazıcıyı Ata — {{ printer.id }}{% endblock %} {% block modal_subtitle %}Yazıcı
+için fabrika, kullanım alanı ve sorumlu bilgilerini güncelleyin.{% endblock %}
 {% block modal_body %}
-<form id="{{ form_id }}" class="form-grid" method="post" action="/printers/{{ printer.id }}/assign">
-  {{ F.select('factory_id','Fabrika', factories, value=printer.factory_id, required=True) }}
-  {{ F.select('usage_area_id','Kullanım Alanı', usage_areas, value=printer.usage_area_id, required=True) }}
-  {{ F.select('owner_id','Sorumlu Personel', people, value=printer.owner_id) }}
-  {{ F.select('inventory_id','Bağlı Olduğu Envanter', inventories, value=printer.inventory_id) }}
+<form
+  id="{{ form_id }}"
+  class="form-grid"
+  method="post"
+  action="/printers/{{ printer.id }}/assign"
+>
+  {{ F.select('factory_id','Fabrika', factories, value=printer.factory_id,
+  required=True) }} {{ F.select('usage_area_id','Kullanım Alanı', usage_areas,
+  value=printer.usage_area_id, required=True) }} {{ F.select('owner_id','Sorumlu
+  Personel', people, value=printer.owner_id) }} {{
+  F.select('inventory_id','Bağlı Olduğu Envanter', inventories,
+  value=printer.inventory_id) }}
 </form>
 {% endblock %}

--- a/templates/printers/_edit_modal.html
+++ b/templates/printers/_edit_modal.html
@@ -1,0 +1,23 @@
+{% extends "components/modal_base.html" %}
+{% import "components/form_macros.html" as F %}
+{% set form_id = "printerEditForm" %}
+{% set submit_text = "Kaydet" %}
+
+{% block modal_id %}printerEditModal{% endblock %}
+{% block modal_theme %}purple{% endblock %}
+{% block modal_eyebrow %}YAZICI YÖNETİMİ{% endblock %}
+{% block modal_title %}Yazıcı Bilgilerini Güncelleyin{% endblock %}
+{% block modal_subtitle %}Envanterde kayıtlı yazıcının temel yapılandırmasını güncelleyin.{% endblock %}
+
+{% block modal_body %}
+<form id="{{ form_id }}" class="form-grid" method="post" action="/printers/{{ printer.id }}/update">
+  {{ F.input('inventory_no','Envanter No','text', printer.inventory_no, True) }}
+  {{ F.select('brand_id','Yazıcı Markası', brands, value=printer.brand_id, required=True) }}
+  {{ F.select('model_id','Yazıcı Modeli', models, value=printer.model_id, hint='Model listesi seçilen markaya göre filtrelenir.') }}
+  {{ F.select('usage_area_id','Kullanım Alanı', usage_areas, value=printer.usage_area_id) }}
+  {{ F.input('ip','IP Adresi','text',printer.ip) }}
+  {{ F.input('mac','MAC','text',printer.mac,False,'AA:BB:CC:DD:EE:FF') }}
+  {{ F.input('hostname','Hostname','text',printer.hostname) }}
+  <div class="col-2">{{ F.info('Kaydedilen bilgiler yazıcı geçmişine işlenecektir.') }}</div>
+</form>
+{% endblock %}

--- a/templates/printers/_edit_modal.html
+++ b/templates/printers/_edit_modal.html
@@ -1,23 +1,26 @@
-{% extends "components/modal_base.html" %}
-{% import "components/form_macros.html" as F %}
-{% set form_id = "printerEditForm" %}
-{% set submit_text = "Kaydet" %}
-
-{% block modal_id %}printerEditModal{% endblock %}
-{% block modal_theme %}purple{% endblock %}
-{% block modal_eyebrow %}YAZICI YÖNETİMİ{% endblock %}
-{% block modal_title %}Yazıcı Bilgilerini Güncelleyin{% endblock %}
-{% block modal_subtitle %}Envanterde kayıtlı yazıcının temel yapılandırmasını güncelleyin.{% endblock %}
-
-{% block modal_body %}
-<form id="{{ form_id }}" class="form-grid" method="post" action="/printers/{{ printer.id }}/update">
+{% extends "components/modal_base.html" %} {% import
+"components/form_macros.html" as F %} {% set form_id = "printerEditForm" %} {%
+set submit_text = "Kaydet" %} {% block modal_id %}printerEditModal{% endblock %}
+{% block modal_theme %}purple{% endblock %} {% block modal_eyebrow %}YAZICI
+YÖNETİMİ{% endblock %} {% block modal_title %}Yazıcı Bilgilerini Güncelleyin{%
+endblock %} {% block modal_subtitle %}Envanterde kayıtlı yazıcının temel
+yapılandırmasını güncelleyin.{% endblock %} {% block modal_body %}
+<form
+  id="{{ form_id }}"
+  class="form-grid"
+  method="post"
+  action="/printers/{{ printer.id }}/update"
+>
   {{ F.input('inventory_no','Envanter No','text', printer.inventory_no, True) }}
-  {{ F.select('brand_id','Yazıcı Markası', brands, value=printer.brand_id, required=True) }}
-  {{ F.select('model_id','Yazıcı Modeli', models, value=printer.model_id, hint='Model listesi seçilen markaya göre filtrelenir.') }}
-  {{ F.select('usage_area_id','Kullanım Alanı', usage_areas, value=printer.usage_area_id) }}
-  {{ F.input('ip','IP Adresi','text',printer.ip) }}
-  {{ F.input('mac','MAC','text',printer.mac,False,'AA:BB:CC:DD:EE:FF') }}
-  {{ F.input('hostname','Hostname','text',printer.hostname) }}
-  <div class="col-2">{{ F.info('Kaydedilen bilgiler yazıcı geçmişine işlenecektir.') }}</div>
+  {{ F.select('brand_id','Yazıcı Markası', brands, value=printer.brand_id,
+  required=True) }} {{ F.select('model_id','Yazıcı Modeli', models,
+  value=printer.model_id, hint='Model listesi seçilen markaya göre
+  filtrelenir.') }} {{ F.select('usage_area_id','Kullanım Alanı', usage_areas,
+  value=printer.usage_area_id) }} {{ F.input('ip','IP Adresi','text',printer.ip)
+  }} {{ F.input('mac','MAC','text',printer.mac,False,'AA:BB:CC:DD:EE:FF') }} {{
+  F.input('hostname','Hostname','text',printer.hostname) }}
+  <div class="col-2">
+    {{ F.info('Kaydedilen bilgiler yazıcı geçmişine işlenecektir.') }}
+  </div>
 </form>
 {% endblock %}

--- a/templates/stock/_assign_modal.html
+++ b/templates/stock/_assign_modal.html
@@ -1,48 +1,61 @@
-{% extends "components/modal_base.html" %}
-{% import "components/form_macros.html" as F %}
-{% set form_id = "stockAssignForm" %}
-{% set submit_text = "Kaydet" %}
+{% extends "components/modal_base.html" %} {% import
+"components/form_macros.html" as F %} {% set form_id = "stockAssignForm" %} {%
+set submit_text = "Kaydet" %} {% block modal_id %}stockAssignModal{% endblock %}
+{% block modal_theme %}orange{% endblock %} {% block modal_eyebrow %}STOK
+YÖNETİMİ{% endblock %} {% block modal_title %}Stok Kaydını Atayın{% endblock %}
+{% block modal_subtitle %}Stok durumu tablosundan seçtiğiniz kalemi envantere,
+yazıcıya veya lisansa atayın.{% endblock %} {% block modal_body %}
+<div class="mb-2">
+  {{ F.input('selected_stock','Seçilen Stok','text', selected_stock_readable,
+  False) }}
+</div>
 
-{% block modal_id %}stockAssignModal{% endblock %}
-{% block modal_theme %}orange{% endblock %}
-{% block modal_eyebrow %}STOK YÖNETİMİ{% endblock %}
-{% block modal_title %}Stok Kaydını Atayın{% endblock %}
-{% block modal_subtitle %}Stok durumu tablosundan seçtiğiniz kalemi envantere, yazıcıya veya lisansa atayın.{% endblock %}
-
-{% block modal_body %}
-  <div class="mb-2">
-    {{ F.input('selected_stock','Seçilen Stok','text', selected_stock_readable, False) }}
+<div class="tabbed">
+  <div class="tab-lite" role="tablist">
+    <button type="button" class="btn active" data-target="#tab-license">
+      Lisans
+    </button>
+    <button type="button" class="btn" data-target="#tab-inventory">
+      Envanter
+    </button>
+    <button type="button" class="btn" data-target="#tab-printer">Yazıcı</button>
   </div>
 
-  <div class="tabbed">
-    <div class="tab-lite" role="tablist">
-      <button type="button" class="btn active" data-target="#tab-license">Lisans</button>
-      <button type="button" class="btn" data-target="#tab-inventory">Envanter</button>
-      <button type="button" class="btn" data-target="#tab-printer">Yazıcı</button>
+  <form
+    id="{{ form_id }}"
+    class="form-grid"
+    method="post"
+    action="/stock/assign"
+  >
+    <input type="hidden" name="stock_id" value="{{ stock.id }}" />
+
+    <div id="tab-license" class="tab-pane">
+      {{ F.select('license_id','Lisans Adı', licenses, required=True) }} {{
+      F.select('owner_id','Sorumlu', people) }}
+      <div class="col-2">
+        {{ F.input('note','Açıklama','text','',False,'','Opsiyonel') }}
+      </div>
     </div>
 
-    <form id="{{ form_id }}" class="form-grid" method="post" action="/stock/assign">
-      <input type="hidden" name="stock_id" value="{{ stock.id }}"/>
-
-      <div id="tab-license" class="tab-pane">
-        {{ F.select('license_id','Lisans Adı', licenses, required=True) }}
-        {{ F.select('owner_id','Sorumlu', people) }}
-        <div class="col-2">{{ F.input('note','Açıklama','text','',False,'','Opsiyonel') }}</div>
+    <div id="tab-inventory" class="tab-pane d-none">
+      {{ F.select('inventory_id','Envanter', inventories, required=True) }} {{
+      F.select('owner_id_inv','Sorumlu', people) }}
+      <div class="col-2">
+        {{ F.input('note_inv','Açıklama','text','',False,'','Opsiyonel') }}
       </div>
+    </div>
 
-      <div id="tab-inventory" class="tab-pane d-none">
-        {{ F.select('inventory_id','Envanter', inventories, required=True) }}
-        {{ F.select('owner_id_inv','Sorumlu', people) }}
-        <div class="col-2">{{ F.input('note_inv','Açıklama','text','',False,'','Opsiyonel') }}</div>
+    <div id="tab-printer" class="tab-pane d-none">
+      {{ F.select('printer_id','Yazıcı', printers, required=True) }} {{
+      F.select('owner_id_prn','Sorumlu', people) }}
+      <div class="col-2">
+        {{ F.input('note_prn','Açıklama','text','',False,'','Opsiyonel') }}
       </div>
+    </div>
 
-      <div id="tab-printer" class="tab-pane d-none">
-        {{ F.select('printer_id','Yazıcı', printers, required=True) }}
-        {{ F.select('owner_id_prn','Sorumlu', people) }}
-        <div class="col-2">{{ F.input('note_prn','Açıklama','text','',False,'','Opsiyonel') }}</div>
-      </div>
-
-      <div class="col-2">{{ F.input('global_note','Genel Not','text','',False,'','Opsiyonel') }}</div>
-    </form>
-  </div>
+    <div class="col-2">
+      {{ F.input('global_note','Genel Not','text','',False,'','Opsiyonel') }}
+    </div>
+  </form>
+</div>
 {% endblock %}

--- a/templates/stock/_assign_modal.html
+++ b/templates/stock/_assign_modal.html
@@ -1,0 +1,48 @@
+{% extends "components/modal_base.html" %}
+{% import "components/form_macros.html" as F %}
+{% set form_id = "stockAssignForm" %}
+{% set submit_text = "Kaydet" %}
+
+{% block modal_id %}stockAssignModal{% endblock %}
+{% block modal_theme %}orange{% endblock %}
+{% block modal_eyebrow %}STOK YÖNETİMİ{% endblock %}
+{% block modal_title %}Stok Kaydını Atayın{% endblock %}
+{% block modal_subtitle %}Stok durumu tablosundan seçtiğiniz kalemi envantere, yazıcıya veya lisansa atayın.{% endblock %}
+
+{% block modal_body %}
+  <div class="mb-2">
+    {{ F.input('selected_stock','Seçilen Stok','text', selected_stock_readable, False) }}
+  </div>
+
+  <div class="tabbed">
+    <div class="tab-lite" role="tablist">
+      <button type="button" class="btn active" data-target="#tab-license">Lisans</button>
+      <button type="button" class="btn" data-target="#tab-inventory">Envanter</button>
+      <button type="button" class="btn" data-target="#tab-printer">Yazıcı</button>
+    </div>
+
+    <form id="{{ form_id }}" class="form-grid" method="post" action="/stock/assign">
+      <input type="hidden" name="stock_id" value="{{ stock.id }}"/>
+
+      <div id="tab-license" class="tab-pane">
+        {{ F.select('license_id','Lisans Adı', licenses, required=True) }}
+        {{ F.select('owner_id','Sorumlu', people) }}
+        <div class="col-2">{{ F.input('note','Açıklama','text','',False,'','Opsiyonel') }}</div>
+      </div>
+
+      <div id="tab-inventory" class="tab-pane d-none">
+        {{ F.select('inventory_id','Envanter', inventories, required=True) }}
+        {{ F.select('owner_id_inv','Sorumlu', people) }}
+        <div class="col-2">{{ F.input('note_inv','Açıklama','text','',False,'','Opsiyonel') }}</div>
+      </div>
+
+      <div id="tab-printer" class="tab-pane d-none">
+        {{ F.select('printer_id','Yazıcı', printers, required=True) }}
+        {{ F.select('owner_id_prn','Sorumlu', people) }}
+        <div class="col-2">{{ F.input('note_prn','Açıklama','text','',False,'','Opsiyonel') }}</div>
+      </div>
+
+      <div class="col-2">{{ F.input('global_note','Genel Not','text','',False,'','Opsiyonel') }}</div>
+    </form>
+  </div>
+{% endblock %}

--- a/templates/stock/_edit_modal.html
+++ b/templates/stock/_edit_modal.html
@@ -1,13 +1,9 @@
-{% extends "components/modal_base.html" %}
-
-{% block modal_id %}modalStockAdd{% endblock %}
-{% block modal_dialog_classes %}modal-lg modal-dialog-scrollable{% endblock %}
-{% block modal_theme %}orange{% endblock %}
-{% block modal_eyebrow %}STOK YÖNETİMİ{% endblock %}
-{% block modal_title %}Stok Kaydını Düzenleyin{% endblock %}
-{% block modal_subtitle %}Envanter veya lisans stok hareketlerini sisteme ekleyin.{% endblock %}
-
-{% block modal_body %}
+{% extends "components/modal_base.html" %} {% block modal_id %}modalStockAdd{%
+endblock %} {% block modal_dialog_classes %}modal-lg modal-dialog-scrollable{%
+endblock %} {% block modal_theme %}orange{% endblock %} {% block modal_eyebrow
+%}STOK YÖNETİMİ{% endblock %} {% block modal_title %}Stok Kaydını Düzenleyin{%
+endblock %} {% block modal_subtitle %}Envanter veya lisans stok hareketlerini
+sisteme ekleyin.{% endblock %} {% block modal_body %}
 <form id="frmStockAdd" class="stack-md" autocomplete="off">
   <div class="tab-lite" role="tablist" aria-label="Stok kayıt tipi">
     <button
@@ -129,9 +125,7 @@
     </div>
   </div>
 </form>
-{% endblock %}
-
-{% block modal_footer %}
+{% endblock %} {% block modal_footer %}
 <button type="button" class="btn btn-light" data-bs-dismiss="modal">
   Kapat
 </button>

--- a/templates/stock/_edit_modal.html
+++ b/templates/stock/_edit_modal.html
@@ -1,11 +1,13 @@
-{% extends "components/modal_base.html" %} {% block modal_id %}modalStockAdd{%
-endblock %} {% block modal_dialog_classes %}modal-lg modal-dialog-scrollable{%
-endblock %} {% block modal_title %}Stok Kaydını Düzenleyin{% endblock %} {%
-block modal_subtitle %}
-<p class="modal-subtitle">
-  Envanter veya lisans stok hareketlerini sisteme ekleyin.
-</p>
-{% endblock %} {% block modal_body %}
+{% extends "components/modal_base.html" %}
+
+{% block modal_id %}modalStockAdd{% endblock %}
+{% block modal_dialog_classes %}modal-lg modal-dialog-scrollable{% endblock %}
+{% block modal_theme %}orange{% endblock %}
+{% block modal_eyebrow %}STOK YÖNETİMİ{% endblock %}
+{% block modal_title %}Stok Kaydını Düzenleyin{% endblock %}
+{% block modal_subtitle %}Envanter veya lisans stok hareketlerini sisteme ekleyin.{% endblock %}
+
+{% block modal_body %}
 <form id="frmStockAdd" class="stack-md" autocomplete="off">
   <div class="tab-lite" role="tablist" aria-label="Stok kayıt tipi">
     <button
@@ -127,7 +129,9 @@ block modal_subtitle %}
     </div>
   </div>
 </form>
-{% endblock %} {% block modal_footer %}
+{% endblock %}
+
+{% block modal_footer %}
 <button type="button" class="btn btn-light" data-bs-dismiss="modal">
   Kapat
 </button>


### PR DESCRIPTION
## Summary
- refactor the shared modal template and styling to support themed headers and reusable form macros
- add dedicated modal partials for license, printer, and stock assignment flows built on the new skeleton
- ship supporting CSS/JS assets and update existing inventory/stock modals plus the base layout include

## Testing
- not run (templates only)


------
https://chatgpt.com/codex/tasks/task_e_68e3a97995b4832b88e71033e82c6a7c