### PR TITLE
Handle case-insensitive usernames on login

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.core.security import hash_password, pwd_context, verify_password
@@ -7,7 +8,15 @@ from models import User
 
 
 def get_user_by_username(db: Session, username: str) -> User | None:
-    return db.query(User).filter(User.username == username).first()
+    normalized = (username or "").strip()
+    if not normalized:
+        return None
+
+    return (
+        db.query(User)
+        .filter(func.lower(User.username) == normalized.lower())
+        .first()
+    )
 
 
 def get_user_by_id(db: Session, user_id: int) -> User | None:

--- a/auth.py
+++ b/auth.py
@@ -13,9 +13,7 @@ def get_user_by_username(db: Session, username: str) -> User | None:
         return None
 
     return (
-        db.query(User)
-        .filter(func.lower(User.username) == normalized.lower())
-        .first()
+        db.query(User).filter(func.lower(User.username) == normalized.lower()).first()
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import pytest
+
+import models
+
+
+class DummyRequest:
+    def __init__(self) -> None:
+        state = SimpleNamespace(session_https_only=False)
+        self.app = SimpleNamespace(state=state)
+        self.session: dict[str, object] = {}
+        self.cookies: dict[str, str] = {}
+        self.headers: dict[str, str] = {}
+
+
+@pytest.fixture()
+def db_session():
+    models.Base.metadata.create_all(models.engine)
+    db = models.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        models.Base.metadata.drop_all(models.engine)
+
+
+@pytest.fixture()
+def dummy_request() -> DummyRequest:
+    request = DummyRequest()
+    request.session["csrf_token"] = "token"
+    return request


### PR DESCRIPTION
## Summary
- normalise login handling to reuse trimmed usernames, update saved username cookies, and call a case-insensitive lookup
- add shared pytest fixtures plus a regression test ensuring logins succeed regardless of username casing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4d77cf7e0832b88bcad70289b7bd4