### PR TITLE
Fix printer edit modal data population and layout

### DIFF
--- a/routers/printers.py
+++ b/routers/printers.py
@@ -355,6 +355,7 @@ def edit_printer_post(
     ifs_no: str = Form(None),
     marka_id: str = Form(None),
     model_id: str = Form(None),
+    kullanim_alani: str = Form(None),
     kullanim_alani_id: str = Form(None),
     modal: bool = False,
     db: Session = Depends(get_db),
@@ -415,14 +416,14 @@ def edit_printer_post(
     if ifs_no is not None:
         new_vals["ifs_no"] = ifs_no or None
 
-    if kullanim_alani_id is not None:
-        usage_name = None
+    if kullanim_alani_id is not None or kullanim_alani is not None:
+        usage_name = kullanim_alani or None
         usage_pk = parse_int(kullanim_alani_id)
         if kullanim_alani_id == "":
             usage_name = None
         elif usage_pk is not None:
             area = db.get(UsageArea, usage_pk)
-            usage_name = area.name if area else None
+            usage_name = area.name if area else usage_name
         new_vals["kullanim_alani"] = usage_name
 
     if not new_vals:

--- a/routers/printers.py
+++ b/routers/printers.py
@@ -427,7 +427,12 @@ def edit_printer_post(
         new_vals["kullanim_alani"] = usage_name
 
     if not new_vals:
-        new_vals = {"marka": marka, "model": model, "seri_no": seri_no, "notlar": notlar}
+        new_vals = {
+            "marka": marka,
+            "model": model,
+            "seri_no": seri_no,
+            "notlar": notlar,
+        }
 
     changes = build_changes(p, new_vals)
     for k, v in new_vals.items():

--- a/static/js/selects.js
+++ b/static/js/selects.js
@@ -88,7 +88,8 @@ async function bindMarkaModel(markaSelectId, modelSelectId) {
   async function updateModels() {
     const m = markaEl.value;
     if (aborter) aborter.abort();
-    if (!m) {
+    const parsed = Number.parseInt(m, 10);
+    if (!m || Number.isNaN(parsed)) {
       modelInst.clearStore();
       modelInst.disable();
       return;
@@ -99,7 +100,7 @@ async function bindMarkaModel(markaSelectId, modelSelectId) {
       await fillChoices({
         endpoint: "/api/lookup/model",
         selectId: modelSelectId,
-        params: { marka_id: m },
+        params: { marka_id: parsed },
         placeholder: "Model seçiniz…",
         signal: aborter.signal,
       });
@@ -132,10 +133,17 @@ function enableRemoteSearch(
     "input",
     debounce(async () => {
       const q = input.value.trim();
+      const extras = extraParamsFn ? extraParamsFn() : {};
+      if (extras === false) return;
+      const params = { q, ...(extras || {}) };
+      if (params.__skip) {
+        return;
+      }
+      delete params.__skip;
       await fillChoices({
         endpoint,
         selectId,
-        params: { q, ...extraParamsFn() },
+        params,
         keepValue: false,
         mapFn,
       });

--- a/templates/_printer_form_fields.html
+++ b/templates/_printer_form_fields.html
@@ -11,8 +11,15 @@
   </div>
   <div class="col-md-6">
     <label for="selYaziciModel" class="form-label">Yazıcı Modeli</label>
-    <select id="selYaziciModel" name="model_id" class="form-select" disabled></select>
-    <div class="form-text">Not: Model listesi seçilen Markaya göre filtrelenir.</div>
+    <select
+      id="selYaziciModel"
+      name="model_id"
+      class="form-select"
+      disabled
+    ></select>
+    <div class="form-text">
+      Not: Model listesi seçilen Markaya göre filtrelenir.
+    </div>
     <input
       type="hidden"
       name="model"
@@ -38,7 +45,12 @@
 
   <div class="col-md-6">
     <label for="printerEnvanterNo" class="form-label">Envanter No</label>
-    <input id="printerEnvanterNo" name="envanter_no" class="form-control" required />
+    <input
+      id="printerEnvanterNo"
+      name="envanter_no"
+      class="form-control"
+      required
+    />
   </div>
 
   <div class="col-md-6">

--- a/templates/_printer_form_fields.html
+++ b/templates/_printer_form_fields.html
@@ -2,11 +2,23 @@
   <div class="col-md-6">
     <label for="selYaziciMarka" class="form-label">Yazıcı Markası</label>
     <select id="selYaziciMarka" name="marka_id" class="form-select"></select>
+    <input
+      type="hidden"
+      name="marka"
+      id="printerMarkaName"
+      value="{{ (p.marka if p is defined else '') or '' }}"
+    />
   </div>
   <div class="col-md-6">
     <label for="selYaziciModel" class="form-label">Yazıcı Modeli</label>
     <select id="selYaziciModel" name="model_id" class="form-select" disabled></select>
     <div class="form-text">Not: Model listesi seçilen Markaya göre filtrelenir.</div>
+    <input
+      type="hidden"
+      name="model"
+      id="printerModelName"
+      value="{{ (p.model if p is defined else '') or '' }}"
+    />
   </div>
 
   <div class="col-md-6">
@@ -16,6 +28,12 @@
       name="kullanim_alani_id"
       class="form-select"
     ></select>
+    <input
+      type="hidden"
+      name="kullanim_alani"
+      id="printerUsageName"
+      value="{{ (p.kullanim_alani if p is defined else '') or '' }}"
+    />
   </div>
 
   <div class="col-md-6">

--- a/templates/printer_create.html
+++ b/templates/printer_create.html
@@ -44,9 +44,36 @@ content %}
       placeholder: "Kullanım alanı seçiniz…",
     });
     await _selects.bindMarkaModel("selYaziciMarka", "selYaziciModel");
-    _selects.enableRemoteSearch("selYaziciModel", "/api/lookup/model", () => ({
-      marka_id: document.getElementById("selYaziciMarka").value || "",
-    }));
+
+    const brandSelect = document.getElementById("selYaziciMarka");
+    const modelSelect = document.getElementById("selYaziciModel");
+    const usageSelect = document.getElementById("selYaziciKullanim");
+    const hiddenBrand = document.getElementById("printerMarkaName");
+    const hiddenModel = document.getElementById("printerModelName");
+    const hiddenUsage = document.getElementById("printerUsageName");
+
+    _selects.enableRemoteSearch("selYaziciModel", "/api/lookup/model", () => {
+      const raw = brandSelect?.value || "";
+      const parsed = Number.parseInt(raw, 10);
+      if (!Number.isFinite(parsed)) {
+        return { __skip: true };
+      }
+      return { marka_id: parsed };
+    });
+
+    const syncHidden = (select, hidden) => {
+      if (!select || !hidden) return;
+      const update = () => {
+        const opt = select.options[select.selectedIndex];
+        hidden.value = opt ? opt.text.trim() : "";
+      };
+      select.addEventListener("change", update);
+      update();
+    };
+
+    syncHidden(brandSelect, hiddenBrand);
+    syncHidden(modelSelect, hiddenModel);
+    syncHidden(usageSelect, hiddenUsage);
   });
 </script>
 {% endblock %}

--- a/templates/printers_detail.html
+++ b/templates/printers_detail.html
@@ -10,6 +10,7 @@ content %}
         data-modal-url="/printers/{{ p.id }}/edit?modal=1"
         data-modal-title="Yazıcı Düzenle"
         data-modal-size="md"
+        data-modal-chrome="frameless"
         >Düzenle</a
       >
       <a class="btn btn-sm btn-outline-secondary" href="/printers">Geri</a>

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -186,20 +186,81 @@ content %}
       setFormValue("hostname", {{ (p.hostname or '')|tojson }});
       setFormValue("ifs_no", {{ (p.ifs_no or '')|tojson }});
 
-      const setChoiceByLabel = (select, label) => {
+      const hiddenBrand = form.querySelector("#printerMarkaName");
+      const hiddenModel = form.querySelector("#printerModelName");
+      const hiddenUsage = form.querySelector("#printerUsageName");
+
+      const updateHiddenValue = (select, hidden) => {
+        if (!select || !hidden) return;
+        const opt = select.options[select.selectedIndex];
+        hidden.value = opt ? opt.text.trim() : "";
+      };
+
+      const attachHiddenSync = (select, hidden) => {
+        if (!select || !hidden) return;
+        select.addEventListener("change", () => updateHiddenValue(select, hidden));
+      };
+
+      const setChoiceByLabel = (select, label, { hidden, fallbackPrefix } = {}) => {
         if (!select) return null;
-        const targetLabel = String(label || "").trim().toLowerCase();
-        if (!targetLabel) return null;
-        const option = Array.from(select.options).find((opt) =>
-          opt.text.trim().toLowerCase() === targetLabel,
-        );
-        if (!option) return null;
-        const inst = select._choices;
-        if (inst && option.value !== undefined) {
-          inst.setChoiceByValue(String(option.value));
+        const targetLabel = String(label || "").trim();
+        if (!targetLabel) {
+          if (hidden) hidden.value = "";
+          return null;
         }
-        select.value = option.value;
-        return option.value;
+        const lower = targetLabel.toLowerCase();
+        const option = Array.from(select.options).find((opt) =>
+          opt.text.trim().toLowerCase() === lower,
+        );
+        if (option) {
+          const inst = select._choices;
+          if (inst && option.value !== undefined) {
+            inst.setChoiceByValue(String(option.value));
+          }
+          select.value = option.value;
+          if (hidden) hidden.value = option.text.trim();
+          return option.value;
+        }
+
+        const inst = select._choices;
+        const fallbackValue =
+          select.dataset.fallbackValue ||
+          `${fallbackPrefix || "__custom"}_${select.id || "choice"}`;
+        select.dataset.fallbackValue = fallbackValue;
+        if (inst) {
+          const hasExisting = Array.from(select.options).some(
+            (opt) => opt.value === fallbackValue,
+          );
+          if (!hasExisting) {
+            inst.setChoices(
+              [
+                {
+                  value: fallbackValue,
+                  label: targetLabel,
+                  selected: true,
+                },
+              ],
+              "value",
+              "label",
+              false,
+            );
+          }
+          inst.setChoiceByValue(fallbackValue);
+        } else {
+          let opt = Array.from(select.options).find(
+            (o) => o.value === fallbackValue,
+          );
+          if (!opt) {
+            opt = document.createElement("option");
+            opt.value = fallbackValue;
+            opt.textContent = targetLabel;
+            select.appendChild(opt);
+          }
+          opt.selected = true;
+          select.value = fallbackValue;
+        }
+        if (hidden) hidden.value = targetLabel;
+        return fallbackValue;
       };
 
       const initSelects = async () => {
@@ -209,34 +270,57 @@ content %}
         const usageSelect = form.querySelector("#selYaziciKullanim");
 
         if (brandSelect) {
+          attachHiddenSync(brandSelect, hiddenBrand);
           await window._selects.fillChoices({
             endpoint: "/api/lookup/marka",
             selectId: "selYaziciMarka",
             placeholder: "Yazıcı markası seçiniz…",
           });
-          setChoiceByLabel(brandSelect, {{ (p.marka or '')|tojson }});
+          setChoiceByLabel(brandSelect, {{ (p.marka or '')|tojson }}, {
+            hidden: hiddenBrand,
+            fallbackPrefix: "brand",
+          });
           await window._selects.bindMarkaModel(
             "selYaziciMarka",
             "selYaziciModel",
           );
           if (modelSelect) {
-            setChoiceByLabel(modelSelect, {{ (p.model or '')|tojson }});
+            attachHiddenSync(modelSelect, hiddenModel);
+            setChoiceByLabel(modelSelect, {{ (p.model or '')|tojson }}, {
+              hidden: hiddenModel,
+              fallbackPrefix: "model",
+            });
           }
           window._selects.enableRemoteSearch(
             "selYaziciModel",
             "/api/lookup/model",
-            () => ({ marka_id: brandSelect.value || "" }),
+            () => {
+              const raw = brandSelect.value || "";
+              const parsed = Number.parseInt(raw, 10);
+              if (!Number.isFinite(parsed)) {
+                return { __skip: true };
+              }
+              return { marka_id: parsed };
+            },
           );
         }
 
         if (usageSelect) {
+          attachHiddenSync(usageSelect, hiddenUsage);
           await window._selects.fillChoices({
             endpoint: "/api/lookup/kullanim-alani",
             selectId: "selYaziciKullanim",
             placeholder: "Kullanım alanı seçiniz…",
           });
-          setChoiceByLabel(usageSelect, {{ (p.kullanim_alani or '')|tojson }});
+          setChoiceByLabel(usageSelect, {{ (p.kullanim_alani or '')|tojson }}, {
+            hidden: hiddenUsage,
+            fallbackPrefix: "usage",
+          });
         }
+
+        updateHiddenValue(brandSelect, hiddenBrand);
+        updateHiddenValue(modelSelect, hiddenModel);
+        updateHiddenValue(usageSelect, hiddenUsage);
       };
 
       initSelects().catch((err) => {

--- a/templates/printers_edit.html
+++ b/templates/printers_edit.html
@@ -53,9 +53,7 @@ content %}
               readonly
             />
           </div>
-          <div class="col-12">
-            {% include "_printer_form_fields.html" %}
-          </div>
+          <div class="col-12">{% include "_printer_form_fields.html" %}</div>
           <div class="col-lg-6">
             <label for="printerSerial" class="form-label">Seri No</label>
             <input
@@ -75,7 +73,9 @@ content %}
               class="form-control"
               rows="4"
               placeholder="Bakım, toner değişimi veya diğer notlar..."
-            >{{ p.notlar or '' }}</textarea>
+            >
+{{ p.notlar or '' }}</textarea
+            >
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- keep existing printer marka/model/usage selections by adding hidden fallbacks and enhancing the edit modal script
- harden lookup helpers to ignore non-numeric brand ids and sync hidden display values across create/edit forms
- open the edit dialog in frameless mode from the printer detail page

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3c3fc8354832ba048d7d9e4b0b13d