### PR TITLE
Persist generated session secret across workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ coverage.xml
 # Env/Secrets
 .env
 .env.*.local
+.session_secret
 
 # Node/Vite
 node_modules/


### PR DESCRIPTION
## Summary
- persist generated session secrets to disk so CSRF/session cookies survive across workers
- reuse any stored fallback secret when SESSION_SECRET is missing or too short and ignore the helper file in git

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4ce9e7404832ba5f9451fd76cdb9b