### PR TITLE
Fix passlib InvalidHash import error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,6 @@ from fastapi.exception_handlers import http_exception_handler
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from passlib.exc import InvalidHash
 from starlette import status as st_status
 from starlette.middleware.sessions import SessionMiddleware
 


### PR DESCRIPTION
## Summary
- remove the unused InvalidHash import that is not provided by passlib.exc and broke app startup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4d4376e50832b9106227ac6ac0799