### PR TITLE
Show admin panel permission errors via flash alerts

### DIFF
--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -786,6 +786,18 @@ content %}
   </div>
 </div>
 {% endblock %} {% block scripts %} {{ super() }}
+{% if flash %}
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    if (window.showAlert) {
+      window.showAlert({{ flash.message|tojson }}, {
+        title: {{ (flash.title or 'Bilgi')|tojson }},
+        variant: {{ (flash.variant or 'primary')|tojson }},
+      });
+    }
+  });
+</script>
+{% endif %}
 <style>
   .chip {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- add flash helper utilities that reuse HTTP exceptions when no request context is present
- update admin user edit and delete flows to redirect with flash messages instead of rendering standalone error pages
- render flash alerts on the admin page so permission problems surface inside the global modal

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3bdf8cf50832b9be22f4f1da50e80