### PR TITLE
Fix conditional styling on printer list rows

### DIFF
--- a/templates/printers_list.html
+++ b/templates/printers_list.html
@@ -138,14 +138,11 @@ content %}
               data-kullanim="{{ p.kullanim_alani or '' }}"
               data-personel="{{ p.sorumlu_personel or '' }}"
               data-bagli="{{ p.bagli_envanter_no or '' }}"
-              {%
-              if
-              p.durum=""
-              ="arızalı"
-              %}class="table-warning"
-              {%
-              endif
-              %}
+              {% if p.durum == 'arızalı' %}
+              class="table-warning"
+              {% elif p.durum == 'hurda' %}
+              class="table-secondary"
+              {% endif %}
             >
               <td>#{{ p.id }}</td>
               <td>{{ p.marka or '-' }}</td>


### PR DESCRIPTION
## Summary
- correct the Jinja condition that applies warning styling to faulty printers
- add secondary styling for scrapped printers to keep visual feedback working

## Testing
- not run (template change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3bdd27190832b94e9fc5784144b28