### PR TITLE
Add admin password reset utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,34 @@
 ## Çalıştırma (Yerel)
 
 ```bash
-python -m venv .venv && source .venv/bin/activate # Windows: .venv\\Scripts\\activate
+python -m venv .venv && source .venv/bin/activate # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 cp .env.example .env # düzenleyin, üretimde SESSION_HTTPS_ONLY=true yapın
 uvicorn app:app --reload --port 5000
 ```
 
+## Varsayılan yönetici hesabı ve parolayı sıfırlama
 
+Uygulama her açılışta veritabanında bir yönetici hesabı olup olmadığını
+kontrol eder. Hesap yoksa, ortam değişkenlerinden alınan kullanıcı adı ve
+parola ile yeni bir kullanıcı oluşturulur. Parola önce `DEFAULT_ADMIN_PASSWORD`
+değişkeninden okunur; bu değişken tanımlı değilse geliştirme için
+`DEFAULT_ADMIN_DEV_PASSWORD` (varsayılan değeri `admin123`) kullanılır. 【F:app/main.py†L100-L135】【F:app/main.py†L240-L266】
+
+Kurulumdan sonra parolanın değiştirilmiş olması ihtimaline karşı, mevcut
+hesabın parolasını komut satırından kolayca sıfırlayabilirsiniz:
+
+```bash
+python -m scripts.reset_admin_password --username admin --password yeni_sifre
+```
+
+Komut, kullanıcı adını büyük/küçük harfe duyarsız olarak arar ve yeni parolayı
+güvenli bir biçimde (bcrypt) tekrar yazar. Parolayı komut satırında vermek
+istemiyorsanız `DEFAULT_ADMIN_PASSWORD` ortam değişkenini tanımlayıp komutu
+parametresiz olarak da çalıştırabilirsiniz. 【F:scripts/reset_admin_password.py†L1-L118】
 
 ## Güvenlik Notları
 
-- `.env` dosyasındaki `SESSION_SECRET` değerini **üretimde mutlaka** rastgele, en az 32 karakterlik bir anahtar ile değiştirin. Değer ayarlanmamışsa geliştirme ve test sırasında geçici bir anahtar otomatik olarak üretilir.
+- `.env` dosyasındaki `SESSION_SECRET` değerini **üretimde mutlaka** rastgele, en az 32 karakterlik bir anahtar ile değiştirin.
+Değer ayarlanmamışsa geliştirme ve test sırasında geçici bir anahtar otomatik olarak üretilir.
 - Tarayıcı oturum çerezlerinin sadece HTTPS üzerinden gönderilmesi için `SESSION_HTTPS_ONLY=true` ayarını etkinleştirin ve uygulamayı TLS terminasyonu yapan bir ters proxy arkasında yayınlayın.

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ parametresiz olarak da çalıştırabilirsiniz. 【F:scripts/reset_admin_passwor
 ## Güvenlik Notları
 
 - `.env` dosyasındaki `SESSION_SECRET` değerini **üretimde mutlaka** rastgele, en az 32 karakterlik bir anahtar ile değiştirin.
-Değer ayarlanmamışsa geliştirme ve test sırasında geçici bir anahtar otomatik olarak üretilir.
+  Değer ayarlanmamışsa geliştirme ve test sırasında geçici bir anahtar otomatik olarak üretilir.
 - Tarayıcı oturum çerezlerinin sadece HTTPS üzerinden gönderilmesi için `SESSION_HTTPS_ONLY=true` ayarını etkinleştirin ve uygulamayı TLS terminasyonu yapan bir ters proxy arkasında yayınlayın.

--- a/scripts/reset_admin_password.py
+++ b/scripts/reset_admin_password.py
@@ -1,0 +1,127 @@
+"""Utility for resetting a user's password from the command line."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Iterable
+
+from dotenv import load_dotenv
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.security import hash_password
+from models import SessionLocal, User
+
+
+def reset_password(
+    username: str,
+    password: str,
+    *,
+    db: Session | None = None,
+) -> bool:
+    """Update ``username`` with a freshly hashed ``password``.
+
+    Parameters
+    ----------
+    username:
+        The account whose password should be updated. Comparison is case
+        insensitive and leading / trailing whitespace is ignored.
+    password:
+        The new plaintext password. An empty value raises :class:`ValueError`.
+    db:
+        Optional SQLAlchemy session. When omitted a dedicated session is
+        created for the duration of the call.
+
+    Returns
+    -------
+    bool
+        ``True`` if the user was found and updated, otherwise ``False``.
+    """
+
+    normalized = (username or "").strip()
+    if not normalized:
+        raise ValueError("username cannot be blank")
+
+    if not password:
+        raise ValueError("password cannot be empty")
+
+    own_session = db is None
+    session = db or SessionLocal()
+
+    try:
+        user = (
+            session.query(User)
+            .filter(func.lower(User.username) == normalized.lower())
+            .first()
+        )
+        if not user:
+            return False
+
+        user.password_hash = hash_password(password)
+        session.add(user)
+        session.commit()
+        if own_session:
+            session.refresh(user)
+        return True
+    finally:
+        if own_session:
+            session.close()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Reset an application's user password.",
+    )
+    parser.add_argument(
+        "-u",
+        "--username",
+        default=os.getenv("DEFAULT_ADMIN_USERNAME", "admin"),
+        help="Kullanıcı adı (varsayılan: %(default)s)",
+    )
+    parser.add_argument(
+        "-p",
+        "--password",
+        help=(
+            "Yeni parolayı belirtin. Eğer verilmezse DEFAULT_ADMIN_PASSWORD "
+            "ortam değişkeni kullanılmaya çalışılır."
+        ),
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    load_dotenv()
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    password = args.password or os.getenv("DEFAULT_ADMIN_PASSWORD", "")
+    if not password:
+        parser.error(
+            "Parola belirtilmedi. --password kullanın ya da "
+            "DEFAULT_ADMIN_PASSWORD ortam değişkenini ayarlayın."
+        )
+
+    try:
+        updated = reset_password(args.username, password)
+    except ValueError as exc:  # pragma: no cover - parser enforces inputs
+        parser.error(str(exc))
+        return 1
+
+    if not updated:
+        print(
+            f"Hata: '{args.username}' adına sahip bir kullanıcı bulunamadı.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Parola başarıyla güncellendi: {args.username}",
+        file=sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    sys.exit(main())

--- a/tests/test_reset_admin_password.py
+++ b/tests/test_reset_admin_password.py
@@ -1,0 +1,40 @@
+import models
+from app.core.security import verify_password
+from scripts.reset_admin_password import reset_password
+
+
+def make_user(db, username: str, password_hash: str = "x", full_name: str = "Test"):
+    user = models.User(
+        username=username,
+        password_hash=password_hash,
+        full_name=full_name,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def test_reset_password_updates_hash(db_session):
+    db = db_session
+    user = make_user(db, "admin", "old", "Admin")
+
+    assert reset_password("admin", "yeniParola123", db=db)
+
+    db.refresh(user)
+    assert verify_password("yeniParola123", user.password_hash)
+
+
+def test_reset_password_case_insensitive_lookup(db_session):
+    db = db_session
+    user = make_user(db, "destek", "old", "Destek")
+
+    assert reset_password("DeStEk", "guncel123", db=db)
+
+    db.refresh(user)
+    assert verify_password("guncel123", user.password_hash)
+
+
+def test_reset_password_returns_false_when_user_missing(db_session):
+    db = db_session
+    assert not reset_password("bilinmeyen", "deneme123", db=db)


### PR DESCRIPTION
## Summary
- add a command-line helper for resetting user passwords, defaulting to the admin account
- document how the default admin account is created and how to run the reset helper
- cover the helper with unit tests to ensure case-insensitive lookups and safe hashing

## Testing
- pytest tests/test_reset_admin_password.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4e7e2baec832b989a2b7079fcb072