### PR TITLE
Handle Turkish casing in username lookups

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -7,14 +7,57 @@ from app.core.security import hash_password, pwd_context, verify_password
 from models import User
 
 
+_TURKISH_UPPER_REPLACEMENTS = {
+    "İ": "I",
+    "İ": "I",
+    "Ş": "S",
+    "Ğ": "G",
+    "Ü": "U",
+    "Ö": "O",
+    "Ç": "C",
+}
+
+_TURKISH_LOWER_REPLACEMENTS = {
+    "ı": "i",
+    "ş": "s",
+    "ğ": "g",
+    "ü": "u",
+    "ö": "o",
+    "ç": "c",
+    "̇": "",
+}
+
+
 def get_user_by_username(db: Session, username: str) -> User | None:
-    normalized = (username or "").strip()
+    normalized = _normalize_username(username)
     if not normalized:
         return None
 
-    return (
-        db.query(User).filter(func.lower(User.username) == normalized.lower()).first()
-    )
+    return db.query(User).filter(_normalized_username_column() == normalized).first()
+
+
+def _normalize_username(value: str | None) -> str:
+    """Return a case-insensitive, accent-free representation of *value*."""
+
+    if not value:
+        return ""
+
+    normalized = value.strip().casefold()
+    for search, replacement in _TURKISH_LOWER_REPLACEMENTS.items():
+        normalized = normalized.replace(search, replacement)
+    return normalized
+
+
+def _normalized_username_column():
+    """Return a SQL expression mirroring :func:`_normalize_username`."""
+
+    column = func.trim(User.username)
+    for search, replacement in _TURKISH_UPPER_REPLACEMENTS.items():
+        column = func.replace(column, search, replacement)
+    column = func.lower(column)
+    for search, replacement in _TURKISH_LOWER_REPLACEMENTS.items():
+        column = func.replace(column, search, replacement)
+    return column
 
 
 def get_user_by_id(db: Session, user_id: int) -> User | None:

--- a/auth.py
+++ b/auth.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session
 from app.core.security import hash_password, pwd_context, verify_password
 from models import User
 
-
 _TURKISH_UPPER_REPLACEMENTS = {
     "İ": "I",
     "İ": "I",

--- a/tests/test_login_username_case.py
+++ b/tests/test_login_username_case.py
@@ -35,3 +35,59 @@ def test_login_accepts_case_insensitive_username(db_session, dummy_request):
     assert request.session["user_name"] == user.full_name
     assert request.session["user_role"] == user.role
     assert "saved_username=demo" in response.headers.get("set-cookie", "")
+
+
+def test_login_handles_turkish_dotted_i(db_session, dummy_request):
+    db = db_session
+    user = models.User(
+        username="İBRAHİM",
+        password_hash=hash_password("demo"),
+        full_name="İbrahim Demo",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    request = dummy_request
+
+    response = asyncio.run(
+        login_submit(
+            request,
+            username="ibrahim",
+            password="demo",
+            remember=None,
+            csrf_token="token",
+            db=db,
+        )
+    )
+
+    assert response.status_code == 303
+    assert request.session["user_id"] == user.id
+
+
+def test_login_handles_turkish_dotless_i(db_session, dummy_request):
+    db = db_session
+    user = models.User(
+        username="IŞIK",
+        password_hash=hash_password("demo"),
+        full_name="Işık Demo",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    request = dummy_request
+
+    response = asyncio.run(
+        login_submit(
+            request,
+            username="isik",
+            password="demo",
+            remember=None,
+            csrf_token="token",
+            db=db,
+        )
+    )
+
+    assert response.status_code == 303
+    assert request.session["user_id"] == user.id


### PR DESCRIPTION
## Summary
- normalise usernames with Turkish-specific casing replacements before querying
- add login tests covering dotted/dotless Turkish “i” usernames

## Testing
- pytest tests/test_login_username_case.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e4ea564bcc832ba7ae6f30cc0c047a