### PR TITLE
Add license creation modal and supporting routes

### DIFF
--- a/alembic/versions/f8b1234d9abc_add_license_metadata_columns.py
+++ b/alembic/versions/f8b1234d9abc_add_license_metadata_columns.py
@@ -1,0 +1,101 @@
+"""add license metadata columns
+
+Revision ID: f8b1234d9abc
+Revises: e6c1d9b8f4d1
+Create Date: 2025-02-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "f8b1234d9abc"
+down_revision = "e6c1d9b8f4d1"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(bind, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade():
+    bind = op.get_bind()
+
+    if not _table_exists(bind, "departments"):
+        op.create_table(
+            "departments",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("name", sa.String(length=150), nullable=False, unique=True),
+        )
+        op.create_index("ix_departments_name", "departments", ["name"], unique=True)
+
+    op.add_column("licenses", sa.Column("license_code", sa.String(length=64), nullable=True))
+    op.add_column("licenses", sa.Column("license_type", sa.String(length=32), nullable=True))
+    op.add_column(
+        "licenses",
+        sa.Column("seat_count", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.add_column("licenses", sa.Column("start_date", sa.Date(), nullable=True))
+    op.add_column("licenses", sa.Column("end_date", sa.Date(), nullable=True))
+    op.add_column("licenses", sa.Column("factory_id", sa.Integer(), nullable=True))
+    op.add_column("licenses", sa.Column("department_id", sa.Integer(), nullable=True))
+    op.add_column("licenses", sa.Column("owner_id", sa.Integer(), nullable=True))
+
+    op.create_index("ix_licenses_license_code", "licenses", ["license_code"], unique=True)
+
+    op.create_foreign_key(
+        "fk_licenses_factory_id_factories",
+        "licenses",
+        "factories",
+        ["factory_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "fk_licenses_department_id_departments",
+        "licenses",
+        "departments",
+        ["department_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "fk_licenses_owner_id_users",
+        "licenses",
+        "users",
+        ["owner_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.alter_column(
+        "licenses",
+        "seat_count",
+        server_default=None,
+        existing_type=sa.Integer(),
+    )
+
+
+def downgrade():
+    op.drop_constraint("fk_licenses_owner_id_users", "licenses", type_="foreignkey")
+    op.drop_constraint(
+        "fk_licenses_department_id_departments", "licenses", type_="foreignkey"
+    )
+    op.drop_constraint("fk_licenses_factory_id_factories", "licenses", type_="foreignkey")
+    op.drop_index("ix_licenses_license_code", table_name="licenses")
+
+    op.drop_column("licenses", "owner_id")
+    op.drop_column("licenses", "department_id")
+    op.drop_column("licenses", "factory_id")
+    op.drop_column("licenses", "end_date")
+    op.drop_column("licenses", "start_date")
+    op.drop_column("licenses", "seat_count")
+    op.drop_column("licenses", "license_type")
+    op.drop_column("licenses", "license_code")
+
+    bind = op.get_bind()
+    if _table_exists(bind, "departments"):
+        op.drop_index("ix_departments_name", table_name="departments")
+        op.drop_table("departments")

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -38,6 +38,7 @@ from routers.api import router as api_router
 from routers.lookup import router as lookup_router
 from routers.picker import router as picker_router
 from routers.talep import router as talep_router
+from routes import licenses as licenses_router
 from routes.admin import router as admin_router
 from routes.scrap import router as scrap_router
 from routes.talepler import router as talepler_router
@@ -161,13 +162,6 @@ async def logout(request: Request):
     return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
 
 
-@router.get("/licenses", include_in_schema=False)
-def licenses_list_alias(
-    request: Request, db: Session = Depends(get_db), user=Depends(current_user)
-):
-    return license_router.license_list(request, db, user)
-
-
 @router.get("/licenses/{lic_id}", include_in_schema=False)
 def licenses_detail_alias(
     lic_id: int,
@@ -216,6 +210,7 @@ router.include_router(license_router.router, dependencies=[Depends(current_user)
 router.include_router(printers_scrap_list.router, dependencies=[Depends(current_user)])
 router.include_router(printers_router.router, dependencies=[Depends(current_user)])
 router.include_router(catalog_router.router, dependencies=[Depends(current_user)])
+router.include_router(licenses_router.router, dependencies=[Depends(current_user)])
 router.include_router(
     requests_router.router,
     prefix="/requests",

--- a/models.py
+++ b/models.py
@@ -283,12 +283,28 @@ class License(Base):
     lisans_anahtari = Column(String(500), nullable=True)
     lisans_key = synonym("lisans_anahtari")
     anahtar = synonym("lisans_anahtari")
+    license_key = synonym("lisans_anahtari")
+    product_name = synonym("lisans_adi")
     sorumlu_personel = Column(String(120), nullable=True)
     bagli_envanter_no = Column(String(120), nullable=True)
     ifs_no = Column(String(100), nullable=True)
     tarih = Column(Date, default=datetime.utcnow)
     islem_yapan = Column(String(120), nullable=True)
     mail_adresi = Column(String(200), nullable=True)
+    license_code = Column(String(64), unique=True, index=True, nullable=True)
+    license_type = Column(String(32), nullable=True)
+    seat_count = Column(Integer, nullable=False, default=1)
+    start_date = Column(Date, nullable=True)
+    end_date = Column(Date, nullable=True)
+    factory_id = Column(
+        Integer, ForeignKey("factories.id", ondelete="SET NULL"), nullable=True
+    )
+    department_id = Column(
+        Integer, ForeignKey("departments.id", ondelete="SET NULL"), nullable=True
+    )
+    owner_id = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
     inventory_id = Column(
         Integer,
         ForeignKey("inventories.id", ondelete="SET NULL"),
@@ -297,11 +313,15 @@ class License(Base):
     )
     durum = Column(String(20), default="aktif")
     notlar = Column(Text, nullable=True)
+    note = synonym("notlar")
 
     logs = relationship(
         "LicenseLog", back_populates="license", cascade="all, delete-orphan"
     )
     inventory = relationship("Inventory", back_populates="licenses")
+    factory = relationship("Factory", foreign_keys=[factory_id])
+    department = relationship("Department", foreign_keys=[department_id])
+    owner = relationship("User", foreign_keys=[owner_id])
 
 
 class LicenseLog(Base):
@@ -352,6 +372,15 @@ class UsageArea(Base):
 
 class Factory(Base):
     __tablename__ = "factories"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(
+        String(150), unique=True, nullable=False, index=True
+    )
+
+
+class Department(Base):
+    __tablename__ = "departments"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(

--- a/routes/licenses.py
+++ b/routes/licenses.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from datetime import datetime, date
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+from starlette import status
+
+from database import get_db
+from models import Department, Factory, Inventory, License, User
+from security import current_user
+
+router = APIRouter(prefix="/licenses", tags=["Licenses"])
+templates = Jinja2Templates(directory="templates")
+
+
+def _parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Tarih formatı geçersiz") from exc
+
+
+def _to_optional_int(value: str | None) -> int | None:
+    if value in (None, "", "None"):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Geçersiz sayısal değer") from exc
+
+
+def _lists(db: Session) -> dict[str, object]:
+    factories = db.query(Factory).order_by(Factory.name.asc()).all()
+    departments = db.query(Department).order_by(Department.name.asc()).all()
+    persons = (
+        db.query(User)
+        .order_by(User.full_name.asc(), User.username.asc())
+        .all()
+    )
+    inventories = db.query(Inventory).order_by(Inventory.no.asc()).all()
+    return {
+        "factories": factories,
+        "departments": departments,
+        "persons": persons,
+        "inventories": inventories,
+    }
+
+
+@router.get("", name="licenses.list")
+def license_index(
+    request: Request, db: Session = Depends(get_db), user=Depends(current_user)
+):
+    licenses = db.query(License).order_by(License.id.desc()).all()
+    context = {"request": request, "licenses": licenses}
+    context.update(_lists(db))
+    return templates.TemplateResponse("licenses/list.html", context)
+
+
+@router.post("/add", name="licenses.add")
+def license_add(
+    request: Request,
+    license_code: str = Form(...),
+    product_name: str = Form(...),
+    factory_id: str | None = Form(None),
+    department_id: str | None = Form(None),
+    owner_id: str | None = Form(None),
+    inventory_id: str | None = Form(None),
+    license_type: str = Form(...),
+    seat_count: int = Form(...),
+    start_date: str | None = Form(None),
+    end_date: str | None = Form(None),
+    license_key: str | None = Form(None),
+    note: str | None = Form(None),
+    db: Session = Depends(get_db),
+    user=Depends(current_user),
+):
+    normalized_code = license_code.strip()
+    if not normalized_code:
+        raise HTTPException(status_code=400, detail="Lisans numarası gerekli")
+
+    existing = (
+        db.query(License)
+        .filter(License.license_code == normalized_code)
+        .first()
+    )
+    if existing:
+        raise HTTPException(status_code=400, detail="Bu lisans numarası zaten kayıtlı")
+
+    product = product_name.strip()
+    if not product:
+        raise HTTPException(status_code=400, detail="Ürün adı gerekli")
+
+    seat = int(seat_count) if isinstance(seat_count, str) else seat_count
+    if seat <= 0:
+        raise HTTPException(
+            status_code=400, detail="Koltuk sayısı 1 veya daha büyük olmalı"
+        )
+
+    start = _parse_date(start_date)
+    end = _parse_date(end_date)
+
+    factory_fk = _to_optional_int(factory_id)
+    department_fk = _to_optional_int(department_id)
+    owner_fk = _to_optional_int(owner_id)
+    inventory_fk = _to_optional_int(inventory_id)
+
+    owner = db.get(User, owner_fk) if owner_fk else None
+    inventory = db.get(Inventory, inventory_fk) if inventory_fk else None
+
+    lic = License(
+        license_code=normalized_code,
+        product_name=product,
+        license_type=license_type,
+        seat_count=seat,
+        start_date=start,
+        end_date=end,
+        license_key=(license_key or "").strip() or None,
+        note=(note or "").strip() or None,
+        factory_id=factory_fk,
+        department_id=department_fk,
+        owner_id=owner_fk,
+        inventory_id=inventory_fk,
+    )
+
+    if owner:
+        lic.sorumlu_personel = owner.full_name or owner.username
+    if inventory:
+        lic.bagli_envanter_no = inventory.no
+
+    lic.islem_yapan = (
+        getattr(user, "full_name", None)
+        or getattr(user, "username", "")
+        or "system"
+    )
+    db.add(lic)
+    db.commit()
+
+    return RedirectResponse(url="/licenses", status_code=status.HTTP_303_SEE_OTHER)

--- a/static/js/licenses.add.js
+++ b/static/js/licenses.add.js
@@ -1,0 +1,17 @@
+(function () {
+  const form = document.getElementById("licenseAddForm");
+  if (!form) return;
+
+  form.addEventListener("submit", () => {
+    if (form.dataset.submitting === "true") {
+      return;
+    }
+    form.dataset.submitting = "true";
+    const submitButton = form.querySelector('button[type="submit"]');
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.dataset.originalText = submitButton.innerHTML;
+      submitButton.innerHTML = "Kaydediliyor...";
+    }
+  });
+})();

--- a/templates/licenses/_license_add_modal.html
+++ b/templates/licenses/_license_add_modal.html
@@ -1,0 +1,102 @@
+<div class="modal fade" id="licenseAddModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-xl modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Lisans Ekle</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+      </div>
+
+      <form id="licenseAddForm" method="post" action="/licenses/add">
+        <div class="modal-body">
+          <div class="container-fluid">
+            <div class="row g-3">
+              <!-- Satır 1 -->
+              <div class="col-md-6">
+                <label class="form-label">Lisans No</label>
+                <input name="license_code" class="form-control" placeholder="LIC-000123" required />
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Ürün / Yazılım Adı</label>
+                <input name="product_name" class="form-control" placeholder="Microsoft 365 Business Standard" required />
+              </div>
+
+              <!-- Satır 2 -->
+              <div class="col-md-6">
+                <label class="form-label">Fabrika</label>
+                <select name="factory_id" class="form-select" required>
+                  <option value="" selected>Seçiniz...</option>
+                  {% for f in factories %}<option value="{{f.id}}">{{f.name}}</option>{% endfor %}
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Departman</label>
+                <select name="department_id" class="form-select" required>
+                  <option value="" selected>Seçiniz...</option>
+                  {% for d in departments %}<option value="{{d.id}}">{{d.name}}</option>{% endfor %}
+                </select>
+              </div>
+
+              <!-- Satır 3 -->
+              <div class="col-md-6">
+                <label class="form-label">Sorumlu Personel</label>
+                <select name="owner_id" class="form-select">
+                  <option value="" selected>Seçiniz...</option>
+                  {% for p in persons %}<option value="{{p.id}}">{{p.full_name or p.username}}</option>{% endfor %}
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Atandığı Envanter</label>
+                <select name="inventory_id" class="form-select">
+                  <option value="">Seçiniz (opsiyonel)...</option>
+                  {% for i in inventories %}<option value="{{i.id}}">{{i.no}}{% if i.bilgisayar_adi %} - {{i.bilgisayar_adi}}{% endif %}</option>{% endfor %}
+                </select>
+              </div>
+
+              <!-- Satır 4 -->
+              <div class="col-md-6">
+                <label class="form-label">Lisans Tipi</label>
+                <select name="license_type" class="form-select" required>
+                  <option value="" selected>Seçiniz...</option>
+                  <option value="perpetual">Süresiz</option>
+                  <option value="subscription">Abonelik</option>
+                  <option value="oem">OEM</option>
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Koltuk / Adet</label>
+                <input type="number" min="1" name="seat_count" class="form-control" placeholder="1" value="1" required />
+              </div>
+
+              <!-- Satır 5 -->
+              <div class="col-md-6">
+                <label class="form-label">Başlangıç Tarihi</label>
+                <input type="date" name="start_date" class="form-control" />
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Bitiş Tarihi</label>
+                <input type="date" name="end_date" class="form-control" />
+              </div>
+
+              <!-- Satır 6 -->
+              <div class="col-md-12">
+                <label class="form-label">Lisans Anahtarı (opsiyonel)</label>
+                <input name="license_key" autocomplete="off" class="form-control" placeholder="XXXXX-XXXXX-XXXXX-XXXXX" />
+              </div>
+
+              <!-- Satır 7 -->
+              <div class="col-md-12">
+                <label class="form-label">Not (zorunlu değil)</label>
+                <textarea name="note" class="form-control" rows="3" placeholder="Açıklama / notlar"></textarea>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          <button class="btn btn-primary" type="submit">Kaydet</button>
+          <button class="btn btn-secondary" type="button" data-bs-dismiss="modal">İptal</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/templates/licenses/list.html
+++ b/templates/licenses/list.html
@@ -1,38 +1,70 @@
-{% extends "base.html" %}{% block title %}Lisans – Liste{% endblock %} {% block
-content %}
-<h2 class="h5 mb-3">Lisans Listesi</h2>
-<div class="mb-3">
-  <div class="dropdown d-inline">
-    <button
-      class="btn btn-outline-primary btn-sm dropdown-toggle"
-      type="button"
-      data-bs-toggle="dropdown"
-      aria-expanded="false"
-    >
-      Excel
+{% extends "base.html" %}
+{% block title %}Lisanslar{% endblock %}
+{% block content %}
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
+  <div>
+    <span class="text-uppercase text-primary fw-semibold small">Lisans Yönetimi</span>
+    <h1 class="h4 mb-1">Lisanslar</h1>
+    <p class="text-muted mb-0">Yazılım lisanslarını görüntüleyin, yeni kayıt ekleyin ve yönetin.</p>
+  </div>
+  <div class="d-flex gap-2">
+    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#licenseAddModal">
+      <i class="bi bi-plus-lg me-1"></i>
+      Lisans Ekle
     </button>
-    <ul class="dropdown-menu">
-      <li><a class="dropdown-item" href="/licenses/export">Dışa Aktar</a></li>
-      <li>
-        <form
-          action="/licenses/import"
-          method="post"
-          enctype="multipart/form-data"
-        >
-          <input
-            type="file"
-            name="file"
-            id="licensesExcel"
-            class="d-none"
-            onchange="this.form.submit()"
-          />
-          <label for="licensesExcel" class="dropdown-item mb-0"
-            >İçe Aktar</label
-          >
-        </form>
-      </li>
-    </ul>
   </div>
 </div>
-<div class="card p-3">Liste/filtre...</div>
+
+<div class="card shadow-sm">
+  <div class="card-body">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            <th scope="col">Lisans No</th>
+            <th scope="col">Ürün / Yazılım</th>
+            <th scope="col">Tip</th>
+            <th scope="col">Koltuk</th>
+            <th scope="col">Sorumlu</th>
+            <th scope="col">Envanter</th>
+            <th scope="col" class="text-end">Başlangıç</th>
+            <th scope="col" class="text-end">Bitiş</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if licenses %}
+          {% for lic in licenses %}
+          <tr>
+            <td class="fw-semibold">{{ lic.license_code or '-' }}</td>
+            <td>
+              <div class="fw-semibold">{{ lic.product_name or lic.lisans_adi or '-' }}</div>
+              {% if lic.license_key %}
+              <div class="text-muted small">{{ lic.license_key }}</div>
+              {% endif %}
+            </td>
+            <td>{{ lic.license_type or '-' }}</td>
+            <td>{{ lic.seat_count or 0 }}</td>
+            <td>{{ lic.sorumlu_personel or '-' }}</td>
+            <td>{{ lic.bagli_envanter_no or '-' }}</td>
+            <td class="text-end">{{ lic.start_date or '-' }}</td>
+            <td class="text-end">{{ lic.end_date or '-' }}</td>
+          </tr>
+          {% endfor %}
+          {% else %}
+          <tr>
+            <td colspan="8" class="text-center text-muted py-4">Henüz lisans kaydı bulunmuyor.</td>
+          </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+{% include "licenses/_license_add_modal.html" %}
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="{{ url_for('static', path='js/licenses.add.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a dedicated licenses router that serves the updated list page and accepts new license submissions
- align the licenses list UI with the inventory modal experience and introduce a reusable modal partial with matching styling and behaviour
- extend the License model with metadata relationships, supporting migration, and light client-side UX polish for the new form

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3b2c88c5c832bbb6c1570684cfd25