### PR TITLE
Handle legacy password hashes during login

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from passlib import exc as passlib_exc
 from passlib.context import CryptContext
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+pwd_context = CryptContext(
+    schemes=["bcrypt", "pbkdf2_sha256", "sha256_crypt"],
+    deprecated="auto",
+)
 
 
 def hash_password(password: str) -> str:
@@ -35,4 +38,19 @@ def is_password_hash(value: str | None) -> bool:
         return False
 
 
-__all__ = ["hash_password", "verify_password", "pwd_context", "is_password_hash"]
+def needs_password_rehash(password_hash: str) -> bool:
+    """Return ``True`` if the stored hash should be upgraded."""
+
+    try:
+        return pwd_context.needs_update(password_hash)
+    except passlib_exc.UnknownHashError:
+        return True
+
+
+__all__ = [
+    "hash_password",
+    "verify_password",
+    "pwd_context",
+    "is_password_hash",
+    "needs_password_rehash",
+]

--- a/tests/test_login_password_upgrade.py
+++ b/tests/test_login_password_upgrade.py
@@ -1,7 +1,9 @@
 import asyncio
 
 import models
-from app.core.security import is_password_hash
+from passlib.context import CryptContext
+
+from app.core.security import is_password_hash, pwd_context
 from app.web.router import login_submit
 
 
@@ -34,3 +36,36 @@ def test_login_upgrades_plaintext_password(db_session, dummy_request):
     db.refresh(user)
     assert user.password_hash != "demo"
     assert is_password_hash(user.password_hash)
+
+
+def test_login_upgrades_legacy_hash(db_session, dummy_request):
+    db = db_session
+    legacy_context = CryptContext(schemes=["pbkdf2_sha256"])
+    legacy_hash = legacy_context.hash("demo")
+    user = models.User(
+        username="demo", password_hash=legacy_hash, full_name="Demo Kullanıcı"
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    request = dummy_request
+
+    response = asyncio.run(
+        login_submit(
+            request,
+            username="demo",
+            password="demo",
+            remember=None,
+            csrf_token="token",
+            db=db,
+        )
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/dashboard"
+    assert request.session["user_id"] == user.id
+
+    db.refresh(user)
+    assert is_password_hash(user.password_hash)
+    assert pwd_context.identify(user.password_hash) == "bcrypt"


### PR DESCRIPTION
## Summary
- allow verifying historic password hashes (pbkdf2, sha256) alongside bcrypt
- transparently rehash legacy passwords to bcrypt after successful authentication
- cover plaintext and legacy hash upgrades with new test cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4dbf67d00832b85dd6975c1e213f0